### PR TITLE
Update internet_connection_checker_lib

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,18 +181,18 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: "224a77051d52a11fbad53dd57827594d3bd24f945af28bd70bab376d68d437f0"
+      sha256: db7a4e143dc72cc3cb2044ef9b052a7ebfe729513e6a82943bc3526f784365b8
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "6.0.3"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: cf1d1c28f4416f8c654d7dc3cd638ec586076255d407cef3ddbdaf178272a71a
+      sha256: b6a56efe1e6675be240de39107281d4034b64ac23438026355b4234042a35adb
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.4"
+    version: "2.0.0"
   conventional_commit:
     dependency: transitive
     description:
@@ -703,10 +703,10 @@ packages:
     dependency: "direct main"
     description:
       name: internet_connection_checker_plus
-      sha256: "7daf4458c62923f4c7f3b54b1b3191bc3d8813e69a45722ef0ff5fc3ef2ef686"
+      sha256: "423480962bda16f10d0a79efe6c4f1b5212d80203f6b8ee921edb0a1d3c17c88"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   intl:
     dependency: "direct main"
     description:
@@ -1641,5 +1641,5 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.3.1 <4.0.0"
   flutter: ">=3.19.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
     path: ./packages/http_certificate_pinning
   http_interceptor: 2.0.0-beta.7
   iban: ^1.0.1
-  internet_connection_checker_plus: ^2.1.0
+  internet_connection_checker_plus: ^2.3.0
   intl: ^0.18.0
   ios_utsname_ext: ^2.2.0
   jiffy: ^6.2.1


### PR DESCRIPTION
internet_connection_checker_plus relies on connectivity_plus package of which 6.0.1 fixes the wifi+vpn problem and that update was added in 2.3.0.

https://linear.app/givt/issue/KIDS-964/update-internet-connection-package
