### PR TITLE
Feature: retrieve admin fee from api (KIDS-1164)

### DIFF
--- a/lib/app/injection/injection.dart
+++ b/lib/app/injection/injection.dart
@@ -25,6 +25,7 @@ import 'package:givt_app/features/children/generosity_challenge_chat/chat_script
 import 'package:givt_app/features/children/generosity_challenge_chat/chat_scripts/utils/chat_script_registration_handler.dart';
 import 'package:givt_app/features/children/overview/repositories/family_overview_repository.dart';
 import 'package:givt_app/features/children/parental_approval/repositories/parental_approval_repository.dart';
+import 'package:givt_app/features/family/features/admin_fee/repositories/admin_fee_repository.dart';
 import 'package:givt_app/features/family/features/avatars/repositories/avatars_repository.dart';
 import 'package:givt_app/features/give/repositories/beacon_repository.dart';
 import 'package:givt_app/features/give/repositories/campaign_repository.dart';

--- a/lib/app/injection/injection.dart
+++ b/lib/app/injection/injection.dart
@@ -25,7 +25,6 @@ import 'package:givt_app/features/children/generosity_challenge_chat/chat_script
 import 'package:givt_app/features/children/generosity_challenge_chat/chat_scripts/utils/chat_script_registration_handler.dart';
 import 'package:givt_app/features/children/overview/repositories/family_overview_repository.dart';
 import 'package:givt_app/features/children/parental_approval/repositories/parental_approval_repository.dart';
-import 'package:givt_app/features/family/features/admin_fee/repositories/admin_fee_repository.dart';
 import 'package:givt_app/features/family/features/avatars/repositories/avatars_repository.dart';
 import 'package:givt_app/features/give/repositories/beacon_repository.dart';
 import 'package:givt_app/features/give/repositories/campaign_repository.dart';

--- a/lib/features/children/add_member/widgets/add_member_form.dart
+++ b/lib/features/children/add_member/widgets/add_member_form.dart
@@ -12,6 +12,7 @@ import 'package:givt_app/features/children/add_member/utils/member_utils.dart';
 import 'package:givt_app/features/children/add_member/widgets/allowance_counter.dart';
 import 'package:givt_app/features/children/add_member/widgets/family_text_form_field.dart';
 import 'package:givt_app/features/children/shared/profile_type.dart';
+import 'package:givt_app/features/family/features/admin_fee/presentation/widgets/admin_fee_text.dart';
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/utils/utils.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -341,7 +342,17 @@ class _AddMemberFormState extends State<AddMemberForm> {
             currency: currency,
             initialAllowance: _allowance,
             canAmountBeZero: true,
-            onAllowanceChanged: (allowance) => _allowance = allowance,
+            onAllowanceChanged: (allowance) => setState(() {
+              _allowance = allowance;
+            }),
+          ),
+          const SizedBox(height: 16),
+          AdminFeeText(
+            amount: _allowance.toDouble(),
+            textStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
+              fontWeight: FontWeight.w700,
+              fontSize: 15,
+            ),
           ),
         ],
       ),

--- a/lib/features/children/details/pages/child_details_page.dart
+++ b/lib/features/children/details/pages/child_details_page.dart
@@ -254,7 +254,6 @@ class ChildDetailsPage extends StatelessWidget {
     final dynamic result = await Navigator.push(
       context,
       EditAllowancePage(
-        fee: 0.65,
         currency: r'$',
         initialAllowance: currentAllowance,
         onCancel: () => context.read<ChildDetailsCubit>().cancelAllowance(),

--- a/lib/features/children/generosity_challenge/assignments/set_up_allowance/generosity_allowance_flow_page.dart
+++ b/lib/features/children/generosity_challenge/assignments/set_up_allowance/generosity_allowance_flow_page.dart
@@ -31,7 +31,6 @@ class GenerosityAllowanceFlowPage extends StatelessWidget {
     final dynamic result = await Navigator.push(
       context,
       EditAllowancePage(
-        fee: 0.65,
         extraHeader: _allowancesHeader(context),
         currency: r'$',
         isMultipleChildren: nrOfChildren > 1,

--- a/lib/features/children/overview/pages/edit_allowance_page.dart
+++ b/lib/features/children/overview/pages/edit_allowance_page.dart
@@ -106,8 +106,6 @@ class _EditAllowancePageState extends State<EditAllowancePage> {
                     children: [
                       AdminFeeText(
                         amount: _allowance.toDouble(),
-                        textStyle: theme.textTheme.bodySmall!
-                            .copyWith(fontWeight: FontWeight.w700),
                       ),
                       const SizedBox(height: 4),
                       GivtElevatedButton(

--- a/lib/features/children/overview/pages/edit_allowance_page.dart
+++ b/lib/features/children/overview/pages/edit_allowance_page.dart
@@ -106,6 +106,8 @@ class _EditAllowancePageState extends State<EditAllowancePage> {
                     children: [
                       AdminFeeText(
                         amount: _allowance.toDouble(),
+                        isMonthly: true,
+                        isMultipleChildren: widget.isMultipleChildren,
                       ),
                       const SizedBox(height: 4),
                       GivtElevatedButton(

--- a/lib/features/children/overview/pages/edit_allowance_page.dart
+++ b/lib/features/children/overview/pages/edit_allowance_page.dart
@@ -4,6 +4,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:givt_app/features/children/add_member/widgets/allowance_counter.dart';
 import 'package:givt_app/features/children/generosity_challenge/widgets/generosity_back_button.dart';
 import 'package:givt_app/features/children/overview/widgets/cancel_allowance_dialog.dart';
+import 'package:givt_app/features/family/features/admin_fee/presentation/widgets/admin_fee_text.dart';
 import 'package:givt_app/features/family/shared/widgets/layout/top_app_bar.dart';
 import 'package:givt_app/features/family/utils/family_app_theme.dart';
 import 'package:givt_app/l10n/l10n.dart';
@@ -18,12 +19,10 @@ class EditAllowancePage extends StatefulWidget {
     this.initialAllowance,
     this.extraHeader,
     this.isMultipleChildren = false,
-    this.fee = 0.65,
     super.key,
   });
 
   final String currency;
-  final double fee;
   final int? initialAllowance;
   final Widget? extraHeader;
   final bool isMultipleChildren;
@@ -49,7 +48,6 @@ class _EditAllowancePageState extends State<EditAllowancePage> {
   Widget build(BuildContext context) {
     final child =
         widget.isMultipleChildren ? 'each of your children' : 'your child';
-    final perchild = widget.isMultipleChildren ? ' per child' : '';
     final theme = FamilyAppTheme().toThemeData();
     return Scaffold(
       appBar: const TopAppBar(
@@ -106,13 +104,10 @@ class _EditAllowancePageState extends State<EditAllowancePage> {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      Visibility(
-                        visible: false,
-                        child: Text(
-                          'Admin fee of ${widget.fee.toStringAsFixed(2)} applies$perchild monthly',
-                          style: theme.textTheme.bodySmall!
-                              .copyWith(fontWeight: FontWeight.w700),
-                        ),
+                      AdminFeeText(
+                        amount: _allowance.toDouble(),
+                        textStyle: theme.textTheme.bodySmall!
+                            .copyWith(fontWeight: FontWeight.w700),
                       ),
                       const SizedBox(height: 4),
                       GivtElevatedButton(

--- a/lib/features/family/app/injection.dart
+++ b/lib/features/family/app/injection.dart
@@ -1,5 +1,6 @@
 import 'package:get_it/get_it.dart';
 import 'package:givt_app/core/network/request_helper.dart';
+import 'package:givt_app/features/family/features/admin_fee/repositories/admin_fee_repository.dart';
 import 'package:givt_app/features/family/features/avatars/repositories/avatars_repository.dart';
 import 'package:givt_app/features/family/features/edit_profile/repositories/edit_profile_repository.dart';
 import 'package:givt_app/features/family/features/giving_flow/create_transaction/repositories/create_transaction_repository.dart';
@@ -30,6 +31,11 @@ Future<void> initAPIService() async {
 
 void initRepositories() {
   getIt
+    ..registerSingleton<AdminFeeRepository>(
+      AdminFeeRepository(
+        getIt(),
+      ),
+    )
     ..registerLazySingleton<ProfilesRepository>(
       () => ProfilesRepositoryImpl(
         getIt(),

--- a/lib/features/family/features/admin_fee/models/admin_fee.dart
+++ b/lib/features/family/features/admin_fee/models/admin_fee.dart
@@ -1,0 +1,27 @@
+class AdminFee {
+  const AdminFee({
+    required this.startAmount,
+    required this.amountPerExtraDollar,
+    required this.maxAmount,
+  });
+
+  factory AdminFee.fromMap(Map<String, dynamic> map) {
+    return AdminFee(
+      startAmount: map['startAmount'] as double,
+      amountPerExtraDollar: map['amountPerExtraDollar'] as double,
+      maxAmount: map['maxAmount'] as double,
+    );
+  }
+
+  factory AdminFee.initial() {
+    return const AdminFee(
+      startAmount: 0.30,
+      amountPerExtraDollar: 0.08,
+      maxAmount: 1,
+    );
+  }
+
+  final double startAmount;
+  final double amountPerExtraDollar;
+  final double maxAmount;
+}

--- a/lib/features/family/features/admin_fee/presentation/widgets/admin_fee_text.dart
+++ b/lib/features/family/features/admin_fee/presentation/widgets/admin_fee_text.dart
@@ -31,8 +31,8 @@ class _AdminFeeTextState extends State<AdminFeeText> {
     final perchild = widget.isMultipleChildren ? ' per child' : '';
     final fee =
         _adminFeeRepository.getTotalFee(widget.amount).toStringAsFixed(2);
-    final nonMonthlyText = 'Admin fee of $fee applies$perchild monthly';
-    final monthlyText = 'An admin fee of $fee will be added';
+    final nonMonthlyText = 'Admin fee of \$$fee applies$perchild monthly';
+    final monthlyText = 'An admin fee of \$$fee will be added';
     return Text(
       widget.isMonthly ? monthlyText : nonMonthlyText,
       style: widget.textStyle ??

--- a/lib/features/family/features/admin_fee/presentation/widgets/admin_fee_text.dart
+++ b/lib/features/family/features/admin_fee/presentation/widgets/admin_fee_text.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/app/injection/injection.dart';
+import 'package:givt_app/features/family/features/admin_fee/repositories/admin_fee_repository.dart';
+
+class AdminFeeText extends StatefulWidget {
+  const AdminFeeText({
+    required this.amount,
+    super.key,
+    this.theme,
+    this.isMonthly = false,
+    this.isMultipleChildren = false,
+    this.textStyle,
+  });
+
+  final ThemeData? theme;
+  final TextStyle? textStyle;
+  final double amount;
+  final bool isMonthly;
+  final bool isMultipleChildren;
+
+  @override
+  State<AdminFeeText> createState() => _AdminFeeTextState();
+}
+
+class _AdminFeeTextState extends State<AdminFeeText> {
+  final AdminFeeRepository _adminFeeRepository = getIt<AdminFeeRepository>();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = widget.theme ?? Theme.of(context);
+    final perchild = widget.isMultipleChildren ? ' per child' : '';
+    final fee =
+        _adminFeeRepository.getTotalFee(widget.amount).toStringAsFixed(2);
+    final nonMonthlyText = 'Admin fee of $fee applies$perchild monthly';
+    final monthlyText = 'An admin fee of $fee will be added';
+    return Text(
+      widget.isMonthly ? monthlyText : nonMonthlyText,
+      style: widget.textStyle ??
+          theme.textTheme.bodySmall!.copyWith(fontWeight: FontWeight.w700),
+    );
+  }
+}

--- a/lib/features/family/features/admin_fee/presentation/widgets/admin_fee_text.dart
+++ b/lib/features/family/features/admin_fee/presentation/widgets/admin_fee_text.dart
@@ -31,8 +31,8 @@ class _AdminFeeTextState extends State<AdminFeeText> {
     final perchild = widget.isMultipleChildren ? ' per child' : '';
     final fee =
         _adminFeeRepository.getTotalFee(widget.amount).toStringAsFixed(2);
-    final nonMonthlyText = 'Admin fee of \$$fee applies$perchild monthly';
-    final monthlyText = 'An admin fee of \$$fee will be added';
+    final monthlyText = 'Admin fee of \$$fee applies$perchild monthly';
+    final nonMonthlyText = 'An admin fee of \$$fee will be added';
     return Text(
       widget.isMonthly ? monthlyText : nonMonthlyText,
       style: widget.textStyle ??

--- a/lib/features/family/features/admin_fee/repositories/admin_fee_repository.dart
+++ b/lib/features/family/features/admin_fee/repositories/admin_fee_repository.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:givt_app/core/logging/logging.dart';
+import 'package:givt_app/features/family/features/admin_fee/models/admin_fee.dart';
+import 'package:givt_app/features/family/network/api_service.dart';
+
+class AdminFeeRepository {
+  AdminFeeRepository(this._familyAPIService) {
+    fetchAdminFee();
+  }
+
+  final FamilyAPIService _familyAPIService;
+  AdminFee? _adminFee;
+
+  AdminFee get adminFee => _adminFee ?? AdminFee.initial();
+
+  Future<void> fetchAdminFee() async {
+    try {
+      final response = await _familyAPIService.fetchAdminFee();
+      _adminFee = AdminFee.fromMap(response);
+    } catch (e, s) {
+      _adminFee = AdminFee.initial();
+      unawaited(
+        LoggingInfo.instance.warning(
+          'Failed to fetch admin fee: $e\n\n$s',
+        ),
+      );
+    }
+  }
+
+  double getTotalFee(double amount) {
+    final extraAmount =
+        amount > 1 ? (amount - 1) * adminFee.amountPerExtraDollar : 0;
+    final total = extraAmount + adminFee.startAmount;
+    return total > adminFee.maxAmount ? adminFee.maxAmount : total;
+  }
+}

--- a/lib/features/family/network/api_service.dart
+++ b/lib/features/family/network/api_service.dart
@@ -31,6 +31,21 @@ class FamilyAPIService {
     }
   }
 
+  Future<Map<String, dynamic>> fetchAdminFee() async {
+    final url = Uri.https(_apiURL, '/givtservice/v1/config/adminfee');
+    final response = await client.get(url);
+
+    if (response.statusCode >= 400) {
+      throw GivtServerFailure(
+        statusCode: response.statusCode,
+        body: jsonDecode(response.body) as Map<String, dynamic>,
+      );
+    } else {
+      final decodedBody = jsonDecode(response.body) as Map<String, dynamic>;
+      return decodedBody['item'] as Map<String, dynamic>;
+    }
+  }
+
   Future<Map<String, dynamic>> fetchChildDetails(String childGuid) async {
     final url = Uri.https(_apiURL, '/givtservice/v1/profiles/$childGuid');
 


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
https://linear.app/givt/issue/KIDS-1164/add-admin-fee-text-during-registration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `AdminFeeText` widget to display admin fee details dynamically.
  
- **Enhancements**
  - Improved allowance update functionality with the new `AdminFeeText` widget.
  - Enhanced the `EditAllowancePage` with updated admin fee display logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->