### PR TITLE
Fix: Empty wallet in external coin flow (kids-1255)

### DIFF
--- a/lib/features/family/features/profiles/screens/profile_selection_screen.dart
+++ b/lib/features/family/features/profiles/screens/profile_selection_screen.dart
@@ -17,6 +17,7 @@ import 'package:givt_app/features/family/features/profiles/models/profile.dart';
 import 'package:givt_app/features/family/features/profiles/widgets/parent_overview_widget.dart';
 import 'package:givt_app/features/family/features/profiles/widgets/profile_item.dart';
 import 'package:givt_app/features/family/features/profiles/widgets/profiles_empty_state_widget.dart';
+import 'package:givt_app/features/family/features/topup/screens/empty_wallet_bottom_sheet.dart';
 import 'package:givt_app/features/family/shared/widgets/layout/top_app_bar.dart';
 import 'package:givt_app/features/family/shared/widgets/loading/custom_progress_indicator.dart';
 import 'package:givt_app/features/family/utils/utils.dart';
@@ -271,6 +272,10 @@ class _ProfileSelectionScreenState extends State<ProfileSelectionScreen> {
               return;
             }
             if (flow.isCoin) {
+              if (selectedProfile.wallet.balance < 1) {
+                EmptyWalletBottomSheet.show(context);
+                return;
+              }
               context.goNamed(FamilyPages.scanNFC.name);
               return;
             }


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a conditional check to display a warning when the user's wallet balance is empty before navigating to the next screen.

- **User Experience Enhancements**
	- Improved feedback mechanism for users attempting an action that requires a non-empty wallet, ensuring they are promptly informed of insufficient balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->