### PR TITLE
Bugfix: creating family goal doesn't show organizations (KIDS-1097)

### DIFF
--- a/lib/features/family/app/routes.dart
+++ b/lib/features/family/app/routes.dart
@@ -79,6 +79,7 @@ import 'package:givt_app/features/registration/cubit/stripe_cubit.dart';
 import 'package:givt_app/features/registration/pages/credit_card_details_page.dart';
 import 'package:givt_app/features/registration/pages/registration_success_us.dart';
 import 'package:givt_app/l10n/l10n.dart';
+import 'package:givt_app/shared/bloc/remote_data_source_sync/remote_data_source_sync_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -180,14 +181,13 @@ class FamilyAppRoutes {
             return MultiBlocProvider(
               providers: [
                 BlocProvider.value(
-                  value:
-                  extra[GenerosityChallengeHelper.generosityChallengeKey]
-                  as GenerosityChallengeCubit,
+                  value: extra[GenerosityChallengeHelper.generosityChallengeKey]
+                      as GenerosityChallengeCubit,
                 ),
               ],
               child: DisplayOrganisations(
                 familyValues: extra[FamilyValuesCubit.familyValuesKey]
-                as List<FamilyValue>,
+                    as List<FamilyValue>,
               ),
             );
           },
@@ -422,7 +422,18 @@ class FamilyAppRoutes {
       name: FamilyPages.profileSelection.name,
       builder: (context, state) => Theme(
         data: const FamilyAppTheme().toThemeData(),
-        child: const ProfileSelectionScreen(),
+        child: MultiBlocProvider(
+          providers: [
+            BlocProvider(
+              lazy: false,
+              create: (_) => RemoteDataSourceSyncBloc(
+                getIt(),
+                getIt(),
+              )..add(const RemoteDataSourceSyncRequested()),
+            ),
+          ],
+          child: const ProfileSelectionScreen(),
+        ),
       ),
     ),
     GoRoute(


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
TODO: change base before merge

https://linear.app/givt/issue/KIDS-1097/creating-family-goal-doesnt-show-organisations-to-select-from
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c51e516e66352d99ca24de0b12a975ca27401f9a  | 
|--------|--------|

### Summary:
Fixes bug to display organizations when creating a family goal by adding `RemoteDataSourceSyncBloc` to `ProfileSelectionScreen` route.

**Key points**:
- **Bugfix**: Ensure organizations are displayed when creating a family goal.
- **File Modified**: `lib/features/family/app/routes.dart`
- **Changes**:
  - Added `RemoteDataSourceSyncBloc` to `ProfileSelectionScreen` route.
  - Updated `MultiBlocProvider` to include `RemoteDataSourceSyncBloc` with `RemoteDataSourceSyncRequested` event.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->