### PR TITLE
fix: Make add member form  counter nullable (kids-858)

### DIFF
--- a/lib/features/children/add_member/widgets/add_member_form.dart
+++ b/lib/features/children/add_member/widgets/add_member_form.dart
@@ -340,6 +340,7 @@ class _AddMemberFormState extends State<AddMemberForm> {
           AllowanceCounter(
             currency: currency,
             initialAllowance: 5,
+            isAmountNullable: true,
             onAllowanceChanged: (allowance) => _allowance = allowance,
           ),
         ],

--- a/lib/features/children/add_member/widgets/add_member_form.dart
+++ b/lib/features/children/add_member/widgets/add_member_form.dart
@@ -340,7 +340,7 @@ class _AddMemberFormState extends State<AddMemberForm> {
           AllowanceCounter(
             currency: currency,
             initialAllowance: 5,
-            isAmountNullable: true,
+            canAmountBeZero: true,
             onAllowanceChanged: (allowance) => _allowance = allowance,
           ),
         ],

--- a/lib/features/children/add_member/widgets/allowance_counter.dart
+++ b/lib/features/children/add_member/widgets/allowance_counter.dart
@@ -10,12 +10,14 @@ class AllowanceCounter extends StatefulWidget {
     required this.currency,
     this.initialAllowance,
     this.onAllowanceChanged,
+    this.isAmountNullable = false,
     super.key,
   });
 
   final String? currency;
   final int? initialAllowance;
   final void Function(int allowance)? onAllowanceChanged;
+  final bool isAmountNullable;
 
   @override
   State<AllowanceCounter> createState() => _AllowanceCounterState();
@@ -26,7 +28,7 @@ class _AllowanceCounterState extends State<AllowanceCounter> {
   static const int holdDownDuration = 1000;
   static const int holdDownDuration2 = 2000;
   static const int maxAllowance = 999;
-  static const int minAllowance = 1;
+  static late int minAllowance;
   static const int allowanceIncrement = 5;
   static const int allowanceIncrement2 = 10;
 
@@ -37,6 +39,7 @@ class _AllowanceCounterState extends State<AllowanceCounter> {
   @override
   void initState() {
     super.initState();
+    minAllowance = widget.isAmountNullable ? 0 : 1;
     _allowance = widget.initialAllowance ?? 15;
   }
 
@@ -122,7 +125,7 @@ class _AllowanceCounterState extends State<AllowanceCounter> {
             _stopTimer();
           },
           onTapCancel: _stopTimer,
-          onTap: (_allowance < 2) ? null : _decrementCounter,
+          onTap: (_allowance < minAllowance + 1) ? null : _decrementCounter,
           child: SizedBox(
             width: 32,
             height: 32,

--- a/lib/features/children/add_member/widgets/allowance_counter.dart
+++ b/lib/features/children/add_member/widgets/allowance_counter.dart
@@ -10,14 +10,14 @@ class AllowanceCounter extends StatefulWidget {
     required this.currency,
     this.initialAllowance,
     this.onAllowanceChanged,
-    this.isAmountNullable = false,
+    this.canAmountBeZero = false,
     super.key,
   });
 
   final String? currency;
   final int? initialAllowance;
   final void Function(int allowance)? onAllowanceChanged;
-  final bool isAmountNullable;
+  final bool canAmountBeZero;
 
   @override
   State<AllowanceCounter> createState() => _AllowanceCounterState();
@@ -39,7 +39,7 @@ class _AllowanceCounterState extends State<AllowanceCounter> {
   @override
   void initState() {
     super.initState();
-    minAllowance = widget.isAmountNullable ? 0 : 1;
+    minAllowance = widget.canAmountBeZero ? 0 : 1;
     _allowance = widget.initialAllowance ?? 15;
   }
 
@@ -125,7 +125,7 @@ class _AllowanceCounterState extends State<AllowanceCounter> {
             _stopTimer();
           },
           onTapCancel: _stopTimer,
-          onTap: (_allowance < minAllowance + 1) ? null : _decrementCounter,
+          onTap: (_allowance <= minAllowance) ? null : _decrementCounter,
           child: SizedBox(
             width: 32,
             height: 32,


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced `AllowanceCounter` widget to support nullable amounts and zero values in the add member form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->