### PR TITLE
Fix: camera permission setup (kids-1123)

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -37,5 +37,17 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    # Start of the permission_handler configuration
+    target.build_configurations.each do |config|
+
+      #  Preprocessor definitions can be found at: https://github.com/Baseflow/flutter-permission-handler/blob/master/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+        '$(inherited)',
+
+        # dart: PermissionGroup.camera
+        'PERMISSION_CAMERA=1',
+      ]
+
+    end
   end
 end


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated iOS configuration to handle camera permissions using `permission_handler`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->