### PR TITLE
Bug: fix nfc error back home broken gen challenge (KIDS-1214)

### DIFF
--- a/lib/features/children/generosity_challenge/pages/generosity_challenge_overview.dart
+++ b/lib/features/children/generosity_challenge/pages/generosity_challenge_overview.dart
@@ -15,7 +15,6 @@ import 'package:givt_app/shared/widgets/buttons/givt_elevated_button.dart';
 import 'package:givt_app/shared/widgets/common_icons.dart';
 import 'package:givt_app/utils/utils.dart';
 import 'package:go_router/go_router.dart';
-import 'dart:io' show Platform;
 
 class GenerosityChallengeOverview extends StatefulWidget {
   const GenerosityChallengeOverview({
@@ -117,6 +116,7 @@ class _GenerosityChallengeOverviewState
         actions: const [ChatIconButton()],
       ),
       body: SafeArea(
+        minimum: const EdgeInsets.only(bottom: 16),
         child: Stack(
           children: [
             if (arePersonalDetailsAvailable)
@@ -218,10 +218,6 @@ class _GenerosityChallengeOverviewState
                   leadingImage: coin(width: 32, height: 32),
                   text: 'Give with a coin',
                 ),
-                if (Platform.isAndroid)
-                  const SizedBox(
-                    height: 16,
-                  ),
               ],
             ),
           ],

--- a/lib/features/children/generosity_challenge/pages/generosity_challenge_overview.dart
+++ b/lib/features/children/generosity_challenge/pages/generosity_challenge_overview.dart
@@ -21,7 +21,9 @@ class GenerosityChallengeOverview extends StatefulWidget {
     required this.isDebug,
     super.key,
   });
+
   final bool isDebug;
+
   @override
   State<GenerosityChallengeOverview> createState() =>
       _GenerosityChallengeOverviewState();
@@ -202,7 +204,12 @@ class _GenerosityChallengeOverviewState
                 GivtElevatedButton(
                   onTap: () {
                     context.read<FlowsCubit>().startInGenerosityCoinFlow();
-                    context.pushNamed(FamilyPages.scanNFC.name);
+                    context.pushNamed(
+                      FamilyPages.scanNFC.name,
+                      extra: {
+                        'isGenerosityChallenge': true,
+                      },
+                    );
                     AnalyticsHelper.logEvent(
                       eventName: AmplitudeEvents.giveWithCoinInChallengeClicked,
                     );

--- a/lib/features/children/generosity_challenge/pages/generosity_challenge_overview.dart
+++ b/lib/features/children/generosity_challenge/pages/generosity_challenge_overview.dart
@@ -15,6 +15,7 @@ import 'package:givt_app/shared/widgets/buttons/givt_elevated_button.dart';
 import 'package:givt_app/shared/widgets/common_icons.dart';
 import 'package:givt_app/utils/utils.dart';
 import 'package:go_router/go_router.dart';
+import 'dart:io' show Platform;
 
 class GenerosityChallengeOverview extends StatefulWidget {
   const GenerosityChallengeOverview({
@@ -217,6 +218,10 @@ class _GenerosityChallengeOverviewState
                   leadingImage: coin(width: 32, height: 32),
                   text: 'Give with a coin',
                 ),
+                if (Platform.isAndroid)
+                  const SizedBox(
+                    height: 16,
+                  ),
               ],
             ),
           ],

--- a/lib/features/family/app/family_routes.dart
+++ b/lib/features/family/app/family_routes.dart
@@ -298,10 +298,10 @@ class FamilyAppRoutes {
               name: FamilyPages.scanNFC.name,
               builder: (context, state) {
                 final extra = state.extra as Map<String, dynamic>?;
-                final shouldErrorPopBack =
+                final isFromGenerosityChallenge =
                     extra?['isGenerosityChallenge'] as bool? ?? false;
                 return NFCScanPage(
-                  shouldErrorPopBack: shouldErrorPopBack,
+                  isFromGenerosityChallenge: isFromGenerosityChallenge,
                 );
               },
             ),

--- a/lib/features/family/app/family_routes.dart
+++ b/lib/features/family/app/family_routes.dart
@@ -297,7 +297,12 @@ class FamilyAppRoutes {
               path: FamilyPages.scanNFC.path,
               name: FamilyPages.scanNFC.name,
               builder: (context, state) {
-                return const NFCScanPage();
+                final extra = state.extra as Map<String, dynamic>?;
+                final shouldErrorPopBack =
+                    extra?['isGenerosityChallenge'] as bool? ?? false;
+                return NFCScanPage(
+                  shouldErrorPopBack: shouldErrorPopBack,
+                );
               },
             ),
             GoRoute(

--- a/lib/features/family/features/scan_nfc/nfc_scan_screen.dart
+++ b/lib/features/family/features/scan_nfc/nfc_scan_screen.dart
@@ -28,10 +28,10 @@ import 'package:go_router/go_router.dart';
 class NFCScanPage extends StatefulWidget {
   const NFCScanPage({
     super.key,
-    this.shouldErrorPopBack = false,
+    this.isFromGenerosityChallenge = false,
   });
 
-  final bool shouldErrorPopBack;
+  final bool isFromGenerosityChallenge;
 
   @override
   State<NFCScanPage> createState() => _NFCScanPageState();
@@ -228,8 +228,8 @@ class _NFCScanPageState extends State<NFCScanPage> {
       onClickPrimaryBtn: () async =>
           _handleNotAGivtCoinTryAgainClicked(context),
       onClickSecondaryBtn: () {
-        if (widget.shouldErrorPopBack) {
-          context.pop();
+        if (widget.isFromGenerosityChallenge) {
+          context.goNamed(FamilyPages.generosityChallenge.name);
         } else {
           context.goNamed(FamilyPages.wallet.name);
         }
@@ -272,8 +272,8 @@ class _NFCScanPageState extends State<NFCScanPage> {
       onClickPrimaryBtn: () async =>
           _handleGenericErrorTryAgainClicked(context),
       onClickSecondaryBtn: () {
-        if (widget.shouldErrorPopBack) {
-          context.pop();
+        if (widget.isFromGenerosityChallenge) {
+          context.goNamed(FamilyPages.generosityChallenge.name);
         } else {
           context.goNamed(FamilyPages.wallet.name);
         }

--- a/lib/features/family/features/scan_nfc/nfc_scan_screen.dart
+++ b/lib/features/family/features/scan_nfc/nfc_scan_screen.dart
@@ -28,7 +28,10 @@ import 'package:go_router/go_router.dart';
 class NFCScanPage extends StatefulWidget {
   const NFCScanPage({
     super.key,
+    this.shouldErrorPopBack = false,
   });
+
+  final bool shouldErrorPopBack;
 
   @override
   State<NFCScanPage> createState() => _NFCScanPageState();
@@ -225,10 +228,16 @@ class _NFCScanPageState extends State<NFCScanPage> {
       onClickPrimaryBtn: () async =>
           _handleNotAGivtCoinTryAgainClicked(context),
       onClickSecondaryBtn: () {
-        context.goNamed(FamilyPages.wallet.name);
-        unawaited(AnalyticsHelper.logEvent(
-          eventName: AmplitudeEvents.notAGivtCoinNFCErrorGoBackHomeClicked,
-        ));
+        if (widget.shouldErrorPopBack) {
+          context.pop();
+        } else {
+          context.goNamed(FamilyPages.wallet.name);
+        }
+        unawaited(
+          AnalyticsHelper.logEvent(
+            eventName: AmplitudeEvents.notAGivtCoinNFCErrorGoBackHomeClicked,
+          ),
+        );
       },
       icon: FontAwesomeIcons.question,
       secondaryBtnText: 'Go back home',
@@ -263,13 +272,17 @@ class _NFCScanPageState extends State<NFCScanPage> {
       onClickPrimaryBtn: () async =>
           _handleGenericErrorTryAgainClicked(context),
       onClickSecondaryBtn: () {
+        if (widget.shouldErrorPopBack) {
+          context.pop();
+        } else {
+          context.goNamed(FamilyPages.wallet.name);
+        }
         unawaited(
           AnalyticsHelper.logEvent(
             eventName:
                 AmplitudeEvents.coinMediumIdNotRecognizedGoBackHomeClicked,
           ),
         );
-        context.goNamed(FamilyPages.wallet.name);
       },
       secondaryBtnText: 'Go back home',
       primaryBtnText: 'Try again',

--- a/lib/features/family/features/scan_nfc/nfc_scan_screen.dart
+++ b/lib/features/family/features/scan_nfc/nfc_scan_screen.dart
@@ -228,11 +228,7 @@ class _NFCScanPageState extends State<NFCScanPage> {
       onClickPrimaryBtn: () async =>
           _handleNotAGivtCoinTryAgainClicked(context),
       onClickSecondaryBtn: () {
-        if (widget.isFromGenerosityChallenge) {
-          context.goNamed(FamilyPages.generosityChallenge.name);
-        } else {
-          context.goNamed(FamilyPages.wallet.name);
-        }
+        _navigateToHome(context);
         unawaited(
           AnalyticsHelper.logEvent(
             eventName: AmplitudeEvents.notAGivtCoinNFCErrorGoBackHomeClicked,
@@ -248,6 +244,14 @@ class _NFCScanPageState extends State<NFCScanPage> {
     unawaited(AnalyticsHelper.logEvent(
       eventName: AmplitudeEvents.notAGivtCoinNFCError,
     ));
+  }
+
+  void _navigateToHome(BuildContext context) {
+    if (widget.isFromGenerosityChallenge) {
+      context.goNamed(FamilyPages.generosityChallenge.name);
+    } else {
+      context.goNamed(FamilyPages.wallet.name);
+    }
   }
 
   void _handleNotAGivtCoinTryAgainClicked(BuildContext context) {
@@ -272,11 +276,7 @@ class _NFCScanPageState extends State<NFCScanPage> {
       onClickPrimaryBtn: () async =>
           _handleGenericErrorTryAgainClicked(context),
       onClickSecondaryBtn: () {
-        if (widget.isFromGenerosityChallenge) {
-          context.goNamed(FamilyPages.generosityChallenge.name);
-        } else {
-          context.goNamed(FamilyPages.wallet.name);
-        }
+        _navigateToHome(context);
         unawaited(
           AnalyticsHelper.logEvent(
             eventName:


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
https://linear.app/givt/issue/KIDS-1214/in-app-scanning-coin-when-you-use-go-back-home-on-error-popup-it-sends

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced NFC scan functionality to support the generosity challenge.
  - Added a debug mode option to the Generosity Challenge overview for improved testing.

- **Refactor**
  - Updated navigation logic to pass additional data for better contextual handling.
  - Improved button click handling in the NFC scan feature to conditionally navigate based on user context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->