### PR TITLE
Hotfix: init fetch all profiles

### DIFF
--- a/lib/features/family/features/profiles/cubit/profiles_cubit.dart
+++ b/lib/features/family/features/profiles/cubit/profiles_cubit.dart
@@ -9,7 +9,6 @@ import 'package:givt_app/features/children/add_member/repository/add_member_repo
 import 'package:givt_app/features/family/features/profiles/models/profile.dart';
 import 'package:givt_app/features/family/features/profiles/repository/profiles_repository.dart';
 import 'package:givt_app/shared/models/user_ext.dart';
-import 'package:givt_app/utils/utils.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 
 part 'profiles_state.dart';

--- a/lib/features/family/features/profiles/screens/profile_selection_screen.dart
+++ b/lib/features/family/features/profiles/screens/profile_selection_screen.dart
@@ -38,6 +38,12 @@ class ProfileSelectionScreen extends StatefulWidget {
 
 class _ProfileSelectionScreenState extends State<ProfileSelectionScreen> {
   @override
+  void initState() {
+    super.initState();
+    context.read<ProfilesCubit>().fetchAllProfiles();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return BlocConsumer<ProfilesCubit, ProfilesState>(
       listener: (context, state) async {


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Profile selection screen now automatically fetches all profiles upon initialization.
- **Chores**
  - Removed unnecessary import statements to clean up dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->