### PR TITLE
Bugfix: Initial amount when adding a member (kids-1151)

### DIFF
--- a/lib/features/children/add_member/widgets/add_member_form.dart
+++ b/lib/features/children/add_member/widgets/add_member_form.dart
@@ -39,7 +39,7 @@ class _AddMemberFormState extends State<AddMemberForm> {
   final _emailParentController = TextEditingController();
   final _ageController = TextEditingController();
   bool isChildSelected = true;
-  int _allowance = 15;
+  int _allowance = 5;
   final formKeyChild = GlobalKey<FormState>();
   final formKeyParent = GlobalKey<FormState>();
   late final FocusNode _childNameFocusNode;
@@ -339,7 +339,7 @@ class _AddMemberFormState extends State<AddMemberForm> {
           ),
           AllowanceCounter(
             currency: currency,
-            initialAllowance: 5,
+            initialAllowance: _allowance,
             canAmountBeZero: true,
             onAllowanceChanged: (allowance) => _allowance = allowance,
           ),


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the initial allowance value in the Add Member Form to be dynamically set, enhancing flexibility and customization options for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->