### PR TITLE
Separate NFC and deeplink intent filters.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -58,6 +58,34 @@
             <intent-filter
                 android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:host="*givtapp.net"/>
+                <data android:path="/download" />
+                <data android:path="/*/download" />
+                <data android:scheme="https"/>
+                <data android:scheme="http"/>
+                <data android:pathPrefix="/search-for-coin"/>
+
+            </intent-filter>
+            <intent-filter
+                android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:host="*givt.app"/>
+                <data android:path="/download" />
+                <data android:path="/*/download" />
+                <data android:scheme="https"/>
+                <data android:scheme="http"/>
+                <data android:pathPrefix="/search-for-coin"/>
+
+            </intent-filter>
+            <intent-filter
+                android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.NFC" />
 
     <queries>
         <!-- tel:<phone-number> -->
@@ -85,10 +86,8 @@
             </intent-filter>
             <intent-filter
                 android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:host="*givtapp.net"/>
                 <data android:path="/download" />
@@ -100,10 +99,8 @@
             </intent-filter>
             <intent-filter
                 android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:host="*givt.app"/>
                 <data android:path="/download" />

--- a/lib/features/family/features/scan_nfc/nfc_scan_screen.dart
+++ b/lib/features/family/features/scan_nfc/nfc_scan_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app/app/routes/routes.dart';
 import 'package:givt_app/core/enums/enums.dart';
+import 'package:givt_app/features/family/app/pages.dart';
 import 'package:givt_app/features/family/features/coin_flow/widgets/search_coin_animated_widget.dart';
 import 'package:givt_app/features/family/features/giving_flow/organisation_details/cubit/organisation_details_cubit.dart';
 import 'package:givt_app/features/family/features/scan_nfc/cubit/scan_nfc_cubit.dart';
@@ -101,12 +102,8 @@ class _NFCScanPageState extends State<NFCScanPage> {
           // Android needs the delay to show the success bottom sheet animation
           // iOS needs this delay to allow for the bottomsheet to close
           Future.delayed(ScanNfcCubit.animationDuration, () {
-            // close the android success bottom sheet animation
-            if (Platform.isAndroid) {
-              context.pop();
-            }
 
-            context.pushReplacementNamed(Pages.chooseAmountSlider.name);
+            context.pushReplacementNamed(FamilyPages.chooseAmountSlider.name);
 
             AnalyticsHelper.logEvent(
               eventName: AmplitudeEvents.inAppCoinScannedSuccessfully,


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5ebc331fc19a48843789654f44d35a9592ebabed  | 
|--------|--------|

### Summary:
Separated NFC and deeplink intent filters in AndroidManifest.xml, added new deeplink intent filters, and updated NFC scan screen routing.

**Key points**:
- Updated `android/app/src/main/AndroidManifest.xml` to separate NFC and deeplink intent filters.
- Added two new intent filters for deeplinks with hosts `*givtapp.net` and `*givt.app`.
- Existing intent filters for NFC and deeplinks are now distinct, ensuring independent handling.
- Updated `lib/features/family/features/scan_nfc/nfc_scan_screen.dart` to use `FamilyPages.chooseAmountSlider` route.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->