### PR TITLE
Fix: clear local cache of invite after accept

### DIFF
--- a/lib/features/family/features/profiles/cubit/profiles_cubit.dart
+++ b/lib/features/family/features/profiles/cubit/profiles_cubit.dart
@@ -69,6 +69,10 @@ class ProfilesCubit extends HydratedCubit<ProfilesState> {
     }
   }
 
+  void clearInvite() {
+    _invitedToGroup = null;
+  }
+
   bool _isInvitedToGroup() => _invitedToGroup != null;
 
   void _showInviteSheet() {

--- a/lib/features/impact_groups/widgets/impact_group_recieve_invite_sheet.dart
+++ b/lib/features/impact_groups/widgets/impact_group_recieve_invite_sheet.dart
@@ -53,9 +53,9 @@ class ImpactGroupRecieveInviteSheet extends StatelessWidget {
               context
                   .read<ImpactGroupsCubit>()
                   .acceptGroupInvite(groupId: invitdImpactGroup.id);
-              context
-                  .read<ProfilesCubit>()
-                  .fetchAllProfiles(checkRegistrationAndSetup: true);
+              context.read<ProfilesCubit>()
+                ..clearInvite()
+                ..fetchAllProfiles(checkRegistrationAndSetup: true);
               context.pop();
             },
           ),


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to clear existing group invitation states in user profiles.
	- Improved handling of group invitations by ensuring previous invite states are cleared before updating profile lists.

- **Bug Fixes**
	- Enhanced the logic for managing group invitation states, improving overall user experience when accepting invites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->