### PR TITLE
Bug: kids-329 wrong org name on beacon screen

### DIFF
--- a/lib/features/give/repositories/campaign_repository.dart
+++ b/lib/features/give/repositories/campaign_repository.dart
@@ -59,13 +59,23 @@ class CampaignRepositoryImpl with CampaignRepository {
       Organisation.lastOrganisationDonatedKey,
     );
     if (lastDonation == null) {
-      return Organisation.empty();
+      return const Organisation.empty();
     }
     final organisation = Organisation.fromJson(
       jsonDecode(
         lastDonation,
       ) as Map<String, dynamic>,
     );
+    final cachedCollectGroup = (await _getCollectGroupList()).firstWhere(
+      (collectGroup) => organisation.mediumId!.contains(collectGroup.nameSpace),
+      orElse: CollectGroup.empty,
+    );
+
+    if (cachedCollectGroup.orgName != organisation.organisationName) {
+      return organisation.copyWith(
+        organisationName: cachedCollectGroup.orgName,
+      );
+    }
     return organisation;
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Check that the name of the organization from the last donation remembered in shared preferences is the same as the name in the cached list of orgs.