### PR TITLE
Fix: Replace success page with profile overview (kids-1142)

### DIFF
--- a/lib/features/registration/pages/registration_success_us.dart
+++ b/lib/features/registration/pages/registration_success_us.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:givt_app/app/routes/pages.dart';
 import 'package:givt_app/features/family/app/family_pages.dart';
 import 'package:givt_app/features/registration/widgets/registered_check_animation.dart';
 import 'package:givt_app/l10n/l10n.dart';
@@ -44,7 +43,9 @@ class RegistrationSuccessUs extends StatelessWidget {
                   const Spacer(),
                   CustomGreenElevatedButton(
                     title: context.l10n.setUpFamily,
-                    onPressed: () => context.pushNamed(FamilyPages.addMember.name),
+                    onPressed: () => context
+                      ..pushReplacementNamed(FamilyPages.addMember.name)
+                      ..pushNamed(FamilyPages.addMember.name),
                   ),
                   const SizedBox(height: 10),
                 ],


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
When user clicks set up family on registration success screen that screen should be replaced with profiles overview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved navigation behavior on the registration success screen to enhance user experience by replacing the current route before pushing a new one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->