### PR TITLE
PushnotificationId is not send to our db when user account is created (BFF-1456)

### DIFF
--- a/lib/shared/models/user_ext.dart
+++ b/lib/shared/models/user_ext.dart
@@ -250,6 +250,7 @@ class UserExt extends Equatable {
       pinSet: pinSet ?? this.pinSet,
       multipleCollectsAccepted:
           multipleCollectsAccepted ?? this.multipleCollectsAccepted,
+      notificationId: notificationId ?? this.notificationId,
     );
   }
 
@@ -281,6 +282,7 @@ class UserExt extends Equatable {
         personalInfoRegistered,
         pinSet,
         multipleCollectsAccepted,
+        notificationId,
       ];
 
   static String tag = 'UserExt';


### PR DESCRIPTION
## Description
Set notificationid when temp account is transformed to registered