### PR TITLE
BFF-1474 Adjusted the notification setup for iOS to redirect the user

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Flutter
+import flutter_local_notifications
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
@@ -8,6 +9,13 @@ import Flutter
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+    FlutterLocalNotificationsPlugin.setPluginRegistrantCallback { (registry) in
+        GeneratedPluginRegistrant.register(with: registry)
+    }
+    
+    if #available(iOS 10.0, *) {
+        UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
+    }
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }

--- a/lib/core/notification/notification_service.dart
+++ b/lib/core/notification/notification_service.dart
@@ -108,9 +108,18 @@ class NotificationService implements INotificationService {
     flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
 
     await flutterLocalNotificationsPlugin.initialize(
-      const InitializationSettings(
-        android: AndroidInitializationSettings('icon'),
-        iOS: DarwinInitializationSettings(),
+      InitializationSettings(
+        android: const AndroidInitializationSettings('icon'),
+        iOS: DarwinInitializationSettings(
+          onDidReceiveLocalNotification: (id, title, body, payload) async =>
+              _navigateToScreen(
+            NotificationResponse(
+              payload: payload,
+              notificationResponseType:
+                  NotificationResponseType.selectedNotification,
+            ),
+          ),
+        ),
       ),
       onDidReceiveBackgroundNotificationResponse: _navigateToScreen,
       onDidReceiveNotificationResponse: _navigateToScreen,


### PR DESCRIPTION


## Description
<!--- Describe your changes -->
There was a setup missed for iOS where the delegate had to be initialized to communicate when on background and the onDidReceive notifcation tap had to be initialized in the DarwinInit