### PR TITLE
fix: Await the invite sheet before proceeding (kids-1223)

### DIFF
--- a/lib/features/family/features/profiles/cubit/profiles_cubit.dart
+++ b/lib/features/family/features/profiles/cubit/profiles_cubit.dart
@@ -100,11 +100,12 @@ class ProfilesCubit extends HydratedCubit<ProfilesState> {
 
   Future<void> fetchAllProfiles({
     bool checkRegistrationAndSetup = false,
+    bool checkInvite = false,
   }) async {
     _emitLoadingState();
 
     try {
-      if (checkRegistrationAndSetup) {
+      if (checkInvite) {
         await checkIfInvitedToGroup();
       }
       if (_isInvitedToGroup()) {

--- a/lib/features/family/features/profiles/screens/profile_selection_screen.dart
+++ b/lib/features/family/features/profiles/screens/profile_selection_screen.dart
@@ -110,9 +110,11 @@ class _ProfileSelectionScreenState extends State<ProfileSelectionScreen> {
               ? const CustomCircularProgressIndicator()
               : state.children.isEmpty
                   ? ProfilesEmptyStateWidget(
-                      onRetry: () => context
-                          .read<ProfilesCubit>()
-                          .fetchAllProfiles(checkRegistrationAndSetup: true),
+                      onRetry: () =>
+                          context.read<ProfilesCubit>().fetchAllProfiles(
+                                checkRegistrationAndSetup: true,
+                                checkInvite: true,
+                              ),
                     )
                   : SafeArea(
                       minimum: const EdgeInsets.only(bottom: 40),

--- a/lib/features/family/features/profiles/screens/profile_selection_screen.dart
+++ b/lib/features/family/features/profiles/screens/profile_selection_screen.dart
@@ -49,7 +49,7 @@ class _ProfileSelectionScreenState extends State<ProfileSelectionScreen> {
     return BlocConsumer<ProfilesCubit, ProfilesState>(
       listener: (context, state) async {
         if (state is ProfilesInvitedToGroup) {
-          unawaited(showModalBottomSheet<void>(
+          await showModalBottomSheet<void>(
             isScrollControlled: true,
             context: context,
             useSafeArea: true,
@@ -60,7 +60,7 @@ class _ProfileSelectionScreenState extends State<ProfileSelectionScreen> {
                 invitdImpactGroup: state.impactGroup,
               );
             },
-          ));
+          );
         } else if (state is ProfilesExternalErrorState) {
           log(state.errorMessage);
           SnackBarHelper.showMessage(

--- a/lib/features/impact_groups/widgets/impact_group_recieve_invite_sheet.dart
+++ b/lib/features/impact_groups/widgets/impact_group_recieve_invite_sheet.dart
@@ -53,9 +53,7 @@ class ImpactGroupRecieveInviteSheet extends StatelessWidget {
               context
                   .read<ImpactGroupsCubit>()
                   .acceptGroupInvite(groupId: invitdImpactGroup.id);
-              context
-                  .read<ProfilesCubit>()
-                  .fetchAllProfiles(checkRegistrationAndSetup: true);
+              context.read<ProfilesCubit>().fetchAllProfiles();
               context.pop();
             },
           ),

--- a/lib/features/impact_groups/widgets/impact_group_recieve_invite_sheet.dart
+++ b/lib/features/impact_groups/widgets/impact_group_recieve_invite_sheet.dart
@@ -53,7 +53,9 @@ class ImpactGroupRecieveInviteSheet extends StatelessWidget {
               context
                   .read<ImpactGroupsCubit>()
                   .acceptGroupInvite(groupId: invitdImpactGroup.id);
-              context.read<ProfilesCubit>().fetchAllProfiles();
+              context
+                  .read<ProfilesCubit>()
+                  .fetchAllProfiles(checkRegistrationAndSetup: true);
               context.pop();
             },
           ),


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
- Await invite sheet (so it does. not navigate to registration)
- Separate the registration check from the invite check
- Do not check for invite immediately after accepting, only check for registration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced profile fetching logic to include invitation checks, improving accuracy in user profiles displayed based on group invitations.
- **Improvements**
	- Updated modal bottom sheet handling for smoother user experience during profile invitations.
	- Modified retry functionality to incorporate invitation checks, ensuring more relevant profiles are fetched when reattempting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->