### PR TITLE
Fix not being able to press profiles when first names are too long.

### DIFF
--- a/lib/features/family/features/profiles/widgets/profile_item.dart
+++ b/lib/features/family/features/profiles/widgets/profile_item.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:givt_app/utils/utils.dart';
@@ -27,15 +28,17 @@ class ProfileItem extends StatelessWidget {
             height: imgSize,
           ),
           const SizedBox(height: 12),
-          Text(
-            name,
-            textAlign: TextAlign.center,
-            overflow: TextOverflow.ellipsis,
-            maxLines: 1,
-            style: Theme.of(context)
-                .textTheme
-                .bodySmall
-                ?.copyWith(color: AppTheme.defaultTextColor),
+          Flexible(
+            child: Text(
+              name,
+              textAlign: TextAlign.center,
+              overflow: TextOverflow.ellipsis,
+              maxLines: 2,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(color: AppTheme.defaultTextColor),
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved layout for profile names, allowing text to expand to two lines for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->