### PR TITLE
Bugfix/kids 1073 fix family overview back results in an error on profile selection

### DIFF
--- a/lib/features/family/features/profiles/cubit/profiles_cubit.dart
+++ b/lib/features/family/features/profiles/cubit/profiles_cubit.dart
@@ -24,7 +24,6 @@ class ProfilesCubit extends HydratedCubit<ProfilesState> {
   StreamSubscription<void>? _memberAddedSubscription;
 
   void _init() {
-    hydrate();
     AnalyticsHelper.setUserProperties(
       userId: state.activeProfile.id,
       userProperties: {},

--- a/lib/features/family/features/profiles/cubit/profiles_state.dart
+++ b/lib/features/family/features/profiles/cubit/profiles_state.dart
@@ -91,7 +91,7 @@ class ProfilesExternalErrorState extends ProfilesState {
   List<Object> get props => [profiles, activeProfileIndex, errorMessage];
 }
 
-class ProfilesCountdownState extends ProfilesUpdatedState {
+class ProfilesCountdownState extends ProfilesState {
   const ProfilesCountdownState({
     required super.profiles,
     required super.activeProfileIndex,

--- a/lib/features/family/features/profiles/repository/profiles_repository.dart
+++ b/lib/features/family/features/profiles/repository/profiles_repository.dart
@@ -26,6 +26,7 @@ class ProfilesRepositoryImpl with ProfilesRepository {
   @override
   Future<Profile> fetchChildDetails(String childGuid) async {
     final response = await _apiService.fetchChildDetails(childGuid);
+    response['type'] = 'Child';
     return Profile.fromMap(response);
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Error was not related to navigation but fetchChildDetails returning profiles with type None and therefore type checking failing.