### PR TITLE
Fix: camera nad gallery permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.NFC" />
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
     <queries>
         <!-- tel:<phone-number> -->

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -46,6 +46,8 @@ post_install do |installer|
 
         # dart: PermissionGroup.camera
         'PERMISSION_CAMERA=1',
+        ## dart: PermissionGroup.photos
+        'PERMISSION_PHOTOS=1'
       ]
 
     end

--- a/lib/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart
+++ b/lib/features/children/generosity_challenge/cubit/generosity_challenge_cubit.dart
@@ -205,7 +205,7 @@ class GenerosityChallengeCubit extends Cubit<GenerosityChallengeState> {
     }
   }
 
-  Future<void> submitDay5Picture({required bool takenWithCamera}) async {
+  Future<bool> submitDay5Picture({required bool takenWithCamera}) async {
     try {
       await _generosityChallengeRepository.submitDay5Picture(
         takenWithCamera: takenWithCamera,
@@ -213,9 +213,11 @@ class GenerosityChallengeCubit extends Cubit<GenerosityChallengeState> {
       confirmAssignment(
         "Nice! Let's send this to the Mayor.",
       );
+      return true;
     } on Exception catch (e) {
       unawaited(LoggingInfo.instance.error(e.toString()));
     }
+    return false;
   }
 
   Future<String> getDay5PicturePath() async {

--- a/lib/features/children/generosity_challenge/widgets/day5_picture_attachment_buttons.dart
+++ b/lib/features/children/generosity_challenge/widgets/day5_picture_attachment_buttons.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -44,30 +46,37 @@ class Day5PictureAttachmentButtons extends StatelessWidget {
           children: [
             const SizedBox(height: 8),
             GivtElevatedButton(
-              onTap: () {
-                context.read<CameraCubit>().checkCameraPermission();
-
-                cubit.submitDay5Picture(
+              onTap: () async {
+                final success = await cubit.submitDay5Picture(
                   takenWithCamera: true,
                 );
-                AnalyticsHelper.logEvent(
+                if (context.mounted && !success) {
+                  unawaited(
+                      context.read<CameraCubit>().checkCameraPermission());
+                }
+                unawaited(AnalyticsHelper.logEvent(
                   eventName:
                       AmplitudeEvents.generosityChallengeTakePictureClicked,
-                );
+                ));
               },
               leftIcon: FontAwesomeIcons.camera,
               text: 'Take Picture',
             ),
             const SizedBox(height: 8),
             GivtElevatedSecondaryButton(
-              onTap: () {
-                context.read<CameraCubit>().checkGalleryPermission();
-                AnalyticsHelper.logEvent(
-                  eventName:
-                      AmplitudeEvents.generosityChallengeUploadPictureClicked,
-                );
-                cubit.submitDay5Picture(
+              onTap: () async {
+                final success = await cubit.submitDay5Picture(
                   takenWithCamera: false,
+                );
+                if (context.mounted && !success) {
+                  unawaited(
+                      context.read<CameraCubit>().checkGalleryPermission());
+                }
+                unawaited(
+                  AnalyticsHelper.logEvent(
+                    eventName:
+                        AmplitudeEvents.generosityChallengeUploadPictureClicked,
+                  ),
                 );
               },
               leftIcon: const Icon(

--- a/lib/features/family/features/qr_scanner/cubit/camera_cubit.dart
+++ b/lib/features/family/features/qr_scanner/cubit/camera_cubit.dart
@@ -9,7 +9,12 @@ class CameraCubit extends Cubit<CameraState> {
 
   static const Duration _permissionDialogDelay = Duration(milliseconds: 300);
   Future<void> checkGalleryPermission() async {
-    emit(state.copyWith(galleryStatus: GalleryStatus.initial));
+    emit(
+      state.copyWith(
+        galleryStatus: GalleryStatus.initial,
+        status: CameraStatus.initial,
+      ),
+    );
     final status = await Permission.photos.status;
     //delay is from design
     await Future<void>.delayed(_permissionDialogDelay);
@@ -20,15 +25,23 @@ class CameraCubit extends Cubit<CameraState> {
     }
 
     if (status.isPermanentlyDenied) {
-      emit(state.copyWith(
-          galleryStatus: GalleryStatus.permissionPermanentlyDeclined));
+      emit(
+        state.copyWith(
+          galleryStatus: GalleryStatus.permissionPermanentlyDeclined,
+        ),
+      );
       return;
     }
     emit(state.copyWith(galleryStatus: GalleryStatus.permissionGranted));
   }
 
   Future<void> checkCameraPermission() async {
-    emit(state.copyWith(status: CameraStatus.initial));
+    emit(
+      state.copyWith(
+        status: CameraStatus.initial,
+        galleryStatus: GalleryStatus.initial,
+      ),
+    );
     final status = await Permission.camera.status;
     //delay is from design
     await Future<void>.delayed(_permissionDialogDelay);

--- a/lib/features/family/features/qr_scanner/cubit/camera_cubit.dart
+++ b/lib/features/family/features/qr_scanner/cubit/camera_cubit.dart
@@ -9,12 +9,7 @@ class CameraCubit extends Cubit<CameraState> {
 
   static const Duration _permissionDialogDelay = Duration(milliseconds: 300);
   Future<void> checkGalleryPermission() async {
-    emit(
-      state.copyWith(
-        galleryStatus: GalleryStatus.initial,
-        status: CameraStatus.initial,
-      ),
-    );
+    resetPermssionStatuses();
     final status = await Permission.photos.status;
     //delay is from design
     await Future<void>.delayed(_permissionDialogDelay);
@@ -36,12 +31,7 @@ class CameraCubit extends Cubit<CameraState> {
   }
 
   Future<void> checkCameraPermission() async {
-    emit(
-      state.copyWith(
-        status: CameraStatus.initial,
-        galleryStatus: GalleryStatus.initial,
-      ),
-    );
+    resetPermssionStatuses();
     final status = await Permission.camera.status;
     //delay is from design
     await Future<void>.delayed(_permissionDialogDelay);
@@ -91,6 +81,15 @@ class CameraCubit extends Cubit<CameraState> {
     }
     emit(
       state.copyWith(status: CameraStatus.error, feedback: 'Invalid QR Code'),
+    );
+  }
+
+  void resetPermssionStatuses() {
+    emit(
+      state.copyWith(
+        status: CameraStatus.initial,
+        galleryStatus: GalleryStatus.initial,
+      ),
     );
   }
 }

--- a/lib/features/family/features/qr_scanner/cubit/camera_cubit.dart
+++ b/lib/features/family/features/qr_scanner/cubit/camera_cubit.dart
@@ -9,7 +9,7 @@ class CameraCubit extends Cubit<CameraState> {
 
   static const Duration _permissionDialogDelay = Duration(milliseconds: 300);
   Future<void> checkGalleryPermission() async {
-    resetPermssionStatuses();
+    resetPermissionStatuses();
     final status = await Permission.photos.status;
     //delay is from design
     await Future<void>.delayed(_permissionDialogDelay);
@@ -31,7 +31,7 @@ class CameraCubit extends Cubit<CameraState> {
   }
 
   Future<void> checkCameraPermission() async {
-    resetPermssionStatuses();
+    resetPermissionStatuses();
     final status = await Permission.camera.status;
     //delay is from design
     await Future<void>.delayed(_permissionDialogDelay);
@@ -84,7 +84,7 @@ class CameraCubit extends Cubit<CameraState> {
     );
   }
 
-  void resetPermssionStatuses() {
+  void resetPermissionStatuses() {
     emit(
       state.copyWith(
         status: CameraStatus.initial,


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
- Proper set up in podfile & manifest
- Check permissions only if submitting picture fails
- Clear both permission statuses between checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added camera and photo access permissions for both Android and iOS platforms.
  
- **Enhancements**
  - Improved the submission process for Day 5 pictures in the Generosity Challenge, providing better feedback on success or failure.
  - Enhanced QR Scanner functionality with improved permission handling for camera and gallery access.

- **Bug Fixes**
  - Fixed issues related to permission statuses not resetting correctly in the QR Scanner feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->