### PR TITLE
Improvement: KIDS-252 Text capitalisation for name/lastname

### DIFF
--- a/lib/features/registration/pages/signup_page.dart
+++ b/lib/features/registration/pages/signup_page.dart
@@ -250,8 +250,8 @@ class _SignUpPageState extends State<SignUpPage> {
                 height: 0,
               ),
             ),
-            keyboardType: TextInputType.name,
-            textCapitalization: TextCapitalization.words,
+            keyboardType: TextInputType.text,
+            textCapitalization: TextCapitalization.sentences,
           ),
           const SizedBox(height: 16),
           TextFormField(
@@ -277,8 +277,8 @@ class _SignUpPageState extends State<SignUpPage> {
                 height: 0,
               ),
             ),
-            keyboardType: TextInputType.name,
-            textCapitalization: TextCapitalization.words,
+            keyboardType: TextInputType.text,
+            textCapitalization: TextCapitalization.sentences,
           ),
           Visibility(
             visible: !isUS,


### PR DESCRIPTION
## Description
Text capitalisation for name/surname is fixed for iOS
