### PR TITLE
Fix: Add cancelled as possible topup state

### DIFF
--- a/lib/features/children/family_history/models/history_item.dart
+++ b/lib/features/children/family_history/models/history_item.dart
@@ -37,7 +37,8 @@ enum HistoryTypes {
 enum HistoryItemStatus {
   entered('Entered'),
   proccessed('Processed'),
-  rejected('Rejected');
+  rejected('Rejected'),
+  cancelled('Cancelled');
 
   const HistoryItemStatus(this.value);
 

--- a/lib/features/children/family_history/models/topup.dart
+++ b/lib/features/children/family_history/models/topup.dart
@@ -38,5 +38,6 @@ class Topup extends HistoryItem {
   final HistoryItemStatus status;
 
   bool get isNotSuccessful =>
-      status != HistoryItemStatus.proccessed && attemptNr > 0;
+      (status != HistoryItemStatus.proccessed && attemptNr > 0) ||
+      status == HistoryItemStatus.cancelled;
 }

--- a/lib/features/family/features/history/history_repository/history_repository.dart
+++ b/lib/features/family/features/history/history_repository/history_repository.dart
@@ -35,7 +35,8 @@ class HistoryRepositoryImpl with HistoryRepository {
     final result = <HistoryItem>[];
 
     for (final donationMap in response) {
-      if (donationMap['status'] == 'Rejected') {
+      if (donationMap['status'] == 'Rejected' ||
+          donationMap['status'] == 'Cancelled') {
         continue;
       }
       if (donationMap['donationType'] == HistoryTypes.donation.value) {


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new status, "Cancelled," to the history item status options, enhancing the tracking and management of history items.
  - Updated the top-up success assessment to consider a transaction as unsuccessful if it is cancelled.
  - Enhanced filtering in donation history to exclude records with both "Rejected" and "Cancelled" statuses, improving data accuracy.

- **Bug Fixes**
  - Improved logic for determining top-up success, providing a more comprehensive evaluation of transaction outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->