### PR TITLE
Bugfix: fix generosity navigation stack for us flow (KIDS-1073)

### DIFF
--- a/lib/app/routes/app_router.dart
+++ b/lib/app/routes/app_router.dart
@@ -12,25 +12,11 @@ import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/features/children/avatars/cubit/avatars_cubit.dart';
 import 'package:givt_app/features/children/avatars/screens/avatar_selection_screen.dart';
 import 'package:givt_app/features/children/edit_profile/cubit/edit_profile_cubit.dart';
-import 'package:givt_app/features/children/generosity_challenge/assignments/create_challenge_donation/cubit/create_challenge_donation_cubit.dart';
-import 'package:givt_app/features/children/generosity_challenge/assignments/create_challenge_donation/pages/choose_amount_slider_page.dart';
-import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/cubit/family_values_cubit.dart';
-import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/models/family_value.dart';
-import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/pages/display_family_values_page.dart';
-import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/pages/display_organisations_page.dart';
-import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/pages/select_family_values_page.dart';
-import 'package:givt_app/features/children/generosity_challenge/assignments/set_up_allowance/generosity_allowance_flow_page.dart';
-import 'package:givt_app/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart';
-import 'package:givt_app/features/children/generosity_challenge/pages/generosity_challenge.dart';
-import 'package:givt_app/features/children/generosity_challenge/pages/generosity_challenge_introduction.dart';
 import 'package:givt_app/features/children/generosity_challenge/utils/generosity_challenge_helper.dart';
-import 'package:givt_app/features/children/generosity_challenge_chat/chat_scripts/cubit/chat_scripts_cubit.dart';
-import 'package:givt_app/features/children/generosity_challenge_chat/chat_scripts/pages/chat_script_page.dart';
 import 'package:givt_app/features/family/app/pages.dart';
 import 'package:givt_app/features/family/app/routes.dart';
 import 'package:givt_app/features/first_use/pages/welcome_page.dart';
 import 'package:givt_app/features/give/bloc/bloc.dart';
-import 'package:givt_app/features/give/models/models.dart';
 import 'package:givt_app/features/give/pages/bt_scan_page.dart';
 import 'package:givt_app/features/give/pages/giving_page.dart';
 import 'package:givt_app/features/give/pages/gps_scan_page.dart';
@@ -57,9 +43,7 @@ import 'package:givt_app/features/recurring_donations/overview/cubit/recurring_d
 import 'package:givt_app/features/recurring_donations/overview/pages/recurring_donations_overview_page.dart';
 import 'package:givt_app/features/registration/bloc/registration_bloc.dart';
 import 'package:givt_app/features/registration/cubit/stripe_cubit.dart';
-import 'package:givt_app/features/registration/pages/credit_card_details_page.dart';
 import 'package:givt_app/features/registration/pages/pages.dart';
-import 'package:givt_app/features/registration/pages/registration_success_us.dart';
 import 'package:givt_app/features/unregister_account/cubit/unregister_cubit.dart';
 import 'package:givt_app/features/unregister_account/unregister_page.dart';
 import 'package:givt_app/shared/bloc/remote_data_source_sync/remote_data_source_sync_bloc.dart';
@@ -141,151 +125,6 @@ class AppRouter {
             impactGroup: state.extra! as ImpactGroup,
           ),
         ),
-      ),
-      GoRoute(
-        path: Pages.generosityChallenge.path,
-        name: Pages.generosityChallenge.name,
-        builder: (context, state) {
-          return BlocProvider(
-            create: (_) => GenerosityChallengeCubit(
-              getIt(),
-              getIt(),
-              getIt(),
-            )..loadFromCache(),
-            child: const GenerosityChallenge(),
-          );
-        },
-        routes: [
-          GoRoute(
-            path: Pages.generosityChallengeIntroduction.path,
-            name: Pages.generosityChallengeIntroduction.name,
-            builder: (context, state) {
-              final challengeCubit = state.extra! as GenerosityChallengeCubit;
-              return BlocProvider.value(
-                value: challengeCubit,
-                child: const GenerosityChallengeIntruduction(),
-              );
-            },
-          ),
-          GoRoute(
-            path: Pages.generosityChallengeChat.path,
-            name: Pages.generosityChallengeChat.name,
-            builder: (context, state) {
-              final challengeCubit = state.extra! as GenerosityChallengeCubit;
-              return MultiBlocProvider(
-                providers: [
-                  BlocProvider.value(
-                    value: challengeCubit,
-                  ),
-                  BlocProvider(
-                    create: (_) => ChatScriptsCubit(
-                      getIt(),
-                      challengeCubit: challengeCubit,
-                    )..init(context),
-                  ),
-                ],
-                child: const ChatScriptPage(),
-              );
-            },
-          ),
-          GoRoute(
-            path: Pages.selectValues.path,
-            name: Pages.selectValues.name,
-            builder: (context, state) {
-              return MultiBlocProvider(
-                providers: [
-                  BlocProvider.value(
-                    value: state.extra! as GenerosityChallengeCubit,
-                  ),
-                  BlocProvider(
-                    create: (context) => FamilyValuesCubit(
-                      generosityChallengeRepository: getIt(),
-                    ),
-                  ),
-                ],
-                child: const SelectFamilyValues(),
-              );
-            },
-          ),
-          GoRoute(
-            path: Pages.displayValues.path,
-            name: Pages.displayValues.name,
-            builder: (context, state) {
-              return MultiBlocProvider(
-                providers: [
-                  BlocProvider.value(
-                    value: state.extra! as GenerosityChallengeCubit,
-                  ),
-                  BlocProvider(
-                    create: (context) => FamilyValuesCubit(
-                      generosityChallengeRepository: getIt(),
-                    )..getSavedValues(),
-                  ),
-                ],
-                child: const DisplayFamilyValues(),
-              );
-            },
-          ),
-          GoRoute(
-            path: Pages.displayValuesOrganisations.path,
-            name: Pages.displayValuesOrganisations.name,
-            builder: (context, state) {
-              final extra = state.extra! as Map<String, dynamic>;
-              return MultiBlocProvider(
-                providers: [
-                  BlocProvider.value(
-                    value:
-                        extra[GenerosityChallengeHelper.generosityChallengeKey]
-                            as GenerosityChallengeCubit,
-                  ),
-                ],
-                child: DisplayOrganisations(
-                  familyValues: extra[FamilyValuesCubit.familyValuesKey]
-                      as List<FamilyValue>,
-                ),
-              );
-            },
-          ),
-          GoRoute(
-            path: Pages.chooseAmountSlider.path,
-            name: Pages.chooseAmountSlider.name,
-            builder: (context, state) {
-              final extras = state.extra! as List;
-              final organisation = extras[0] as Organisation;
-              final challengeCubit = extras[1] as GenerosityChallengeCubit;
-
-              return MultiBlocProvider(
-                providers: [
-                  BlocProvider(
-                    create: (_) => GiveBloc(
-                      getIt(),
-                      getIt(),
-                      getIt(),
-                      getIt(),
-                    ),
-                  ),
-                  BlocProvider(
-                    create: (context) => CreateChallengeDonationCubit(),
-                  ),
-                  BlocProvider.value(
-                    value: challengeCubit,
-                  ),
-                ],
-                child: ChooseAmountSliderPage(
-                  organisation: organisation,
-                ),
-              );
-            },
-          ),
-          GoRoute(
-            path: Pages.allowanceFlow.path,
-            name: Pages.allowanceFlow.name,
-            builder: (context, state) => BlocProvider.value(
-              value: state.extra! as GenerosityChallengeCubit,
-              child: const GenerosityAllowanceFlowPage(),
-            ),
-          ),
-        ],
       ),
       GoRoute(
         path: Pages.home.path,
@@ -777,7 +616,7 @@ class AppRouter {
 
     params['afterGivingRedirection'] = afterGivingRedirection;
 
-    if (navigatingPage == Pages.generosityChallenge.path &&
+    if (navigatingPage == FamilyPages.generosityChallenge.path &&
         GenerosityChallengeHelper.isCompleted) {
       navigatingPage = '';
       params.remove('page');
@@ -788,9 +627,9 @@ class AppRouter {
     ).query;
 
     if (GenerosityChallengeHelper.isActivated ||
-        (navigatingPage == Pages.generosityChallenge.path &&
+        (navigatingPage == FamilyPages.generosityChallenge.path &&
             !GenerosityChallengeHelper.isCompleted)) {
-      return Pages.generosityChallenge.path;
+      return FamilyPages.generosityChallenge.path;
     }
 
     /// Display the splash screen while checking the auth status
@@ -826,7 +665,9 @@ class AppRouter {
       }
 
       // US users need to select a profile before they can continue
-      if (state.user.isUsUser) {
+      if (state.user.isUsUser &&
+          (!GenerosityChallengeHelper.isActivated ||
+              GenerosityChallengeHelper.isCompleted)) {
         if (state.user.needRegistration) {
           final createStripe = state.user.personalInfoRegistered;
           context.goNamed(

--- a/lib/app/routes/pages.dart
+++ b/lib/app/routes/pages.dart
@@ -3,38 +3,6 @@ enum Pages {
   home(path: '/home', name: 'HOME'),
   loading(path: '/loading', name: 'LOADING'),
   welcome(path: '/welcome', name: 'WELCOME'),
-  generosityChallenge(
-    path: '/generosity-challenge',
-    name: 'GENEROSITY-CHALLENGE',
-  ),
-  generosityChallengeChat(
-    path: 'generosity-challenge-chat',
-    name: 'GENEROSITY-CHALLENGE-CHAT',
-  ),
-  generosityChallengeIntroduction(
-    path: 'generosity-challenge-introduction',
-    name: 'GENEROSITY-CHALLENGE-INTRODUCTION',
-  ),
-  selectValues(
-    path: 'select-values',
-    name: 'SELECT-VALUES',
-  ),
-  displayValues(
-    path: 'display-values',
-    name: 'DISPLAY-VALUES',
-  ),
-  displayValuesOrganisations(
-    path: 'display-values-organisations',
-    name: 'DISPLAY-VALUES-ORGANISATIONS',
-  ),
-  chooseAmountSlider(
-    path: 'choose-amount-slider',
-    name: 'CHOOSE-AMOUNT-SLIDER',
-  ),
-  allowanceFlow(
-    path: 'allowance-flow',
-    name: 'ALLOWANCE-FLOW',
-  ),
 
   selectGivingWay(path: 'select-giving-way', name: 'GIVING-WAY'),
   give(path: 'give', name: 'GIVE'),

--- a/lib/features/children/generosity_challenge/assignments/create_challenge_donation/pages/choose_amount_slider_page.dart
+++ b/lib/features/children/generosity_challenge/assignments/create_challenge_donation/pages/choose_amount_slider_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_stripe/flutter_stripe.dart';
 import 'package:givt_app/app/injection/injection.dart';
-import 'package:givt_app/app/routes/routes.dart';
 import 'package:givt_app/core/enums/enums.dart';
 import 'package:givt_app/core/logging/logging_service.dart';
 import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
@@ -18,11 +17,12 @@ import 'package:givt_app/features/children/generosity_challenge/widgets/generosi
 import 'package:givt_app/features/children/generosity_challenge/widgets/generosity_back_button.dart';
 import 'package:givt_app/features/children/generosity_challenge_chat/chat_scripts/models/enums/chat_script_save_key.dart';
 import 'package:givt_app/features/children/shared/presentation/widgets/no_funds_initial_dialog.dart';
+import 'package:givt_app/features/family/app/pages.dart';
 import 'package:givt_app/features/give/bloc/give/give_bloc.dart';
 import 'package:givt_app/features/give/models/organisation.dart';
 import 'package:givt_app/l10n/l10n.dart';
-import 'package:givt_app/shared/widgets/dialogs/card_dialog.dart';
 import 'package:givt_app/shared/widgets/buttons/givt_elevated_button.dart';
+import 'package:givt_app/shared/widgets/dialogs/card_dialog.dart';
 import 'package:givt_app/utils/stripe_helper.dart';
 import 'package:givt_app/utils/utils.dart';
 import 'package:go_router/go_router.dart';
@@ -67,7 +67,7 @@ class _ChooseAmountSliderPageState extends State<ChooseAmountSliderPage> {
                   ChatScriptSaveKey.organisation,
                   widget.organisation.organisationName!,
                 );
-              context.goNamed(Pages.generosityChallenge.name);
+              context.goNamed(FamilyPages.generosityChallenge.name);
               _logSuccessFullDonation(state);
             } else if (giveState.status == GiveStatus.error) {
               _setLoading(false);

--- a/lib/features/children/generosity_challenge/assignments/family_values/pages/display_family_values_page.dart
+++ b/lib/features/children/generosity_challenge/assignments/family_values/pages/display_family_values_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:givt_app/app/routes/routes.dart';
 import 'package:givt_app/core/enums/amplitude_events.dart';
 import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/cubit/family_values_cubit.dart';
 import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/widgets/family_value_container.dart';
@@ -9,6 +8,7 @@ import 'package:givt_app/features/children/generosity_challenge/cubit/generosity
 import 'package:givt_app/features/children/generosity_challenge/utils/generosity_challenge_helper.dart';
 import 'package:givt_app/features/children/generosity_challenge/widgets/generosity_app_bar.dart';
 import 'package:givt_app/features/children/generosity_challenge/widgets/generosity_back_button.dart';
+import 'package:givt_app/features/family/app/pages.dart';
 import 'package:givt_app/shared/widgets/buttons/givt_elevated_button.dart';
 import 'package:givt_app/utils/utils.dart';
 import 'package:go_router/go_router.dart';
@@ -71,7 +71,7 @@ class DisplayFamilyValues extends StatelessWidget {
                     AmplitudeEvents.daySevenFamilyValuesSeenContinueClicked,
               );
               context.pushNamed(
-                Pages.displayValuesOrganisations.name,
+                FamilyPages.displayValuesOrganisations.name,
                 extra: {
                   FamilyValuesCubit.familyValuesKey: state.selectedValues,
                   GenerosityChallengeHelper.generosityChallengeKey:

--- a/lib/features/children/generosity_challenge/assignments/family_values/widgets/organisation_detail_bottomsheet.dart
+++ b/lib/features/children/generosity_challenge/assignments/family_values/widgets/organisation_detail_bottomsheet.dart
@@ -6,6 +6,7 @@ import 'package:givt_app/core/enums/enums.dart';
 import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/models/family_value.dart';
 import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/widgets/organisation_header.dart';
 import 'package:givt_app/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart';
+import 'package:givt_app/features/family/app/pages.dart';
 import 'package:givt_app/shared/widgets/buttons/custom_icon_border_button.dart';
 import 'package:givt_app/shared/widgets/buttons/givt_elevated_button.dart';
 import 'package:givt_app/utils/utils.dart';
@@ -107,7 +108,7 @@ class OrganisationDetailBottomSheet extends StatelessWidget {
                 );
 
                 context.pushNamed(
-                  Pages.chooseAmountSlider.name,
+                  FamilyPages.chooseAmountSlider.name,
                   extra: [
                     value.organisation,
                     context.read<GenerosityChallengeCubit>(),

--- a/lib/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart
+++ b/lib/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart
@@ -27,12 +27,15 @@ class GenerosityChallengeCubit extends Cubit<GenerosityChallengeState> {
   final ChatScriptsRepository _chatScriptsRepository;
   final ChatHistoryRepository _chatHistoryRepository;
 
+  bool _isDebugQuickFlowEnabled = false;
+
   Future<void> loadFromCache() async {
     emit(state.copyWith(status: GenerosityChallengeStatus.loading));
 
     final days = await _generosityChallengeRepository.loadFromCache();
 
-    final chatScripts = await _chatScriptsRepository.loadChatScripts();
+    final chatScripts = await _chatScriptsRepository.loadChatScripts(
+        isDebugQuickFlowEnabled: _isDebugQuickFlowEnabled);
     final chatActorsSettings =
         await _chatScriptsRepository.loadChatActorsSettings();
 
@@ -41,6 +44,12 @@ class GenerosityChallengeCubit extends Cubit<GenerosityChallengeState> {
       chatScripts: chatScripts,
       chatActorsSettings: chatActorsSettings,
     );
+  }
+
+  void setDebugQuickFlow({required bool enabled}) {
+    _isDebugQuickFlowEnabled = enabled;
+    emit(state.copyWith(isDebugQuickFlowEnabled: enabled));
+    clearCache();
   }
 
   Future<void> clearCache() async {

--- a/lib/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart
+++ b/lib/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart
@@ -49,7 +49,6 @@ class GenerosityChallengeCubit extends Cubit<GenerosityChallengeState> {
   void setDebugQuickFlow({required bool enabled}) {
     _isDebugQuickFlowEnabled = enabled;
     emit(state.copyWith(isDebugQuickFlowEnabled: enabled));
-    clearCache();
   }
 
   Future<void> clearCache() async {
@@ -272,6 +271,7 @@ class GenerosityChallengeCubit extends Cubit<GenerosityChallengeState> {
         chatScripts: chatScripts,
         chatActorsSettings: chatActorsSettings,
         availableChatDayIndex: availableChatDayIndex,
+        isDebugQuickFlowEnabled: _isDebugQuickFlowEnabled,
       ),
     );
   }

--- a/lib/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart
+++ b/lib/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart
@@ -49,6 +49,7 @@ class GenerosityChallengeCubit extends Cubit<GenerosityChallengeState> {
   void setDebugQuickFlow({required bool enabled}) {
     _isDebugQuickFlowEnabled = enabled;
     emit(state.copyWith(isDebugQuickFlowEnabled: enabled));
+    loadFromCache();
   }
 
   Future<void> clearCache() async {

--- a/lib/features/children/generosity_challenge/cubit/generosity_challenge_state.dart
+++ b/lib/features/children/generosity_challenge/cubit/generosity_challenge_state.dart
@@ -15,6 +15,7 @@ class GenerosityChallengeState extends Equatable {
   const GenerosityChallengeState({
     required this.status,
     required this.unlockDayTimeDifference,
+    required this.isDebugQuickFlowEnabled,
     required this.activeDayIndex,
     required this.detailedDayIndex,
     required this.days,
@@ -28,6 +29,7 @@ class GenerosityChallengeState extends Equatable {
   const GenerosityChallengeState.initial({
     this.status = GenerosityChallengeStatus.initial,
     this.unlockDayTimeDifference = UnlockDayTimeDifference.days,
+    this.isDebugQuickFlowEnabled = false,
     this.assignmentDynamicDescription,
     this.activeDayIndex = -1,
     this.detailedDayIndex = -1,
@@ -42,6 +44,7 @@ class GenerosityChallengeState extends Equatable {
   final int activeDayIndex;
   final int detailedDayIndex;
   final UnlockDayTimeDifference unlockDayTimeDifference;
+  final bool isDebugQuickFlowEnabled;
   final GenerosityChallengeStatus status;
   final String? assignmentDynamicDescription;
   final List<ChatScriptItem> chatScripts;
@@ -84,6 +87,7 @@ class GenerosityChallengeState extends Equatable {
     int? detailedDayIndex,
     GenerosityChallengeStatus? status,
     UnlockDayTimeDifference? unlockDayTimeDifference,
+    bool? isDebugQuickFlowEnabled,
     String? assignmentDynamicDescription,
     List<ChatScriptItem>? chatScripts,
     ChatActorsSettings? chatActorsSettings,
@@ -97,6 +101,8 @@ class GenerosityChallengeState extends Equatable {
       status: status ?? this.status,
       unlockDayTimeDifference:
           unlockDayTimeDifference ?? this.unlockDayTimeDifference,
+      isDebugQuickFlowEnabled:
+          isDebugQuickFlowEnabled ?? this.isDebugQuickFlowEnabled,
       assignmentDynamicDescription:
           assignmentDynamicDescription ?? this.assignmentDynamicDescription,
       chatScripts: chatScripts ?? this.chatScripts,

--- a/lib/features/children/generosity_challenge/pages/generosity_challenge.dart
+++ b/lib/features/children/generosity_challenge/pages/generosity_challenge.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:givt_app/app/routes/routes.dart';
 import 'package:givt_app/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart';
 import 'package:givt_app/features/children/generosity_challenge/pages/generosity_challenge_day_details.dart';
 import 'package:givt_app/features/children/generosity_challenge/pages/generosity_challenge_overview.dart';
@@ -31,7 +30,7 @@ class _GenerosityChallengeState extends State<GenerosityChallenge>
       Future.delayed(
         Duration.zero,
         () => context.pushNamed(
-          Pages.generosityChallengeIntroduction.name,
+          FamilyPages.generosityChallengeIntroduction.name,
           extra: context.read<GenerosityChallengeCubit>(),
         ),
       );
@@ -79,7 +78,7 @@ class _GenerosityChallengeState extends State<GenerosityChallenge>
                     context
                       ..pop()
                       ..goNamed(
-                        Pages.generosityChallengeChat.name,
+                        FamilyPages.generosityChallengeChat.name,
                         extra: challenge,
                       );
                   },

--- a/lib/features/children/generosity_challenge/pages/generosity_challenge_day_details.dart
+++ b/lib/features/children/generosity_challenge/pages/generosity_challenge_day_details.dart
@@ -21,6 +21,7 @@ class GenerosityChallengeDayDetails extends StatelessWidget {
     final challenge = context.watch<GenerosityChallengeCubit>();
     final task = GenerosityChallengeContentHelper.getTaskByIndex(
       challenge.state.detailedDayIndex,
+      isDebugQuickFlowEnabled: challenge.state.isDebugQuickFlowEnabled,
     );
     final day = challenge.state.days[challenge.state.detailedDayIndex];
     final isSingleCard = task.partnerCard == null;

--- a/lib/features/children/generosity_challenge/pages/generosity_challenge_introduction.dart
+++ b/lib/features/children/generosity_challenge/pages/generosity_challenge_introduction.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:givt_app/app/routes/routes.dart';
 import 'package:givt_app/core/enums/amplitude_events.dart';
 import 'package:givt_app/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart';
 import 'package:givt_app/features/children/generosity_challenge/utils/generosity_challenge_helper.dart';
 import 'package:givt_app/features/children/generosity_challenge/widgets/generosity_app_bar.dart';
+import 'package:givt_app/features/family/app/pages.dart';
 import 'package:givt_app/features/registration/widgets/acceptPolicyRow.dart';
 import 'package:givt_app/shared/widgets/buttons/givt_elevated_button.dart';
 import 'package:givt_app/utils/utils.dart';
@@ -113,7 +113,7 @@ class _GenerosityChallengeIntruductionState
                   eventName: AmplitudeEvents.acceptedGenerosityChallenge,
                 );
                 context.goNamed(
-                  Pages.generosityChallengeChat.name,
+                  FamilyPages.generosityChallengeChat.name,
                   extra: context.read<GenerosityChallengeCubit>(),
                 );
               },

--- a/lib/features/children/generosity_challenge/pages/generosity_challenge_introduction.dart
+++ b/lib/features/children/generosity_challenge/pages/generosity_challenge_introduction.dart
@@ -13,7 +13,9 @@ import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 class GenerosityChallengeIntruduction extends StatefulWidget {
-  const GenerosityChallengeIntruduction({super.key,});
+  const GenerosityChallengeIntruduction({
+    super.key,
+  });
 
   @override
   State<GenerosityChallengeIntruduction> createState() =>
@@ -24,12 +26,13 @@ class _GenerosityChallengeIntruductionState
     extends State<GenerosityChallengeIntruduction> {
   bool _acceptPolicy = false;
   bool isDebug = false;
+  bool isDebugQuickFlowEnabled = false;
 
   @override
   void initState() {
     super.initState();
     _isDebug().then(
-          (value) => setState(() {
+      (value) => setState(() {
         isDebug = value;
       }),
     );
@@ -126,11 +129,15 @@ class _GenerosityChallengeIntruductionState
                   minWidth: 80,
                 ),
                 isSelected: [
-                  challenge.state.isDebugQuickFlowEnabled == true,
-                  challenge.state.isDebugQuickFlowEnabled == false,
+                  isDebugQuickFlowEnabled == true,
+                  isDebugQuickFlowEnabled == false,
                 ],
-                onPressed: (index) =>
-                    challenge.setDebugQuickFlow(enabled: index == 0),
+                onPressed: (index) {
+                  challenge.setDebugQuickFlow(enabled: index == 0);
+                  setState(() {
+                    isDebugQuickFlowEnabled = index == 0;
+                  });
+                },
                 children: const [
                   Text('Enable quick flow'),
                   Text('Disable quick flow'),

--- a/lib/features/children/generosity_challenge/pages/generosity_challenge_introduction.dart
+++ b/lib/features/children/generosity_challenge/pages/generosity_challenge_introduction.dart
@@ -10,6 +10,7 @@ import 'package:givt_app/features/registration/widgets/acceptPolicyRow.dart';
 import 'package:givt_app/shared/widgets/buttons/givt_elevated_button.dart';
 import 'package:givt_app/utils/utils.dart';
 import 'package:go_router/go_router.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 class GenerosityChallengeIntruduction extends StatefulWidget {
   const GenerosityChallengeIntruduction({super.key,});
@@ -22,9 +23,26 @@ class GenerosityChallengeIntruduction extends StatefulWidget {
 class _GenerosityChallengeIntruductionState
     extends State<GenerosityChallengeIntruduction> {
   bool _acceptPolicy = false;
+  bool isDebug = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _isDebug().then(
+          (value) => setState(() {
+        isDebug = value;
+      }),
+    );
+  }
+
+  Future<bool> _isDebug() async {
+    final info = await PackageInfo.fromPlatform();
+    return info.packageName.contains('test');
+  }
 
   @override
   Widget build(BuildContext context) {
+    final challenge = context.read<GenerosityChallengeCubit>();
     const pictureHeight = 150.0;
     return Scaffold(
       appBar: const GenerosityAppBar(
@@ -96,6 +114,28 @@ class _GenerosityChallengeIntruductionState
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            if (isDebug)
+              ToggleButtons(
+                borderRadius: const BorderRadius.all(Radius.circular(8)),
+                selectedBorderColor: Colors.blue[700],
+                selectedColor: Colors.white,
+                fillColor: Colors.blue[200],
+                color: Colors.blue[400],
+                constraints: const BoxConstraints(
+                  minHeight: 40,
+                  minWidth: 80,
+                ),
+                isSelected: [
+                  challenge.state.isDebugQuickFlowEnabled == true,
+                  challenge.state.isDebugQuickFlowEnabled == false,
+                ],
+                onPressed: (index) =>
+                    challenge.setDebugQuickFlow(enabled: index == 0),
+                children: const [
+                  Text('Enable quick flow'),
+                  Text('Disable quick flow'),
+                ],
+              ),
             AcceptPolicyRow(
               onTap: (value) {
                 setState(() {

--- a/lib/features/children/generosity_challenge/pages/generosity_challenge_overview.dart
+++ b/lib/features/children/generosity_challenge/pages/generosity_challenge_overview.dart
@@ -15,7 +15,9 @@ import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 class GenerosityChallengeOverview extends StatefulWidget {
-  const GenerosityChallengeOverview({super.key,});
+  const GenerosityChallengeOverview({
+    super.key,
+  });
 
   @override
   State<GenerosityChallengeOverview> createState() =>
@@ -25,6 +27,7 @@ class GenerosityChallengeOverview extends StatefulWidget {
 class _GenerosityChallengeOverviewState
     extends State<GenerosityChallengeOverview> {
   bool isDebug = false;
+
   @override
   void initState() {
     super.initState();
@@ -179,29 +182,6 @@ class _GenerosityChallengeOverviewState
                   },
                 ),
                 const Spacer(),
-                if(isDebug)
-                  ToggleButtons(
-                    borderRadius: const BorderRadius.all(Radius.circular(8)),
-                    selectedBorderColor: Colors.blue[700],
-                    selectedColor: Colors.white,
-                    fillColor: Colors.blue[200],
-                    color: Colors.blue[400],
-                    constraints: const BoxConstraints(
-                      minHeight: 40,
-                      minWidth: 80,
-                    ),
-                    isSelected: [
-                      challenge.state.unlockDayTimeDifference ==
-                          UnlockDayTimeDifference.days,
-                      challenge.state.unlockDayTimeDifference ==
-                          UnlockDayTimeDifference.minutes,
-                    ],
-                    onPressed: challenge.toggleTimeDifference,
-                    children: [
-                      Text(UnlockDayTimeDifference.days.name),
-                      Text(UnlockDayTimeDifference.minutes.name),
-                    ],
-                  ),
                 if (isDebug)
                   ToggleButtons(
                     borderRadius: const BorderRadius.all(Radius.circular(8)),

--- a/lib/features/children/generosity_challenge/pages/generosity_challenge_overview.dart
+++ b/lib/features/children/generosity_challenge/pages/generosity_challenge_overview.dart
@@ -179,6 +179,29 @@ class _GenerosityChallengeOverviewState
                   },
                 ),
                 const Spacer(),
+                if(isDebug)
+                  ToggleButtons(
+                    borderRadius: const BorderRadius.all(Radius.circular(8)),
+                    selectedBorderColor: Colors.blue[700],
+                    selectedColor: Colors.white,
+                    fillColor: Colors.blue[200],
+                    color: Colors.blue[400],
+                    constraints: const BoxConstraints(
+                      minHeight: 40,
+                      minWidth: 80,
+                    ),
+                    isSelected: [
+                      challenge.state.unlockDayTimeDifference ==
+                          UnlockDayTimeDifference.days,
+                      challenge.state.unlockDayTimeDifference ==
+                          UnlockDayTimeDifference.minutes,
+                    ],
+                    onPressed: challenge.toggleTimeDifference,
+                    children: [
+                      Text(UnlockDayTimeDifference.days.name),
+                      Text(UnlockDayTimeDifference.minutes.name),
+                    ],
+                  ),
                 if (isDebug)
                   ToggleButtons(
                     borderRadius: const BorderRadius.all(Radius.circular(8)),

--- a/lib/features/children/generosity_challenge/pages/generosity_challenge_overview.dart
+++ b/lib/features/children/generosity_challenge/pages/generosity_challenge_overview.dart
@@ -9,6 +9,7 @@ import 'package:givt_app/features/children/generosity_challenge/utils/generosity
 import 'package:givt_app/features/children/generosity_challenge/widgets/day_button.dart';
 import 'package:givt_app/features/children/generosity_challenge/widgets/generosity_app_bar.dart';
 import 'package:givt_app/features/children/generosity_challenge_chat/chat_scripts/widgets/chat_icon_button.dart';
+import 'package:givt_app/features/family/app/pages.dart';
 import 'package:givt_app/utils/utils.dart';
 import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -165,7 +166,7 @@ class _GenerosityChallengeOverviewState
                                   challenge.state.availableChatDayIndex ==
                                       index) {
                                 context.goNamed(
-                                  Pages.generosityChallengeChat.name,
+                                  FamilyPages.generosityChallengeChat.name,
                                   extra:
                                       context.read<GenerosityChallengeCubit>(),
                                 );

--- a/lib/features/children/generosity_challenge/repositories/chat_scripts_asset_repository.dart
+++ b/lib/features/children/generosity_challenge/repositories/chat_scripts_asset_repository.dart
@@ -11,21 +11,38 @@ class ChatScriptsAssetRepositoryImpl with ChatScriptsRepository {
       'assets/jsons/generosity_challenge/chat_actors_settings.json';
 
   @override
-  Future<List<ChatScriptItem>> loadChatScripts() async {
+  Future<List<ChatScriptItem>> loadChatScripts({
+    bool isDebugQuickFlowEnabled = false,
+  }) async {
     final chatScripts = <ChatScriptItem>[];
-    for (var dayIndex = 0;
-        dayIndex < GenerosityChallengeHelper.generosityChallengeDays;
-        dayIndex++) {
-      final path =
-          'assets/jsons/generosity_challenge/chat_scripts/chat_script_day_$dayIndex.json';
+    if (isDebugQuickFlowEnabled) {
+      chatScripts
+        ..add(ChatScriptItem.fromBranchesMap(await _getChatScriptForDay(0)))
+        ..add(ChatScriptItem.fromBranchesMap(await _getChatScriptForDay(1)))
+        ..add(ChatScriptItem.fromBranchesMap(await _getChatScriptForDay(6)))
+        ..add(ChatScriptItem.fromBranchesMap(await _getChatScriptForDay(7)));
+      return chatScripts;
+    } else {
+      for (var dayIndex = 0;
+          dayIndex < GenerosityChallengeHelper.generosityChallengeDays;
+          dayIndex++) {
+        final chatScriptBranchesMap = await _getChatScriptForDay(dayIndex);
 
-      final json = await root_bundle.rootBundle.loadString(path);
-
-      final chatScriptBranchesMap = jsonDecode(json) as Map<String, dynamic>;
-
-      chatScripts.add(ChatScriptItem.fromBranchesMap(chatScriptBranchesMap));
+        chatScripts.add(ChatScriptItem.fromBranchesMap(chatScriptBranchesMap));
+      }
     }
+
     return chatScripts;
+  }
+
+  Future<Map<String, dynamic>> _getChatScriptForDay(int dayIndex) async {
+    final path =
+        'assets/jsons/generosity_challenge/chat_scripts/chat_script_day_$dayIndex.json';
+
+    final json = await root_bundle.rootBundle.loadString(path);
+
+    final chatScriptBranchesMap = jsonDecode(json) as Map<String, dynamic>;
+    return chatScriptBranchesMap;
   }
 
   @override

--- a/lib/features/children/generosity_challenge/repositories/chat_scripts_repository.dart
+++ b/lib/features/children/generosity_challenge/repositories/chat_scripts_repository.dart
@@ -2,6 +2,6 @@ import 'package:givt_app/features/children/generosity_challenge/models/chat_acto
 import 'package:givt_app/features/children/generosity_challenge_chat/chat_scripts/models/chat_script_item.dart';
 
 mixin ChatScriptsRepository {
-  Future<List<ChatScriptItem>> loadChatScripts();
+  Future<List<ChatScriptItem>> loadChatScripts({bool isDebugQuickFlowEnabled = false});
   Future<ChatActorsSettings> loadChatActorsSettings();
 }

--- a/lib/features/children/generosity_challenge/utils/generosity_challenge_content_helper.dart
+++ b/lib/features/children/generosity_challenge/utils/generosity_challenge_content_helper.dart
@@ -2,6 +2,7 @@
 
 import 'package:givt_app/app/routes/routes.dart';
 import 'package:givt_app/features/children/generosity_challenge/models/task.dart';
+import 'package:givt_app/features/family/app/pages.dart';
 
 class GenerosityChallengeContentHelper {
   static final List<Task> _tasks = [
@@ -18,7 +19,7 @@ class GenerosityChallengeContentHelper {
       description:
           'Chat together and pick 3 values from your welcome pack. These will help guide your decisions around generosity.\n\nMake sure everyone has at least 1 they want of the 3 chosen.',
       buttonText: 'Select 3 values',
-      redirect: Pages.selectValues.path,
+      redirect: FamilyPages.selectValues.path,
       onTap: () {},
       partnerCard: Task.card(
         image: 'assets/images/generosity_challenge_day_2.svg',
@@ -61,7 +62,7 @@ class GenerosityChallengeContentHelper {
       buttonText: 'Find a charity',
       description:
           'Using your Family Values see what charities align with what you care about. Give to one of them.',
-      redirect: Pages.displayValues.path,
+      redirect: FamilyPages.displayValues.path,
       onTap: () {},
       partnerCard: Task.card(
         image: 'assets/images/generosity_challenge_day_7.svg',
@@ -76,7 +77,7 @@ class GenerosityChallengeContentHelper {
       buttonText: 'Yeah sure!',
       description:
           "Let's setup a recurring giving allowance to encourage a lifelong habit of generosity.\n\nAre you ready to help them become generous individuals?",
-      redirect: Pages.allowanceFlow.path,
+      redirect: FamilyPages.allowanceFlow.path,
       onTap: () {},
     ),
   ];

--- a/lib/features/children/generosity_challenge/utils/generosity_challenge_content_helper.dart
+++ b/lib/features/children/generosity_challenge/utils/generosity_challenge_content_helper.dart
@@ -6,28 +6,8 @@ import 'package:givt_app/features/family/app/pages.dart';
 
 class GenerosityChallengeContentHelper {
   static final List<Task> _tasks = [
-    Task.card(
-      image: 'assets/images/generosity_challenge_day_1.svg',
-      title: 'Save the letter',
-      description:
-          "Today's assignment is for each family member to answer the question in the Mayor's letter. Once you've done that, stick it on your fridge with the magnet where you will see it everyday!\n\nDone? Hit the Complete Button",
-      onTap: () {},
-    ),
-    Task.card(
-      image: 'assets/images/generosity_challenge_day_2.svg',
-      title: 'Select Family Values',
-      description:
-          'Chat together and pick 3 values from your welcome pack. These will help guide your decisions around generosity.\n\nMake sure everyone has at least 1 they want of the 3 chosen.',
-      buttonText: 'Select 3 values',
-      redirect: FamilyPages.selectValues.path,
-      onTap: () {},
-      partnerCard: Task.card(
-        image: 'assets/images/generosity_challenge_day_2.svg',
-        title: 'The 3 Family Values are selected!',
-        description: '',
-        onTap: () {},
-      ),
-    ),
+    _day1(),
+    _day2(),
     Task.card(
       image: 'assets/images/generosity_challenge_day_3.svg',
       title: 'Attention',
@@ -56,7 +36,40 @@ class GenerosityChallengeContentHelper {
           'Each person say one nice thing you like about someone else.\n\nFor example, "I love it when you hug me when I\'m sad."',
       onTap: () {},
     ),
-    Task.card(
+    _day7(),
+    day8(),
+  ];
+
+  static Task _day2() {
+    return Task.card(
+      image: 'assets/images/generosity_challenge_day_2.svg',
+      title: 'Select Family Values',
+      description:
+          'Chat together and pick 3 values from your welcome pack. These will help guide your decisions around generosity.\n\nMake sure everyone has at least 1 they want of the 3 chosen.',
+      buttonText: 'Select 3 values',
+      redirect: FamilyPages.selectValues.path,
+      onTap: () {},
+      partnerCard: Task.card(
+        image: 'assets/images/generosity_challenge_day_2.svg',
+        title: 'The 3 Family Values are selected!',
+        description: '',
+        onTap: () {},
+      ),
+    );
+  }
+
+  static Task _day1() {
+    return Task.card(
+      image: 'assets/images/generosity_challenge_day_1.svg',
+      title: 'Save the letter',
+      description:
+          "Today's assignment is for each family member to answer the question in the Mayor's letter. Once you've done that, stick it on your fridge with the magnet where you will see it everyday!\n\nDone? Hit the Complete Button",
+      onTap: () {},
+    );
+  }
+
+  static Task _day7() {
+    return Task.card(
       image: 'assets/images/generosity_challenge_day_7.svg',
       title: 'Giving together',
       buttonText: 'Find a charity',
@@ -70,8 +83,11 @@ class GenerosityChallengeContentHelper {
         description: '',
         onTap: () {},
       ),
-    ),
-    Task.card(
+    );
+  }
+
+  static Task day8() {
+    return Task.card(
       image: 'assets/images/generosity_challenge_day_8.svg',
       title: 'Keep the generosity alive',
       buttonText: 'Yeah sure!',
@@ -79,10 +95,17 @@ class GenerosityChallengeContentHelper {
           "Let's setup a recurring giving allowance to encourage a lifelong habit of generosity.\n\nAre you ready to help them become generous individuals?",
       redirect: FamilyPages.allowanceFlow.path,
       onTap: () {},
-    ),
+    );
+  }
+
+  static final List<Task> _quickFlowTasks = [
+    _day1(),
+    _day2(),
+    _day7(),
+    day8(),
   ];
 
-  static Task getTaskByIndex(int index) {
-    return _tasks[index];
+  static Task getTaskByIndex(int index, {bool isDebugQuickFlowEnabled = false}) {
+    return isDebugQuickFlowEnabled ? _quickFlowTasks[index] : _tasks[index];
   }
 }

--- a/lib/features/children/generosity_challenge/widgets/generosity_challenge_daily_card.dart
+++ b/lib/features/children/generosity_challenge/widgets/generosity_challenge_daily_card.dart
@@ -6,6 +6,7 @@ import 'package:givt_app/app/routes/routes.dart';
 import 'package:givt_app/core/enums/amplitude_events.dart';
 import 'package:givt_app/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart';
 import 'package:givt_app/features/children/generosity_challenge/models/task.dart';
+import 'package:givt_app/features/family/app/pages.dart';
 import 'package:givt_app/shared/widgets/buttons/givt_elevated_button.dart';
 import 'package:givt_app/features/children/generosity_challenge/pages/generosity_challenge_vpc_setup_page.dart';
 import 'package:givt_app/shared/widgets/extensions/route_extensions.dart';
@@ -88,8 +89,9 @@ class GenerosityDailyCard extends StatelessWidget {
                         onTap: redirect
                             ? () {
                                 context.push(
-                                  '${Pages.generosityChallenge.path}/${task.redirect}',
-                                  extra: context.read<GenerosityChallengeCubit>(),
+                                  '${FamilyPages.generosityChallenge.path}/${task.redirect}',
+                                  extra:
+                                      context.read<GenerosityChallengeCubit>(),
                                 );
                                 AnalyticsHelper.logEvent(
                                   eventName: AmplitudeEvents

--- a/lib/features/children/generosity_challenge_chat/chat_scripts/widgets/chat_icon_button.dart
+++ b/lib/features/children/generosity_challenge_chat/chat_scripts/widgets/chat_icon_button.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:givt_app/app/routes/routes.dart';
 import 'package:givt_app/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart';
+import 'package:givt_app/features/family/app/pages.dart';
 import 'package:givt_app/utils/utils.dart';
 import 'package:go_router/go_router.dart';
 
@@ -18,7 +19,7 @@ class ChatIconButton extends StatelessWidget {
             IconButton(
               onPressed: () async {
                 context.goNamed(
-                  Pages.generosityChallengeChat.name,
+                  FamilyPages.generosityChallengeChat.name,
                   extra: context.read<GenerosityChallengeCubit>(),
                 );
               },

--- a/lib/features/family/app/pages.dart
+++ b/lib/features/family/app/pages.dart
@@ -56,7 +56,41 @@ enum FamilyPages {
   chooseAmountSliderGoal(
       path: '/choose-amount-slider-goal', name: 'CHOOSE_AMOUNT_SLIDER_GOAL'),
 
-//school event mode
+  //generosity challenge
+  generosityChallenge(
+    path: '/generosity-challenge',
+    name: 'GENEROSITY-CHALLENGE',
+  ),
+  generosityChallengeChat(
+    path: 'generosity-challenge-chat',
+    name: 'GENEROSITY-CHALLENGE-CHAT',
+  ),
+  generosityChallengeIntroduction(
+    path: 'generosity-challenge-introduction',
+    name: 'GENEROSITY-CHALLENGE-INTRODUCTION',
+  ),
+  selectValues(
+    path: 'select-values',
+    name: 'SELECT-VALUES',
+  ),
+  displayValues(
+    path: 'display-values',
+    name: 'DISPLAY-VALUES',
+  ),
+  displayValuesOrganisations(
+    path: 'display-values-organisations',
+    name: 'DISPLAY-VALUES-ORGANISATIONS',
+  ),
+  chooseAmountSlider(
+    path: 'choose-amount-slider',
+    name: 'CHOOSE-AMOUNT-SLIDER',
+  ),
+  allowanceFlow(
+    path: 'allowance-flow',
+    name: 'ALLOWANCE-FLOW',
+  ),
+
+  //school event mode
   familyNameLogin(path: '/family-name-login', name: 'FAMILY_NAME_LOGIN'),
   schoolEventInfo(path: '/school-event-info', name: 'SCHOOL_EVENT_INFO'),
   schoolEventOrganisations(

--- a/lib/features/family/app/routes.dart
+++ b/lib/features/family/app/routes.dart
@@ -87,152 +87,152 @@ class FamilyAppRoutes {
 
   static final List<RouteBase> _routes = [
     GoRoute(
+      path: FamilyPages.generosityChallenge.path,
+      name: FamilyPages.generosityChallenge.name,
+      builder: (context, state) {
+        return BlocProvider(
+          create: (_) => GenerosityChallengeCubit(
+            getIt(),
+            getIt(),
+            getIt(),
+          )..loadFromCache(),
+          child: const GenerosityChallenge(),
+        );
+      },
       routes: [
         GoRoute(
-          path: FamilyPages.generosityChallenge.path,
-          name: FamilyPages.generosityChallenge.name,
+          path: FamilyPages.generosityChallengeIntroduction.path,
+          name: FamilyPages.generosityChallengeIntroduction.name,
           builder: (context, state) {
-            return BlocProvider(
-              create: (_) => GenerosityChallengeCubit(
-                getIt(),
-                getIt(),
-                getIt(),
-              )..loadFromCache(),
-              child: const GenerosityChallenge(),
+            final challengeCubit = state.extra! as GenerosityChallengeCubit;
+            return BlocProvider.value(
+              value: challengeCubit,
+              child: const GenerosityChallengeIntruduction(),
             );
           },
-          routes: [
-            GoRoute(
-              path: FamilyPages.generosityChallengeIntroduction.path,
-              name: FamilyPages.generosityChallengeIntroduction.name,
-              builder: (context, state) {
-                final challengeCubit = state.extra! as GenerosityChallengeCubit;
-                return BlocProvider.value(
-                  value: challengeCubit,
-                  child: const GenerosityChallengeIntruduction(),
-                );
-              },
-            ),
-            GoRoute(
-              path: FamilyPages.generosityChallengeChat.path,
-              name: FamilyPages.generosityChallengeChat.name,
-              builder: (context, state) {
-                final challengeCubit = state.extra! as GenerosityChallengeCubit;
-                return MultiBlocProvider(
-                  providers: [
-                    BlocProvider.value(
-                      value: challengeCubit,
-                    ),
-                    BlocProvider(
-                      create: (_) => ChatScriptsCubit(
-                        getIt(),
-                        challengeCubit: challengeCubit,
-                      )..init(context),
-                    ),
-                  ],
-                  child: const ChatScriptPage(),
-                );
-              },
-            ),
-            GoRoute(
-              path: FamilyPages.selectValues.path,
-              name: FamilyPages.selectValues.name,
-              builder: (context, state) {
-                return MultiBlocProvider(
-                  providers: [
-                    BlocProvider.value(
-                      value: state.extra! as GenerosityChallengeCubit,
-                    ),
-                    BlocProvider(
-                      create: (context) => FamilyValuesCubit(
-                        generosityChallengeRepository: getIt(),
-                      ),
-                    ),
-                  ],
-                  child: const SelectFamilyValues(),
-                );
-              },
-            ),
-            GoRoute(
-              path: FamilyPages.displayValues.path,
-              name: FamilyPages.displayValues.name,
-              builder: (context, state) {
-                return MultiBlocProvider(
-                  providers: [
-                    BlocProvider.value(
-                      value: state.extra! as GenerosityChallengeCubit,
-                    ),
-                    BlocProvider(
-                      create: (context) => FamilyValuesCubit(
-                        generosityChallengeRepository: getIt(),
-                      )..getSavedValues(),
-                    ),
-                  ],
-                  child: const DisplayFamilyValues(),
-                );
-              },
-            ),
-            GoRoute(
-              path: FamilyPages.displayValuesOrganisations.path,
-              name: FamilyPages.displayValuesOrganisations.name,
-              builder: (context, state) {
-                final extra = state.extra! as Map<String, dynamic>;
-                return MultiBlocProvider(
-                  providers: [
-                    BlocProvider.value(
-                      value:
-                      extra[GenerosityChallengeHelper.generosityChallengeKey]
-                      as GenerosityChallengeCubit,
-                    ),
-                  ],
-                  child: DisplayOrganisations(
-                    familyValues: extra[FamilyValuesCubit.familyValuesKey]
-                    as List<FamilyValue>,
-                  ),
-                );
-              },
-            ),
-            GoRoute(
-              path: FamilyPages.chooseAmountSlider.path,
-              name: FamilyPages.chooseAmountSlider.name,
-              builder: (context, state) {
-                final extras = state.extra! as List;
-                final organisation = extras[0] as Organisation;
-                final challengeCubit = extras[1] as GenerosityChallengeCubit;
-
-                return MultiBlocProvider(
-                  providers: [
-                    BlocProvider(
-                      create: (_) => GiveBloc(
-                        getIt(),
-                        getIt(),
-                        getIt(),
-                        getIt(),
-                      ),
-                    ),
-                    BlocProvider(
-                      create: (context) => CreateChallengeDonationCubit(),
-                    ),
-                    BlocProvider.value(
-                      value: challengeCubit,
-                    ),
-                  ],
-                  child: ChooseAmountSliderPage(
-                    organisation: organisation,
-                  ),
-                );
-              },
-            ),
-            GoRoute(
-              path: FamilyPages.allowanceFlow.path,
-              name: FamilyPages.allowanceFlow.name,
-              builder: (context, state) => BlocProvider.value(
-                value: state.extra! as GenerosityChallengeCubit,
-                child: const GenerosityAllowanceFlowPage(),
-              ),
-            ),
-          ],
         ),
+        GoRoute(
+          path: FamilyPages.generosityChallengeChat.path,
+          name: FamilyPages.generosityChallengeChat.name,
+          builder: (context, state) {
+            final challengeCubit = state.extra! as GenerosityChallengeCubit;
+            return MultiBlocProvider(
+              providers: [
+                BlocProvider.value(
+                  value: challengeCubit,
+                ),
+                BlocProvider(
+                  create: (_) => ChatScriptsCubit(
+                    getIt(),
+                    challengeCubit: challengeCubit,
+                  )..init(context),
+                ),
+              ],
+              child: const ChatScriptPage(),
+            );
+          },
+        ),
+        GoRoute(
+          path: FamilyPages.selectValues.path,
+          name: FamilyPages.selectValues.name,
+          builder: (context, state) {
+            return MultiBlocProvider(
+              providers: [
+                BlocProvider.value(
+                  value: state.extra! as GenerosityChallengeCubit,
+                ),
+                BlocProvider(
+                  create: (context) => FamilyValuesCubit(
+                    generosityChallengeRepository: getIt(),
+                  ),
+                ),
+              ],
+              child: const SelectFamilyValues(),
+            );
+          },
+        ),
+        GoRoute(
+          path: FamilyPages.displayValues.path,
+          name: FamilyPages.displayValues.name,
+          builder: (context, state) {
+            return MultiBlocProvider(
+              providers: [
+                BlocProvider.value(
+                  value: state.extra! as GenerosityChallengeCubit,
+                ),
+                BlocProvider(
+                  create: (context) => FamilyValuesCubit(
+                    generosityChallengeRepository: getIt(),
+                  )..getSavedValues(),
+                ),
+              ],
+              child: const DisplayFamilyValues(),
+            );
+          },
+        ),
+        GoRoute(
+          path: FamilyPages.displayValuesOrganisations.path,
+          name: FamilyPages.displayValuesOrganisations.name,
+          builder: (context, state) {
+            final extra = state.extra! as Map<String, dynamic>;
+            return MultiBlocProvider(
+              providers: [
+                BlocProvider.value(
+                  value:
+                  extra[GenerosityChallengeHelper.generosityChallengeKey]
+                  as GenerosityChallengeCubit,
+                ),
+              ],
+              child: DisplayOrganisations(
+                familyValues: extra[FamilyValuesCubit.familyValuesKey]
+                as List<FamilyValue>,
+              ),
+            );
+          },
+        ),
+        GoRoute(
+          path: FamilyPages.chooseAmountSlider.path,
+          name: FamilyPages.chooseAmountSlider.name,
+          builder: (context, state) {
+            final extras = state.extra! as List;
+            final organisation = extras[0] as Organisation;
+            final challengeCubit = extras[1] as GenerosityChallengeCubit;
+
+            return MultiBlocProvider(
+              providers: [
+                BlocProvider(
+                  create: (_) => GiveBloc(
+                    getIt(),
+                    getIt(),
+                    getIt(),
+                    getIt(),
+                  ),
+                ),
+                BlocProvider(
+                  create: (context) => CreateChallengeDonationCubit(),
+                ),
+                BlocProvider.value(
+                  value: challengeCubit,
+                ),
+              ],
+              child: ChooseAmountSliderPage(
+                organisation: organisation,
+              ),
+            );
+          },
+        ),
+        GoRoute(
+          path: FamilyPages.allowanceFlow.path,
+          name: FamilyPages.allowanceFlow.name,
+          builder: (context, state) => BlocProvider.value(
+            value: state.extra! as GenerosityChallengeCubit,
+            child: const GenerosityAllowanceFlowPage(),
+          ),
+        ),
+      ],
+    ),
+    GoRoute(
+      routes: [
         GoRoute(
           path: FamilyPages.creditCardDetails.path,
           name: FamilyPages.creditCardDetails.name,

--- a/lib/features/family/app/routes.dart
+++ b/lib/features/family/app/routes.dart
@@ -18,6 +18,19 @@ import 'package:givt_app/features/children/edit_child/pages/edit_child_page.dart
 import 'package:givt_app/features/children/family_goal/cubit/create_family_goal_cubit.dart';
 import 'package:givt_app/features/children/family_goal/pages/create_family_goal_flow_page.dart';
 import 'package:givt_app/features/children/family_history/family_history_cubit/family_history_cubit.dart';
+import 'package:givt_app/features/children/generosity_challenge/assignments/create_challenge_donation/cubit/create_challenge_donation_cubit.dart';
+import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/cubit/family_values_cubit.dart';
+import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/models/family_value.dart';
+import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/pages/display_family_values_page.dart';
+import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/pages/display_organisations_page.dart';
+import 'package:givt_app/features/children/generosity_challenge/assignments/family_values/pages/select_family_values_page.dart';
+import 'package:givt_app/features/children/generosity_challenge/assignments/set_up_allowance/generosity_allowance_flow_page.dart';
+import 'package:givt_app/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart';
+import 'package:givt_app/features/children/generosity_challenge/pages/generosity_challenge.dart';
+import 'package:givt_app/features/children/generosity_challenge/pages/generosity_challenge_introduction.dart';
+import 'package:givt_app/features/children/generosity_challenge/utils/generosity_challenge_helper.dart';
+import 'package:givt_app/features/children/generosity_challenge_chat/chat_scripts/cubit/chat_scripts_cubit.dart';
+import 'package:givt_app/features/children/generosity_challenge_chat/chat_scripts/pages/chat_script_page.dart';
 import 'package:givt_app/features/children/overview/cubit/family_overview_cubit.dart';
 import 'package:givt_app/features/children/overview/models/profile.dart';
 import 'package:givt_app/features/children/overview/pages/family_overview_page.dart';
@@ -56,7 +69,9 @@ import 'package:givt_app/features/family/features/recommendation/tags/cubit/tags
 import 'package:givt_app/features/family/features/recommendation/tags/screens/location_selection_screen.dart';
 import 'package:givt_app/features/family/features/scan_nfc/nfc_scan_screen.dart';
 import 'package:givt_app/features/family/utils/utils.dart';
+import 'package:givt_app/features/give/bloc/give/give_bloc.dart';
 import 'package:givt_app/features/give/bloc/organisation/organisation_bloc.dart';
+import 'package:givt_app/features/give/models/organisation.dart';
 import 'package:givt_app/features/registration/bloc/registration_bloc.dart';
 import 'package:givt_app/features/registration/cubit/stripe_cubit.dart';
 import 'package:givt_app/features/registration/pages/credit_card_details_page.dart';
@@ -65,12 +80,159 @@ import 'package:givt_app/l10n/l10n.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../children/generosity_challenge/assignments/create_challenge_donation/pages/choose_amount_slider_page.dart';
+
 class FamilyAppRoutes {
   static List<RouteBase> get routes => _routes;
 
   static final List<RouteBase> _routes = [
     GoRoute(
       routes: [
+        GoRoute(
+          path: FamilyPages.generosityChallenge.path,
+          name: FamilyPages.generosityChallenge.name,
+          builder: (context, state) {
+            return BlocProvider(
+              create: (_) => GenerosityChallengeCubit(
+                getIt(),
+                getIt(),
+                getIt(),
+              )..loadFromCache(),
+              child: const GenerosityChallenge(),
+            );
+          },
+          routes: [
+            GoRoute(
+              path: FamilyPages.generosityChallengeIntroduction.path,
+              name: FamilyPages.generosityChallengeIntroduction.name,
+              builder: (context, state) {
+                final challengeCubit = state.extra! as GenerosityChallengeCubit;
+                return BlocProvider.value(
+                  value: challengeCubit,
+                  child: const GenerosityChallengeIntruduction(),
+                );
+              },
+            ),
+            GoRoute(
+              path: FamilyPages.generosityChallengeChat.path,
+              name: FamilyPages.generosityChallengeChat.name,
+              builder: (context, state) {
+                final challengeCubit = state.extra! as GenerosityChallengeCubit;
+                return MultiBlocProvider(
+                  providers: [
+                    BlocProvider.value(
+                      value: challengeCubit,
+                    ),
+                    BlocProvider(
+                      create: (_) => ChatScriptsCubit(
+                        getIt(),
+                        challengeCubit: challengeCubit,
+                      )..init(context),
+                    ),
+                  ],
+                  child: const ChatScriptPage(),
+                );
+              },
+            ),
+            GoRoute(
+              path: FamilyPages.selectValues.path,
+              name: FamilyPages.selectValues.name,
+              builder: (context, state) {
+                return MultiBlocProvider(
+                  providers: [
+                    BlocProvider.value(
+                      value: state.extra! as GenerosityChallengeCubit,
+                    ),
+                    BlocProvider(
+                      create: (context) => FamilyValuesCubit(
+                        generosityChallengeRepository: getIt(),
+                      ),
+                    ),
+                  ],
+                  child: const SelectFamilyValues(),
+                );
+              },
+            ),
+            GoRoute(
+              path: FamilyPages.displayValues.path,
+              name: FamilyPages.displayValues.name,
+              builder: (context, state) {
+                return MultiBlocProvider(
+                  providers: [
+                    BlocProvider.value(
+                      value: state.extra! as GenerosityChallengeCubit,
+                    ),
+                    BlocProvider(
+                      create: (context) => FamilyValuesCubit(
+                        generosityChallengeRepository: getIt(),
+                      )..getSavedValues(),
+                    ),
+                  ],
+                  child: const DisplayFamilyValues(),
+                );
+              },
+            ),
+            GoRoute(
+              path: FamilyPages.displayValuesOrganisations.path,
+              name: FamilyPages.displayValuesOrganisations.name,
+              builder: (context, state) {
+                final extra = state.extra! as Map<String, dynamic>;
+                return MultiBlocProvider(
+                  providers: [
+                    BlocProvider.value(
+                      value:
+                      extra[GenerosityChallengeHelper.generosityChallengeKey]
+                      as GenerosityChallengeCubit,
+                    ),
+                  ],
+                  child: DisplayOrganisations(
+                    familyValues: extra[FamilyValuesCubit.familyValuesKey]
+                    as List<FamilyValue>,
+                  ),
+                );
+              },
+            ),
+            GoRoute(
+              path: FamilyPages.chooseAmountSlider.path,
+              name: FamilyPages.chooseAmountSlider.name,
+              builder: (context, state) {
+                final extras = state.extra! as List;
+                final organisation = extras[0] as Organisation;
+                final challengeCubit = extras[1] as GenerosityChallengeCubit;
+
+                return MultiBlocProvider(
+                  providers: [
+                    BlocProvider(
+                      create: (_) => GiveBloc(
+                        getIt(),
+                        getIt(),
+                        getIt(),
+                        getIt(),
+                      ),
+                    ),
+                    BlocProvider(
+                      create: (context) => CreateChallengeDonationCubit(),
+                    ),
+                    BlocProvider.value(
+                      value: challengeCubit,
+                    ),
+                  ],
+                  child: ChooseAmountSliderPage(
+                    organisation: organisation,
+                  ),
+                );
+              },
+            ),
+            GoRoute(
+              path: FamilyPages.allowanceFlow.path,
+              name: FamilyPages.allowanceFlow.name,
+              builder: (context, state) => BlocProvider.value(
+                value: state.extra! as GenerosityChallengeCubit,
+                child: const GenerosityAllowanceFlowPage(),
+              ),
+            ),
+          ],
+        ),
         GoRoute(
           path: FamilyPages.creditCardDetails.path,
           name: FamilyPages.creditCardDetails.name,


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Also allow test builds to go through the flow faster (only enable day 1,2,7 and 8).
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7cdea41c7ab62462da3f270200989b62406b28a5  | 
|--------|--------|

### Summary:
Fixed generosity navigation stack for US flow and added debug quick flow feature for test builds.

**Key points**:
- **Updated**: Navigation paths for generosity challenge in `lib/app/routes/app_router.dart` and `lib/app/routes/pages.dart`.
- **Added**: Debug quick flow feature in `lib/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart` and `lib/features/children/generosity_challenge/pages/generosity_challenge_introduction.dart`.
- **Modified**: Generosity challenge related pages and widgets to use new navigation paths and handle debug quick flow.
- **Ensured**: Correct handling of US user flows in `lib/app/routes/app_router.dart`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->