### PR TITLE
Add option to setup allowance instead of topup (KIDS-1251)

### DIFF
--- a/lib/features/children/overview/models/wallet.dart
+++ b/lib/features/children/overview/models/wallet.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:givt_app/features/children/details/models/giving_allowance.dart';
 
 class Wallet extends Equatable {
   const Wallet({
@@ -7,6 +8,7 @@ class Wallet extends Equatable {
     required this.pending,
     required this.currency,
     required this.pendingAllowance,
+    required this.givingAllowance,
   });
 
   const Wallet.empty()
@@ -16,6 +18,7 @@ class Wallet extends Equatable {
           pending: 0,
           currency: 'USD',
           pendingAllowance: false,
+          givingAllowance: const GivingAllowance.empty(),
         );
 
   factory Wallet.fromMap(Map<String, dynamic> map) {
@@ -25,6 +28,11 @@ class Wallet extends Equatable {
       pending: double.parse(map['pending'].toString()),
       pendingAllowance: (map['pendingAllowance'] ?? false) as bool,
       currency: map['currency'] as String,
+      givingAllowance: map['givingAllowance'] != null
+          ? (GivingAllowance.fromMap(
+              map['givingAllowance'] as Map<String, dynamic>,
+            ))
+          : const GivingAllowance.empty(),
     );
   }
 
@@ -33,10 +41,11 @@ class Wallet extends Equatable {
   final double pending;
   final String currency;
   final bool pendingAllowance;
+  final GivingAllowance givingAllowance;
 
   @override
   List<Object?> get props =>
-      [balance, total, pending, currency, pendingAllowance];
+      [balance, total, pending, currency, pendingAllowance, givingAllowance];
 
   Map<String, dynamic> toJson() {
     return {
@@ -45,6 +54,7 @@ class Wallet extends Equatable {
       'pending': pending,
       'currency': currency,
       'pendingAllowance': pendingAllowance,
+      'givingAllowance': givingAllowance,
     };
   }
 }

--- a/lib/features/family/features/profiles/models/profile.dart
+++ b/lib/features/family/features/profiles/models/profile.dart
@@ -1,7 +1,6 @@
 import 'package:equatable/equatable.dart';
+import 'package:givt_app/features/children/overview/models/wallet.dart';
 import 'package:givt_app/features/family/features/history/models/donation.dart';
-
-import '../../../../children/overview/models/wallet.dart';
 
 class Profile extends Equatable {
   factory Profile.fromMap(Map<String, dynamic> map) {

--- a/lib/features/family/features/topup/cubit/topup_cubit.dart
+++ b/lib/features/family/features/topup/cubit/topup_cubit.dart
@@ -9,11 +9,16 @@ class TopupCubit extends Cubit<TopupState> {
 
   final TopupRepository topupRepository;
 
-  Future<void> topup(int amount) async {
-    emit(state.copyWith(status: TopupStatus.loading));
+  Future<void> addMoney(int amount, bool recurring) async {
+    emit(state.copyWith(status: TopupStatus.loading, amount: amount));
 
     try {
-      await topupRepository.topupChild(state.userGuid, amount);
+      if (recurring) {
+        await topupRepository.setupRecurringAmount(state.userGuid, amount);
+      } else {
+        await topupRepository.topupChild(state.userGuid, amount);
+      }
+
       emit(state.copyWith(status: TopupStatus.done));
     } catch (e) {
       emit(state.copyWith(status: TopupStatus.error, error: e.toString()));
@@ -25,6 +30,6 @@ class TopupCubit extends Cubit<TopupState> {
   }
 
   void restart() {
-    emit(state.copyWith(status: TopupStatus.initial));
+    emit(state.copyWith(status: TopupStatus.initial, amount: 0));
   }
 }

--- a/lib/features/family/features/topup/cubit/topup_state.dart
+++ b/lib/features/family/features/topup/cubit/topup_state.dart
@@ -16,8 +16,8 @@ class TopupState extends Equatable {
   final String error;
 
   @override
-  List<Object> get props => [userGuid, status, error];
-
+  List<Object> get props => [userGuid, amount, status, error];
+  
   TopupState copyWith({
     String? userGuid,
     int? amount,

--- a/lib/features/family/features/topup/cubit/topup_state.dart
+++ b/lib/features/family/features/topup/cubit/topup_state.dart
@@ -5,11 +5,13 @@ enum TopupStatus { initial, loading, done, error }
 class TopupState extends Equatable {
   const TopupState({
     this.userGuid = '',
+    this.amount = 0,
     this.status = TopupStatus.initial,
     this.error = '',
   });
 
   final String userGuid;
+  final int amount;
   final TopupStatus status;
   final String error;
 
@@ -18,11 +20,13 @@ class TopupState extends Equatable {
 
   TopupState copyWith({
     String? userGuid,
+    int? amount,
     TopupStatus? status,
     String? error,
   }) {
     return TopupState(
       userGuid: userGuid ?? this.userGuid,
+      amount: amount ?? this.amount,
       status: status ?? this.status,
       error: error ?? this.error,
     );

--- a/lib/features/family/features/topup/repository/topup_repository.dart
+++ b/lib/features/family/features/topup/repository/topup_repository.dart
@@ -2,6 +2,7 @@ import 'package:givt_app/features/family/network/api_service.dart';
 
 mixin TopupRepository {
   Future<bool> topupChild(String childGUID, int amount);
+  Future<bool> setupRecurringAmount(String childGUID, int amount);
 }
 
 class TopupRepositoryImpl with TopupRepository {
@@ -14,6 +15,12 @@ class TopupRepositoryImpl with TopupRepository {
   @override
   Future<bool> topupChild(String childGUID, int amount) async {
     final response = await _apiService.topUpChild(childGUID, amount);
+    return response;
+  }
+
+  @override
+  Future<bool> setupRecurringAmount(String childGUID, int amount) async {
+    final response = await _apiService.setupRecurringAmount(childGUID, amount);
     return response;
   }
 }

--- a/lib/features/family/features/topup/screens/topup_bottom_sheet.dart
+++ b/lib/features/family/features/topup/screens/topup_bottom_sheet.dart
@@ -22,20 +22,13 @@ class _TopupWalletBottomSheetState extends State<TopupWalletBottomSheet> {
       builder: (context, state) {
         switch (state.status) {
           case TopupStatus.initial:
-            return TopupInitialBottomSheet(
-              topupAmount: topupAmount,
-              amountChanged: (amount) {
-                setState(() {
-                  topupAmount = amount;
-                });
-              },
-            );
+            return const TopupInitialBottomSheet();
 
           case TopupStatus.loading:
             return const TopupLoadingBottomSheet();
 
           case TopupStatus.done:
-            return TopupSuccessBottomSheet(topupAmount: topupAmount);
+            return TopupSuccessBottomSheet(topupAmount: state.amount);
 
           case TopupStatus.error:
             return const TopupErrorBottomSheet();

--- a/lib/features/family/network/api_service.dart
+++ b/lib/features/family/network/api_service.dart
@@ -267,4 +267,25 @@ class FamilyAPIService {
     }
     return response.statusCode == 200;
   }
+
+  Future<bool> setupRecurringAmount(String childGUID, int allowance) async {
+    final url =
+        Uri.https(_apiURL, '/givtservice/v1/profiles/$childGUID/allowance');
+
+    final response = await client.put(
+      url,
+      body: jsonEncode({'amount': allowance}),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    );
+
+    if (response.statusCode >= 300) {
+      throw GivtServerFailure(
+        statusCode: response.statusCode,
+        body: jsonDecode(response.body) as Map<String, dynamic>,
+      );
+    }
+    return response.statusCode == 200;
+  }
 }

--- a/lib/features/family/shared/widgets/inputs/input_checkbox.dart
+++ b/lib/features/family/shared/widgets/inputs/input_checkbox.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class InputCheckbox extends StatelessWidget {
+  const InputCheckbox({
+    required this.label,
+    required this.value,
+    required this.onChanged,
+    super.key,
+  });
+
+  final String label;
+  final bool value;
+  final void Function(bool? value)? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Checkbox(
+          value: value,
+          onChanged: onChanged,
+        ),
+        Text(label, style: Theme.of(context).textTheme.bodySmall),
+      ],
+    );
+  }
+}

--- a/lib/features/family/utils/family_app_theme.dart
+++ b/lib/features/family/utils/family_app_theme.dart
@@ -243,6 +243,18 @@ class FamilyAppTheme extends ThemeExtension<FamilyAppTheme> {
         color: colorScheme.background,
         surfaceTintColor: Colors.transparent,
       ),
+      checkboxTheme: CheckboxThemeData(
+        fillColor: MaterialStateProperty.resolveWith<Color>(
+          (Set<MaterialState> states) {
+            if (states.contains(MaterialState.selected)) {
+              return primary80;
+            }
+
+            return Colors.white;
+          },
+        ),
+        checkColor: MaterialStateProperty.all(primary20),
+      ),
     );
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added a new property `givingAllowance` to enhance the `Wallet` functionality.
  - Introduced a method to set up recurring top-up amounts for children.
  - Created a new `InputCheckbox` widget for improved user input handling.
  - Enhanced theme customization with a new `checkboxTheme` property.

- **Improvements**
  - Updated top-up functionality for better state management and flexibility.
  - Enhanced state management capabilities by introducing an `amount` property in `TopupState`.

- **Bug Fixes**
  - Improved handling of state updates in various components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->