### PR TITLE
Refactor path and name for kids impact group details page

### DIFF
--- a/lib/features/family/app/pages.dart
+++ b/lib/features/family/app/pages.dart
@@ -99,8 +99,8 @@ enum FamilyPages {
   schoolEventOrganisations(
       path: '/school-event-organisations', name: 'SCHOOL_EVENT_ORGANISATIONS'),
   impactGroupDetails(
-    path: '/impact-group-details',
-    name: 'IMPACT_GROUP_DETAILS',
+    path: '/kids-impact-group-details',
+    name: 'KIDS_IMPACT_GROUP_DETAILS',
   ),
   ;
 


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c1c85a74cff15473fead0c6a1a684afda47f1b4f  | 
|--------|--------|

### Summary:
Refactored `impactGroupDetails` path and name in `lib/features/family/app/pages.dart` to be more specific to 'kids'.

**Key points**:
- Refactored `impactGroupDetails` in `lib/features/family/app/pages.dart`
  - Changed `path` from `/impact-group-details` to `/kids-impact-group-details`
  - Changed `name` from `IMPACT_GROUP_DETAILS` to `KIDS_IMPACT_GROUP_DETAILS`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->