### PR TITLE
Bugfix: parents history feed sometimes shows a grey area (KIDS-1075)

### DIFF
--- a/lib/features/auth/repositories/auth_repository.dart
+++ b/lib/features/auth/repositories/auth_repository.dart
@@ -97,7 +97,7 @@ class AuthRepositoyImpl with AuthRepository {
 
   // bool hasSession
   final StreamController<bool> _hasSessionStreamController =
-      StreamController<bool>();
+      StreamController<bool>.broadcast();
 
   @override
   Stream<bool> hasSessionStream() => _hasSessionStreamController.stream;

--- a/lib/features/children/edit_child/repositories/edit_child_repository.dart
+++ b/lib/features/children/edit_child/repositories/edit_child_repository.dart
@@ -18,7 +18,8 @@ class EditChildRepositoryImpl with EditChildRepository {
 
   final APIService apiService;
 
-  final StreamController<String> _childGUIDController = StreamController();
+  final StreamController<String> _childGUIDController =
+      StreamController.broadcast();
 
   @override
   Future<bool> editChild(String childGUID, EditChild child) async {


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
https://linear.app/givt/issue/KIDS-1075/parents-history-feed-is-broken
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e6cf8988f71dbfdef50b156c5f691be0fc81cc9f  | 
|--------|--------|

### Summary:
Fixed parents' history feed grey area issue by changing stream controllers to broadcast mode in `auth_repository.dart` and `edit_child_repository.dart`.

**Key points**:
- Modified `lib/features/auth/repositories/auth_repository.dart`.
  - Changed `_hasSessionStreamController` to `StreamController<bool>.broadcast()`.
- Modified `lib/features/children/edit_child/repositories/edit_child_repository.dart`.
  - Changed `_childGUIDController` to `StreamController<String>.broadcast()`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->