### PR TITLE
Fix registrationbloc being closed and being unusable.

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -15,6 +15,7 @@ import 'package:givt_app/features/family/features/impact_groups/cubit/impact_gro
 import 'package:givt_app/features/family/features/profiles/cubit/profiles_cubit.dart';
 import 'package:givt_app/features/family/features/scan_nfc/cubit/scan_nfc_cubit.dart';
 import 'package:givt_app/features/impact_groups/cubit/impact_groups_cubit.dart';
+import 'package:givt_app/features/registration/bloc/registration_bloc.dart';
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/shared/bloc/infra/infra_cubit.dart';
 import 'package:givt_app/utils/utils.dart';
@@ -101,6 +102,12 @@ class _AppState extends State<App> {
           ),
           BlocProvider(
             create: (context) => ScanNfcCubit(),
+          ),
+          BlocProvider(
+            create: (context) => RegistrationBloc(
+              authCubit: context.read<AuthCubit>(),
+              authRepositoy: getIt(),
+            ),
           ),
         ],
         child: const _AppView(),

--- a/lib/app/routes/app_router.dart
+++ b/lib/app/routes/app_router.dart
@@ -417,22 +417,15 @@ class AppRouter {
               final createStripe = bool.parse(
                 state.uri.queryParameters['createStripe'] ?? 'false',
               );
+
+              if (createStripe) {
+                context
+                    .read<RegistrationBloc>()
+                    .add(const RegistrationStripeInit());
+              }
+
               return MultiBlocProvider(
                 providers: [
-                  BlocProvider(
-                    create: (_) {
-                      final registrationBloc = RegistrationBloc(
-                        authCubit: context.read<AuthCubit>(),
-                        authRepositoy: getIt(),
-                      );
-
-                      if (createStripe) {
-                        registrationBloc.add(const RegistrationStripeInit());
-                      }
-
-                      return registrationBloc;
-                    },
-                  ),
                   BlocProvider(
                     create: (_) => StripeCubit(
                       authRepositoy: getIt(),


### PR DESCRIPTION
It was being closed because for US registration we are moving away from home and registration was in home and that's where the blocprovider resided. Moved it one step higher to app so it won't be closed anymore.

## Description
<!--- Describe your changes -->

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 40ee8ac76d79044e40b449f0b40132b6868572d5  | 
|--------|--------|

### Summary:
Moved `RegistrationBloc` provider to app level to prevent it from being closed and ensure it remains usable.

**Key points**:
- Moved `RegistrationBloc` provider from home level to app level in `lib/app/app.dart`.
- Updated `lib/app/routes/app_router.dart` to use the existing `RegistrationBloc` instance instead of creating a new one.
- Ensures `RegistrationBloc` remains active and usable throughout the app's lifecycle.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->