### PR TITLE
Feat: adds Makefile support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.PHONY: lint
+lint:
+	dart format lib test
+	flutter analyze
+
+.PHONY: run_dev
+run_dev:
+	flutter run --flavor development --target lib/main_development.dart
+
+.PHONY: run_prod
+run_prod:
+	flutter run --flavor production --target lib/main_production.dart
+
+.PHONY: run_staging
+run_staging:
+	flutter run --flavor staging --target lib/main_staging.dart
+
+.PHONY: get
+get:
+	flutter pub get
+
+.PHONY: test
+test:
+	flutter test --coverage --test-randomize-ordering-seed random
+
+.PHONY: melos
+melos:
+	flutter pub global run melos exec -c 6 flutter pub get
+
+

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ make run_dev
 make run_staging
 
 # Run Production Flavor
-make make run_prod
+make run_prod
 
 # Run Linter
 make lint

--- a/README.md
+++ b/README.md
@@ -57,6 +57,33 @@ $ open coverage/index.html
 
 ---
 
+### Makefile support
+
+Alternatively, we have a `Makefile` to help with these commands, as well as other frequent commands:
+
+```sh
+# Run Development Flavor
+make run_dev
+
+# Run Staging Flavor
+make run_staging
+
+# Run Production Flavor
+make make run_prod
+
+# Run Linter
+make lint
+
+# Gets Packages
+make get
+
+# Installs Custom Packages
+make melos
+
+# Runs All Tests
+make test
+```
+
 ## Working with Translations 🌐
 
 This project relies on [flutter_localizations][flutter_localizations_link] and follows the [official internationalization guide for Flutter][internationalization_link].


### PR DESCRIPTION
## Description
With features such as flavors and Melos, I've noticed that the app contains several commands that can be shortened with a Makefile. This PR provides a simple quality-of-life feature for app contributors and incentivizes more frequent usage of other commands like `make lint`, which may assist with keeping track and following Flutter's linter rules.
