### PR TITLE
Use/Show Gift Aid Tax Year instead of Calendar Year (KIDS-975)

### DIFF
--- a/lib/features/overview/bloc/givt_bloc.dart
+++ b/lib/features/overview/bloc/givt_bloc.dart
@@ -141,6 +141,7 @@ class GivtBloc extends Bloc<GivtEvent, GivtState> {
     // Set the first month
     lastMonth = lastMonth.copyWith(
       timeStamp: sortedGivts[0].timeStamp,
+      taxYear: sortedGivts[0].taxYear,
     );
 
     // Check all sorted givts;
@@ -152,6 +153,7 @@ class GivtBloc extends Bloc<GivtEvent, GivtState> {
           organisationName: givt.organisationName,
           status: givt.status,
           isGiftAidEnabled: givt.isGiftAidEnabled,
+          taxYear: givt.taxYear,
         );
       }
 
@@ -168,6 +170,7 @@ class GivtBloc extends Bloc<GivtEvent, GivtState> {
           organisationName: givt.organisationName,
           status: givt.status,
           isGiftAidEnabled: givt.isGiftAidEnabled,
+          taxYear: givt.taxYear,
         );
       }
 
@@ -185,6 +188,7 @@ class GivtBloc extends Bloc<GivtEvent, GivtState> {
         givtGroups.add(lastMonth);
         lastMonth = GivtGroup(
           timeStamp: givt.timeStamp,
+          taxYear: givt.taxYear,
         );
       }
 

--- a/lib/features/overview/models/givt_group.dart
+++ b/lib/features/overview/models/givt_group.dart
@@ -9,6 +9,7 @@ class GivtGroup extends Equatable {
     this.organisationName = '',
     this.givts = const [],
     this.amount = 0,
+    this.taxYear = 0,
   });
 
   const GivtGroup.empty()
@@ -17,7 +18,8 @@ class GivtGroup extends Equatable {
         organisationName = '',
         status = 0,
         amount = 0,
-        isGiftAidEnabled = false;
+        isGiftAidEnabled = false,
+        taxYear = 0;
 
   final List<Givt> givts;
   final DateTime? timeStamp;
@@ -25,6 +27,7 @@ class GivtGroup extends Equatable {
   final int status;
   final double amount;
   final bool isGiftAidEnabled;
+  final int taxYear;
 
   GivtGroup copyWith({
     List<Givt>? givts,
@@ -33,6 +36,7 @@ class GivtGroup extends Equatable {
     int? status,
     double? amount,
     bool? isGiftAidEnabled,
+    int? taxYear,
   }) {
     return GivtGroup(
       givts: givts ?? this.givts,
@@ -41,6 +45,7 @@ class GivtGroup extends Equatable {
       status: status ?? this.status,
       amount: amount ?? this.amount,
       isGiftAidEnabled: isGiftAidEnabled ?? this.isGiftAidEnabled,
+      taxYear: taxYear ?? this.taxYear,
     );
   }
 
@@ -52,5 +57,6 @@ class GivtGroup extends Equatable {
         status,
         amount,
         isGiftAidEnabled,
+        taxYear,
       ];
 }

--- a/lib/features/overview/pages/overview_page.dart
+++ b/lib/features/overview/pages/overview_page.dart
@@ -178,6 +178,7 @@ class _OverviewPageState extends State<OverviewPage> {
         itemCount: _getSectionCount(state),
         itemBuilder: (_, int index) {
           return StickyHeader(
+            
             key: Key(monthSections[index].timeStamp!.toString()),
             header: Column(
               children: [
@@ -186,14 +187,12 @@ class _OverviewPageState extends State<OverviewPage> {
                   child: _buildHeader(
                     context: context,
                     amount:
-                        state.givtAided[monthSections[index].timeStamp!.year] ??
+                        state.givtAided[monthSections[index].taxYear] ??
                             0,
                     country: user.country,
                     color: AppTheme.givtYellow,
                     giftAidTitle: locals.giftOverviewGiftAidBanner(
-                      "'${DateFormat('yy').format(
-                        monthSections[index].timeStamp!,
-                      )}",
+                      "'${monthSections[index].taxYear.toString().substring(2)}",
                     ),
                   ),
                 ),


### PR DESCRIPTION
<img width="397" alt="image" src="https://github.com/givtnl/givt-app/assets/13018117/ecb22aa6-ed06-447b-9ec6-b2dc6cda5992">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `taxYear` property to enhance tracking and management of tax-related data.

- **Improvements**
  - Updated logic in the overview page to utilize `taxYear` for better accuracy in displaying gift aid information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->