### PR TITLE
Fix: Set user id in Amplitude when new/temp user signs up (kids-444)

### DIFF
--- a/lib/features/auth/cubit/auth_cubit.dart
+++ b/lib/features/auth/cubit/auth_cubit.dart
@@ -54,6 +54,17 @@ class AuthCubit extends Cubit<AuthState> {
       );
 
       var userExt = await _authRepositoy.fetchUserExtension(session.userGUID);
+      if (password == TempUser.defaultPassword) {
+        await AnalyticsHelper.setUserProperties(userId: userExt.guid);
+        unawaited(
+          AnalyticsHelper.logEvent(
+            eventName: AmplitudeEvents.continueByEmailSignUpTempUserClicked,
+            eventProperties: {
+              'country': userExt.countryCode,
+            },
+          ),
+        );
+      }
 
       await LoggingInfo.instance.info('User logged in with $userExt');
 
@@ -222,14 +233,6 @@ class AuthCubit extends Cubit<AuthState> {
       // When this is a temp user, we skip the login page
       if (result.contains('temp')) {
         await login(email: email, password: TempUser.defaultPassword);
-        unawaited(
-          AnalyticsHelper.logEvent(
-            eventName: AmplitudeEvents.continueByEmailSignUpTempUserClicked,
-            eventProperties: {
-              'country': country.countryCode,
-            },
-          ),
-        );
         return;
       }
 
@@ -252,6 +255,9 @@ class AuthCubit extends Cubit<AuthState> {
         tempUser: tempUser,
         isTempUser: true,
       );
+
+      await AnalyticsHelper.setUserProperties(userId: unRegisteredUserExt.guid);
+
       unawaited(
         AnalyticsHelper.logEvent(
           eventName: AmplitudeEvents.continueByEmailSignUpNewUserCliked,
@@ -261,6 +267,7 @@ class AuthCubit extends Cubit<AuthState> {
           },
         ),
       );
+
       final newNotificationId = await _updateNotificationId(
         guid: unRegisteredUserExt.guid,
         currentNotificationId: unRegisteredUserExt.notificationId,

--- a/lib/features/auth/cubit/auth_cubit.dart
+++ b/lib/features/auth/cubit/auth_cubit.dart
@@ -60,7 +60,7 @@ class AuthCubit extends Cubit<AuthState> {
           AnalyticsHelper.logEvent(
             eventName: AmplitudeEvents.continueByEmailSignUpTempUserClicked,
             eventProperties: {
-              'country': userExt.countryCode,
+              'profile_country': userExt.countryCode,
             },
           ),
         );
@@ -263,7 +263,7 @@ class AuthCubit extends Cubit<AuthState> {
           eventName: AmplitudeEvents.continueByEmailSignUpNewUserCliked,
           eventProperties: {
             'id': unRegisteredUserExt.guid,
-            'country': country.countryCode,
+            'profile_country': country.countryCode,
           },
         ),
       );

--- a/lib/features/registration/pages/credit_card_details_page.dart
+++ b/lib/features/registration/pages/credit_card_details_page.dart
@@ -67,7 +67,7 @@ class CreditCardDetailsPage extends StatelessWidget {
                       AmplitudeEvents.registrationStripeSheetIncompleteClosed,
                   eventProperties: {
                     'id': user.guid,
-                    'country': user.country,
+                    'profile_country': user.country,
                   },
                 ),
               );
@@ -100,7 +100,7 @@ class CreditCardDetailsPage extends StatelessWidget {
         eventName: AmplitudeEvents.registrationStripeSheetFilled,
         eventProperties: {
           'id': user.guid,
-          'country': user.country,
+          'profile_country': user.country,
         },
       ),
     );

--- a/lib/features/registration/pages/signup_page.dart
+++ b/lib/features/registration/pages/signup_page.dart
@@ -160,7 +160,7 @@ class _SignUpPageState extends State<SignUpPage> {
         eventName: AmplitudeEvents.registrationFilledInPersonalInfoSheetFilled,
         eventProperties: {
           'id': context.read<AuthCubit>().state.user.guid,
-          'country': _selectedCountry.countryCode,
+          'profile_country': _selectedCountry.countryCode,
         },
       ),
     );


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced analytics tracking for temporary user actions.
  - Added user property setting for new user sign-ups.

- **Enhancements**
  - Improved sign-in flow with additional parameter support for better tracking and analytics.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->