### PR TITLE
BFF-1463 Use the guid passed through the method

### DIFF
--- a/lib/core/network/api_service.dart
+++ b/lib/core/network/api_service.dart
@@ -121,7 +121,10 @@ class APIService {
     );
     final response = await client.get(url);
     if (response.statusCode >= 400) {
-      throw Exception('something went wrong :(');
+      throw GivtServerFailure(
+        statusCode: response.statusCode,
+        body: jsonDecode(response.body) as Map<String, dynamic>,
+      );
     }
     return jsonDecode(response.body) as Map<String, dynamic>;
   }

--- a/lib/features/auth/cubit/auth_cubit.dart
+++ b/lib/features/auth/cubit/auth_cubit.dart
@@ -402,9 +402,16 @@ class AuthCubit extends Cubit<AuthState> {
 
       await LoggingInfo.instance.info('Updating notification id');
 
+      if (guid.isEmpty) {
+        await LoggingInfo.instance.warning(
+          'Tried to update notification id with empty guid',
+        );
+        return currentNotificationId;
+      }
+
       await _authRepositoy.updateNotificationId(
         notificationId: notificationId,
-        guid: state.user.guid,
+        guid: guid,
       );
       return notificationId;
     } catch (e, stackTrace) {


### PR DESCRIPTION


## Description
Use the guid passed through the method arguments instead of using the one from the state as the one from the state could be empty
