### PR TITLE
bugfix: checks AuthCubit status before trying to validate email form

### DIFF
--- a/lib/features/auth/pages/email_signup_page.dart
+++ b/lib/features/auth/pages/email_signup_page.dart
@@ -170,9 +170,14 @@ class _EmailSignupPageState extends State<EmailSignupPage> {
                     ],
                     autocorrect: false,
                     validator: (value) {
-                      if (value == null ||
-                          value.isEmpty ||
-                          !Util.emailRegEx.hasMatch(value)) {
+                      final isUnknownStatus =
+                          context.read<AuthCubit>().state.status ==
+                              AuthStatus.unknown;
+
+                      if (!isUnknownStatus &&
+                          (value == null ||
+                              value.isEmpty ||
+                              !Util.emailRegEx.hasMatch(value))) {
                         return context.l10n.invalidEmail;
                       }
                       return null;


### PR DESCRIPTION
## Description
The initial state of `email_signup_page` always shows a "invalid email" error message from `TextFormField`. This is because it's not checking the `AuthCubit` status before making the validation; `Unknown` status means that the user hasn't interacted with this form yet, so it shouldn't show any errors.

![Screenshot_20240221-185557](https://github.com/givtnl/givt-app/assets/56059776/326884a4-b5cd-4ed6-9a46-0504aba0d37d)
