### PR TITLE
Bug: handle missing nfc error cases (KIDS-916)

### DIFF
--- a/lib/features/family/features/scan_nfc/cubit/scan_nfc_cubit.dart
+++ b/lib/features/family/features/scan_nfc/cubit/scan_nfc_cubit.dart
@@ -136,7 +136,8 @@ class ScanNfcCubit extends Cubit<ScanNfcState> {
 
               if (mediumId.isEmpty) {
                 _handleException(
-                    Exception('NFC coin decoded error, medium ID is empty'));
+                  Exception('NFC coin decoded error, medium ID is empty'),
+                );
               } else {
                 emit(
                   state.copyWith(
@@ -147,6 +148,12 @@ class ScanNfcCubit extends Cubit<ScanNfcState> {
                 );
               }
             }
+          } else {
+            _handleException(
+              Exception(
+                'NFC could not be decoded error, probably not a Givt coin',
+              ),
+            );
           }
         },
       ));


### PR DESCRIPTION

## Description
<!--- Describe your changes -->
<img width="906" alt="Scherm­afbeelding 2024-07-10 om 11 42 07" src="https://github.com/givtnl/givt-app/assets/2879338/d0a45019-0e79-467e-9357-6331335e7bd3">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced NFC scanning functionality to handle errors when decoding NFC coins. This includes scenarios where the medium ID is empty or when the NFC cannot be decoded, ensuring better reliability and user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->