### PR TITLE
Fix: tile color and hide parents (kids-1260)

### DIFF
--- a/lib/features/family/features/home_screen/parent_home_screen.dart
+++ b/lib/features/family/features/home_screen/parent_home_screen.dart
@@ -104,9 +104,9 @@ class ParentHomeScreen extends StatelessWidget {
               eventName: AmplitudeEvents.parentGiveTileClicked,
             );
           },
-          borderColor: ColorCombo.primary.borderColor,
-          backgroundColor: ColorCombo.primary.backgroundColor,
-          textColor: ColorCombo.primary.textColor,
+          borderColor: ColorCombo.secondary.borderColor,
+          backgroundColor: ColorCombo.secondary.backgroundColor,
+          textColor: ColorCombo.secondary.textColor,
           iconPath: 'assets/family/images/give_tile.svg',
           titleBig: 'Give',
         ),

--- a/lib/features/family/features/profiles/screens/profile_selection_screen.dart
+++ b/lib/features/family/features/profiles/screens/profile_selection_screen.dart
@@ -147,12 +147,15 @@ class _ProfileSelectionScreenState extends State<ProfileSelectionScreen> {
                           children: [
                             const SizedBox(height: 32),
                             if (!flow.state.isCoin)
-                              ParentOverviewWidget(
-                                profiles: sortedAdults(
-                                  user.guid,
-                                  state.profiles
-                                      .where((p) => p.type == 'Parent')
-                                      .toList(),
+                              Visibility(
+                                visible: false,
+                                child: ParentOverviewWidget(
+                                  profiles: sortedAdults(
+                                    user.guid,
+                                    state.profiles
+                                        .where((p) => p.type == 'Parent')
+                                        .toList(),
+                                  ),
                                 ),
                               ),
                             const SizedBox(height: 26),


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Visual Updates**
	- Updated color scheme for the Parent Home Screen, enhancing visual consistency with new color attributes.
  
- **User Interface Changes**
	- Adjusted the visibility of the Parent Overview Widget in the Profile Selection Screen, ensuring it remains in the widget tree while hidden from view, streamlining the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->