### PR TITLE
Use correct month when creating yearly recurring donation (KIDS-1193)

### DIFF
--- a/lib/features/personal_summary/add_external_donation/models/external_donation.dart
+++ b/lib/features/personal_summary/add_external_donation/models/external_donation.dart
@@ -115,7 +115,7 @@ class ExternalDonation extends Equatable {
       case 3: // 6 monthly
         return '0 0 ${startDate.day} ${_getHalfYearlyCronFirstPart(startDate.month)}/6 *';
       case 4: // yearly
-        return '0 0 ${startDate.day} ${startDate.month + 1} *';
+        return '0 0 ${startDate.day} ${startDate.month} *';
       default: // Once
         return '';
     }

--- a/lib/features/recurring_donations/create/models/recurring_donation.dart
+++ b/lib/features/recurring_donations/create/models/recurring_donation.dart
@@ -46,7 +46,7 @@ class RecurringDonation extends Equatable {
       case 3: // 6 monthly
         return '0 0 ${startDate.day} ${_getHalfYearlyCronFirstPart(startDate.month)}/6 *';
       case 4: // yearly
-        return '0 0 ${startDate.day} ${startDate.month + 1} *';
+        return '0 0 ${startDate.day} ${startDate.month} *';
       default:
         return '';
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Adjusted the scheduling logic for yearly donations to ensure they occur in the specified month rather than the following month. 
- **Bug Fixes**
	- Corrected the cron expression generation for yearly recurring donations to accurately reflect the intended scheduling month.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->