### PR TITLE
Fix: Remove namespace from mediumid (kids-613)

### DIFF
--- a/lib/features/give/pages/select_giving_way_page.dart
+++ b/lib/features/give/pages/select_giving_way_page.dart
@@ -11,7 +11,7 @@ import 'package:givt_app/utils/utils.dart';
 import 'package:go_router/go_router.dart';
 
 class SelectGivingWayPage extends StatelessWidget {
-  const SelectGivingWayPage({super.key,});
+  const SelectGivingWayPage({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -192,7 +192,7 @@ class SelectGivingWayPage extends StatelessWidget {
           CupertinoDialogAction(
             onPressed: () => context.read<GiveBloc>().add(
                   GiveOrganisationSelected(
-                    nameSpace: state.organisation.mediumId!,
+                    nameSpace: state.organisation.mediumId!.split('.').first,
                     userGUID: guid,
                   ),
                 ),


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the organization selection process by refining the handling of `mediumId`, improving how organizations are identified and categorized.
  
- **Bug Fixes**
	- Corrected the formatting in the constructor of the `SelectGivingWayPage` class for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->