### PR TITLE
Fix: If amount can be zero then button should not be grey

### DIFF
--- a/lib/features/children/add_member/widgets/allowance_counter.dart
+++ b/lib/features/children/add_member/widgets/allowance_counter.dart
@@ -133,7 +133,7 @@ class _AllowanceCounterState extends State<AllowanceCounter> {
               FontAwesomeIcons.circleMinus,
               size: 32,
               color: (_allowance < 2)
-                  ? widget.canAmountBeZero
+                  ? widget.canAmountBeZero && _allowance > 0
                       ? AppTheme.primary20
                       : Colors.grey
                   : AppTheme.primary20,

--- a/lib/features/children/add_member/widgets/allowance_counter.dart
+++ b/lib/features/children/add_member/widgets/allowance_counter.dart
@@ -132,7 +132,11 @@ class _AllowanceCounterState extends State<AllowanceCounter> {
             child: Icon(
               FontAwesomeIcons.circleMinus,
               size: 32,
-              color: (_allowance < 2) ? Colors.grey : AppTheme.primary20,
+              color: (_allowance < 2)
+                  ? widget.canAmountBeZero
+                      ? AppTheme.primary20
+                      : Colors.grey
+                  : AppTheme.primary20,
             ),
           ),
         ),


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual representation of the allowance icon with improved color logic based on allowance value and associated settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->