### PR TITLE
BFF-1493 Switched the intl locale with the Platform locale name

### DIFF
--- a/lib/core/logging/logging_service.dart
+++ b/lib/core/logging/logging_service.dart
@@ -44,7 +44,7 @@ class LoggingInfo implements ILoggingInfo {
       ),
       level: level.toString(),
       message: message,
-      lang: Intl.getCurrentLocale(),
+      lang: Platform.localeName,
       method: methodName,
       appVersion: '${info.version}.${info.buildNumber}',
     );


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Switched the Intl package method with the platform locale name. 
According to the [documentation](https://api.flutter.dev/flutter/dart-io/Platform/localeName.html) this takes the device current locale. However, on Android devices seems a bit tricky. 

I would like to avoid using a "global" context as we use this logging everywhere in the code and by using context would pollute the code quite a lot. 