### PR TITLE
Feature: Unify text styles and components (KIDS-1200)

### DIFF
--- a/lib/features/children/cached_members/pages/cached_family_overview_page.dart
+++ b/lib/features/children/cached_members/pages/cached_family_overview_page.dart
@@ -68,7 +68,7 @@ class CachedFamilyOverviewPage extends StatelessWidget {
                           context.l10n.addMember,
                           textAlign: TextAlign.start,
                           style:
-                              Theme.of(context).textTheme.labelSmall?.copyWith(
+                              Theme.of(context).textTheme.labelMedium?.copyWith(
                                     fontWeight: FontWeight.bold,
                                     color: AppTheme.givtBlue.withOpacity(.25),
                                   ),

--- a/lib/features/children/family_history/widgets/actioned_donation_widget.dart
+++ b/lib/features/children/family_history/widgets/actioned_donation_widget.dart
@@ -31,7 +31,7 @@ class ActionedDonationWidget extends StatelessWidget {
             children: [
               Text(
                 '\$${donation.amount.toStringAsFixed(2)} ${locals.childHistoryBy} ${donation.name}',
-                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
                       color: DonationState.getAmountColor(donation.state),
                     ),
               ),

--- a/lib/features/children/family_history/widgets/allowance_item_widget.dart
+++ b/lib/features/children/family_history/widgets/allowance_item_widget.dart
@@ -35,7 +35,7 @@ class AllowanceItemWidget extends StatelessWidget {
             children: [
               Text(
                 '+ \$${allowance.amount.toStringAsFixed(2)} ${locals.childHistoryTo} ${allowance.name}',
-                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
                       color: allowance.isNotSuccessful
                           ? AppTheme.childHistoryPendingDark
                           : AppTheme.childHistoryAllowance,

--- a/lib/features/children/family_history/widgets/pending_donation_widget.dart
+++ b/lib/features/children/family_history/widgets/pending_donation_widget.dart
@@ -96,7 +96,7 @@ class _PendingDonationWidgetState extends State<PendingDonationWidget> {
                   children: [
                     Text(
                       '\$${widget.donation.amount.toStringAsFixed(2)} ${locals.childHistoryBy} ${widget.donation.name}',
-                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      style: Theme.of(context).textTheme.labelMedium?.copyWith(
                             color: DonationState.getAmountColor(
                               widget.donation.state,
                             ),

--- a/lib/features/children/family_history/widgets/topup_item_widget.dart
+++ b/lib/features/children/family_history/widgets/topup_item_widget.dart
@@ -29,7 +29,7 @@ class TopupItemWidget extends StatelessWidget {
             children: [
               Text(
                 '+\$${topup.amount.toStringAsFixed(2)} ${locals.childHistoryTo} ${topup.name}',
-                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
                       color: topup.isNotSuccessful
                           ? AppTheme.childHistoryDeclined
                           : AppTheme.childHistoryAllowance,

--- a/lib/features/children/generosity_challenge/assignments/create_challenge_donation/widgets/slider_widget.dart
+++ b/lib/features/children/generosity_challenge/assignments/create_challenge_donation/widgets/slider_widget.dart
@@ -25,7 +25,7 @@ class SliderWidget extends StatelessWidget {
             alignment: Alignment.center,
             child: Text(
               '\$${currentAmount.round()}',
-              style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+              style: Theme.of(context).textTheme.headlineLarge?.copyWith(
                     color: AppTheme.secondary30,
                     fontWeight: FontWeight.w700,
                     fontFamily: 'Rouna',
@@ -80,7 +80,7 @@ class SliderWidget extends StatelessWidget {
   Widget _createLabel(BuildContext context, String text) {
     return Text(
       text,
-      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+      style: Theme.of(context).textTheme.labelMedium?.copyWith(
             color: AppTheme.primary20,
             fontWeight: FontWeight.w700,
             fontSize: 16,

--- a/lib/features/children/generosity_challenge/assignments/family_values/widgets/family_value_container.dart
+++ b/lib/features/children/generosity_challenge/assignments/family_values/widgets/family_value_container.dart
@@ -46,7 +46,7 @@ class FamilyValueContainer extends StatelessWidget {
                 Text(
                   familyValue.displayText,
                   textAlign: TextAlign.center,
-                  style: theme.textTheme.labelSmall?.copyWith(
+                  style: theme.textTheme.labelMedium?.copyWith(
                     color: familyValue.colorCombo.textColor,
                   ),
                 ),

--- a/lib/features/children/generosity_challenge/assignments/family_values/widgets/organisation_header.dart
+++ b/lib/features/children/generosity_challenge/assignments/family_values/widgets/organisation_header.dart
@@ -40,7 +40,7 @@ class OrganisationHeader extends StatelessWidget {
                         ),
                         child: Text(
                           tag.displayText,
-                          style: theme.textTheme.labelSmall?.copyWith(
+                          style: theme.textTheme.labelMedium?.copyWith(
                             color: value.colorCombo.textColor,
                           ),
                         ),

--- a/lib/features/children/generosity_challenge_chat/chat_scripts/widgets/chat_bar.dart
+++ b/lib/features/children/generosity_challenge_chat/chat_scripts/widgets/chat_bar.dart
@@ -75,7 +75,7 @@ class ChatBar extends StatelessWidget {
               child: Text(
                 state.currentConditionalItem.options[0].text,
                 textAlign: TextAlign.center,
-                style: FamilyAppTheme().toThemeData().textTheme.labelMedium,
+                style: FamilyAppTheme().toThemeData().textTheme.labelLarge,
               ),
             ),
           ),

--- a/lib/features/children/generosity_challenge_chat/chat_scripts/widgets/chat_delimiter.dart
+++ b/lib/features/children/generosity_challenge_chat/chat_scripts/widgets/chat_delimiter.dart
@@ -27,7 +27,7 @@ class ChatDelimiter extends StatelessWidget {
             child: Text(
               text,
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
                     fontSize: 16,
                     fontFamily: 'Rouna',
                     fontWeight: FontWeight.w700,

--- a/lib/features/children/overview/widgets/allowance_warning_dialog.dart
+++ b/lib/features/children/overview/widgets/allowance_warning_dialog.dart
@@ -44,7 +44,7 @@ class AllowancesWarningDialog extends StatelessWidget {
           Text(
             context.l10n.noWorriesWeWillTryAgain,
             textAlign: TextAlign.center,
-            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
                   fontFamily: 'Raleway',
                   fontWeight: FontWeight.w600,
                   color: AppTheme.childGivingAllowanceHint,

--- a/lib/features/children/overview/widgets/profile_overview_tile.dart
+++ b/lib/features/children/overview/widgets/profile_overview_tile.dart
@@ -64,7 +64,7 @@ class ProfileOverviewTile extends StatelessWidget {
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
                     color: AppTheme.givtBlue,
                   ),
             ),

--- a/lib/features/family/features/account/presentation/pages/us_personal_info_edit_page.dart
+++ b/lib/features/family/features/account/presentation/pages/us_personal_info_edit_page.dart
@@ -295,7 +295,7 @@ class USPersonalInfoEditPage extends StatelessWidget {
               ),
               _buildInfoRow(
                 context,
-                style: Theme.of(context).textTheme.labelSmall,
+                style: Theme.of(context).textTheme.labelMedium,
                 icon: const Icon(
                   FontAwesomeIcons.rightFromBracket,
                 ),
@@ -353,7 +353,7 @@ class USPersonalInfoEditPage extends StatelessWidget {
               leading: icon,
               title: Text(
                 value,
-                style: style ?? Theme.of(context).textTheme.labelSmall,
+                style: style ?? Theme.of(context).textTheme.labelMedium,
               ),
               trailing: onTap != null
                   ? const Icon(

--- a/lib/features/family/features/giving_flow/widgets/slider_widget.dart
+++ b/lib/features/family/features/giving_flow/widgets/slider_widget.dart
@@ -25,7 +25,7 @@ class SliderWidget extends StatelessWidget {
             alignment: Alignment.center,
             child: Text(
               '\$${currentAmount.round()}',
-              style: Theme.of(context).textTheme.headlineMedium,
+              style: Theme.of(context).textTheme.headlineLarge,
             ),
           ),
           SliderTheme(
@@ -68,12 +68,12 @@ class SliderWidget extends StatelessWidget {
               children: [
                 Text(
                   r'$0',
-                  style: Theme.of(context).textTheme.labelSmall,
+                  style: Theme.of(context).textTheme.labelMedium,
                 ),
                 const Spacer(),
                 Text(
                   '\$${maxAmount.round()}',
-                  style: Theme.of(context).textTheme.labelSmall,
+                  style: Theme.of(context).textTheme.labelMedium,
                 ),
               ],
             ),

--- a/lib/features/family/features/home_screen/parent_home_screen.dart
+++ b/lib/features/family/features/home_screen/parent_home_screen.dart
@@ -87,7 +87,7 @@ class ParentHomeScreen extends StatelessWidget {
               const SizedBox(height: 8),
               Text(
                 NavigationDestinationData.home.label,
-                style: Theme.of(context).textTheme.labelSmall?.copyWith(),
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(),
               ),
               const SizedBox(height: 16),
             ],
@@ -161,14 +161,14 @@ class ParentHomeScreen extends StatelessWidget {
                     children: [
                       Text(
                         'My Settings',
-                        style: Theme.of(context).textTheme.labelSmall,
+                        style: Theme.of(context).textTheme.labelMedium,
                       ),
                       Padding(
                         padding: const EdgeInsets.only(left: 4),
                         child: Icon(
                           FontAwesomeIcons.arrowRight,
                           size:
-                              Theme.of(context).textTheme.labelSmall?.fontSize,
+                              Theme.of(context).textTheme.labelMedium?.fontSize,
                           color:
                               Theme.of(context).colorScheme.onPrimaryContainer,
                         ),

--- a/lib/features/family/features/impact_groups/dialogs/impact_group_details_description_dialog.dart
+++ b/lib/features/family/features/impact_groups/dialogs/impact_group_details_description_dialog.dart
@@ -79,7 +79,7 @@ class ImpactGroupDetailsDescriptionDialog extends StatelessWidget {
                 padding: const EdgeInsets.only(left: 24, right: 24, bottom: 30),
                 child: Text(
                   description,
-                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  style: Theme.of(context).textTheme.labelMedium?.copyWith(
                         fontWeight: FontWeight.w500,
                         color: AppTheme.primary20,
                       ),

--- a/lib/features/family/features/impact_groups/widgets/impact_group_details_expandable_description.dart
+++ b/lib/features/family/features/impact_groups/widgets/impact_group_details_expandable_description.dart
@@ -21,7 +21,7 @@ class ImpactGroupDetailsExpandableDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textStyle = Theme.of(context).textTheme.labelSmall?.copyWith(
+    final textStyle = Theme.of(context).textTheme.labelMedium?.copyWith(
           fontWeight: FontWeight.w500,
           color: Colors.black,
         );

--- a/lib/features/family/features/impact_groups/widgets/impact_group_details_header.dart
+++ b/lib/features/family/features/impact_groups/widgets/impact_group_details_header.dart
@@ -66,7 +66,7 @@ class ImpactGroupDetailsHeader extends StatelessWidget {
                         Text(
                           'Goal: \$${impactGroup.goal.goalAmount}',
                           style:
-                              Theme.of(context).textTheme.labelSmall?.copyWith(
+                              Theme.of(context).textTheme.labelMedium?.copyWith(
                                     fontWeight: FontWeight.w500,
                                     color: AppTheme.primary50,
                                   ),

--- a/lib/features/family/features/parent_giving_flow/presentation/pages/organisation_list_family_page.dart
+++ b/lib/features/family/features/parent_giving_flow/presentation/pages/organisation_list_family_page.dart
@@ -11,6 +11,7 @@ import 'package:givt_app/features/family/shared/widgets/buttons/tiles/church_til
 import 'package:givt_app/features/family/shared/widgets/inputs/family_search_field.dart';
 import 'package:givt_app/features/family/shared/widgets/layout/top_app_bar.dart';
 import 'package:givt_app/features/family/shared/widgets/loading/custom_progress_indicator.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
 import 'package:givt_app/features/family/utils/family_app_theme.dart';
 import 'package:givt_app/features/give/bloc/bloc.dart';
 import 'package:givt_app/l10n/l10n.dart';
@@ -142,13 +143,7 @@ class _OrganisationListFamilyPageState
           CollectGroupType.getIconByType(type),
           color: AppTheme.givtBlue,
         ),
-        title: Text(
-          title,
-          style: Theme.of(context).textTheme.labelSmall ??
-              const TextStyle(
-                color: AppTheme.givtBlue,
-              ),
-        ),
+        title: LabelMediumText(title),
       );
 
   Widget _buildFilterType(OrganisationBloc bloc, AppLocalizations locals) =>

--- a/lib/features/family/features/profiles/widgets/action_tile.dart
+++ b/lib/features/family/features/profiles/widgets/action_tile.dart
@@ -98,7 +98,7 @@ class _ActionTileState extends State<ActionTile> {
                           widget.titleBig,
                           textAlign: TextAlign.center,
                           style:
-                              Theme.of(context).textTheme.labelMedium?.copyWith(
+                              Theme.of(context).textTheme.labelLarge?.copyWith(
                                     color: widget.isDisabled
                                         ? AppTheme.disabledTileBorder
                                         : widget.textColor,
@@ -111,7 +111,7 @@ class _ActionTileState extends State<ActionTile> {
                           widget.titleSmall,
                           textAlign: TextAlign.center,
                           style:
-                              Theme.of(context).textTheme.labelSmall?.copyWith(
+                              Theme.of(context).textTheme.labelMedium?.copyWith(
                                     color: widget.isDisabled
                                         ? AppTheme.disabledTileBorder
                                         : widget.textColor,
@@ -125,7 +125,7 @@ class _ActionTileState extends State<ActionTile> {
                           widget.subtitle,
                           textAlign: TextAlign.center,
                           style:
-                              Theme.of(context).textTheme.labelSmall?.copyWith(
+                              Theme.of(context).textTheme.labelMedium?.copyWith(
                                     color: widget.textColor.withAlpha(200),
                                   ),
                         )

--- a/lib/features/family/features/profiles/widgets/give_bottomsheet.dart
+++ b/lib/features/family/features/profiles/widgets/give_bottomsheet.dart
@@ -159,7 +159,7 @@ class GiveBottomSheet extends StatelessWidget {
                     const SizedBox(width: 4),
                     Text(
                       'Cancel',
-                      style: Theme.of(context).textTheme.labelMedium,
+                      style: Theme.of(context).textTheme.labelLarge,
                     ),
                   ],
                 ),

--- a/lib/features/family/features/profiles/widgets/giving_option_button.dart
+++ b/lib/features/family/features/profiles/widgets/giving_option_button.dart
@@ -45,7 +45,7 @@ class GiveOptionButton extends StatelessWidget {
             Text(
               text,
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              style: Theme.of(context).textTheme.labelLarge?.copyWith(
                     color: secondColor,
                   ),
             ),

--- a/lib/features/family/features/profiles/widgets/parent_overview_widget.dart
+++ b/lib/features/family/features/profiles/widgets/parent_overview_widget.dart
@@ -73,7 +73,7 @@ class ParentOverviewWidget extends StatelessWidget {
                     children: [
                       Text(
                         profile.firstName,
-                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        style: Theme.of(context).textTheme.labelMedium?.copyWith(
                             color: isMainUser
                                 ? AppTheme.defaultTextColor
                                 : AppTheme.tertiary20),
@@ -84,7 +84,7 @@ class ParentOverviewWidget extends StatelessWidget {
                           FontAwesomeIcons.arrowRight,
                           color: AppTheme.defaultTextColor,
                           size:
-                              Theme.of(context).textTheme.labelSmall?.fontSize,
+                              Theme.of(context).textTheme.labelMedium?.fontSize,
                         ),
                     ],
                   ),

--- a/lib/features/family/features/profiles/widgets/profile_item.dart
+++ b/lib/features/family/features/profiles/widgets/profile_item.dart
@@ -36,7 +36,7 @@ class ProfileItem extends StatelessWidget {
                   textAlign: TextAlign.center,
                   overflow: TextOverflow.ellipsis,
                   maxLines: 2,
-                  style: Theme.of(context).textTheme.labelSmall,
+                  style: Theme.of(context).textTheme.labelMedium,
                 ),
               ),
               const SizedBox(width: 4),

--- a/lib/features/family/features/profiles/widgets/wallet_widget.dart
+++ b/lib/features/family/features/profiles/widgets/wallet_widget.dart
@@ -137,7 +137,7 @@ class _WalletWidgetState extends State<WalletWidget> {
                       children: [
                         Text(
                           'My profile',
-                          style: Theme.of(context).textTheme.labelSmall,
+                          style: Theme.of(context).textTheme.labelMedium,
                         ),
                         Padding(
                           padding: const EdgeInsets.only(left: 4),

--- a/lib/features/family/features/recommendation/organisations/widgets/organisation_detail_bottomsheet.dart
+++ b/lib/features/family/features/recommendation/organisations/widgets/organisation_detail_bottomsheet.dart
@@ -73,7 +73,7 @@ class OrganisationDetailBottomSheet extends StatelessWidget {
                       Text(
                         organisation.shortDescription,
                         textAlign: TextAlign.start,
-                        style: Theme.of(context).textTheme.labelSmall,
+                        style: Theme.of(context).textTheme.labelMedium,
                       ),
                       const SizedBox(height: 12),
                       Text(

--- a/lib/features/family/features/recommendation/organisations/widgets/organisation_header.dart
+++ b/lib/features/family/features/recommendation/organisations/widgets/organisation_header.dart
@@ -43,7 +43,7 @@ class OrganisationHeader extends StatelessWidget {
                         child: Text(
                           tag.displayText,
                           style:
-                              Theme.of(context).textTheme.labelSmall?.copyWith(
+                              Theme.of(context).textTheme.labelMedium?.copyWith(
                                     color: tag.area.textColor,
                                     fontSize: 13,
                                   ),

--- a/lib/features/family/shared/design/family_text_styles.dart
+++ b/lib/features/family/shared/design/family_text_styles.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class FamilyTextStyles {
+
+ static const displayLarge = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 57,
+    fontWeight: FontWeight.w700,
+    height: 1.2,
+    fontFamily: 'Rouna',
+  );
+
+ static const displayMedium = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 45,
+    fontWeight: FontWeight.w700,
+    height: 1.2,
+    fontFamily: 'Rouna',
+  );
+
+ static const displaySmall = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 36,
+    fontWeight: FontWeight.w700,
+    height: 1.2,
+    fontFamily: 'Rouna',
+  );
+
+ static const headlineLarge = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 32,
+    fontWeight: FontWeight.w700,
+    height: 1.2,
+    fontFamily: 'Rouna',
+  );
+
+ static const headlineMedium = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 28,
+    fontWeight: FontWeight.w700,
+    height: 1.2,
+    fontFamily: 'Rouna',
+  );
+
+ static const headlineSmall = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 24,
+    fontWeight: FontWeight.w700,
+    height: 1.2,
+    fontFamily: 'Rouna',
+  );
+
+ static const titleLarge = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 26,
+    fontWeight: FontWeight.w700,
+    height: 1.2,
+    fontFamily: 'Rouna',
+  );
+
+ static const titleMedium = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 22,
+    fontWeight: FontWeight.w700,
+    letterSpacing: 0.05,
+    height: 1.2,
+    fontFamily: 'Rouna',
+  );
+
+ static const titleSmall = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 18,
+    fontWeight: FontWeight.w700,
+    letterSpacing: 0.01,
+    height: 1.2,
+    fontFamily: 'Rouna',
+  );
+
+ static const labelLarge = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 20,
+    fontWeight: FontWeight.w700,
+    letterSpacing: 0.05,
+    fontFamily: 'Rouna',
+  );
+
+ static const labelMedium = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 16,
+    fontWeight: FontWeight.w700,
+    letterSpacing: 0.05,
+    fontFamily: 'Rouna',
+  );
+
+ static const labelSmall = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 14,
+    fontWeight: FontWeight.w700,
+    letterSpacing: 0.05,
+    fontFamily: 'Rouna',
+  );
+
+ static const bodyLarge = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 22,
+    fontWeight: FontWeight.w500,
+    height: 1.4,
+    letterSpacing: 0.05,
+    fontFamily: 'Rouna',
+  );
+
+ static const bodyMedium = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 18,
+    fontWeight: FontWeight.w500,
+    height: 1.4,
+    letterSpacing: 0.05,
+    fontFamily: 'Rouna',
+  );
+
+ static const bodySmall = TextStyle(
+    color: FamilyAppTheme.defaultTextColor,
+    fontSize: 15,
+    height: 1.4,
+    fontWeight: FontWeight.w500,
+    fontFamily: 'Rouna',
+  );
+}

--- a/lib/features/family/shared/widgets/buttons/givt_fab.dart
+++ b/lib/features/family/shared/widgets/buttons/givt_fab.dart
@@ -119,7 +119,7 @@ class _GivtFloatingActionButtonState extends State<GivtFloatingActionButton> {
             ),
             Text(
               widget.text,
-              style: Theme.of(context).textTheme.labelMedium,
+              style: Theme.of(context).textTheme.labelLarge,
             ),
           ],
         ),
@@ -134,7 +134,7 @@ class _GivtFloatingActionButtonState extends State<GivtFloatingActionButton> {
           children: [
             Text(
               widget.text,
-              style: Theme.of(context).textTheme.labelMedium,
+              style: Theme.of(context).textTheme.labelLarge,
             ),
             Padding(
               padding: const EdgeInsets.only(left: 8),
@@ -152,7 +152,7 @@ class _GivtFloatingActionButtonState extends State<GivtFloatingActionButton> {
       padding: const EdgeInsets.all(12),
       child: Text(
         widget.text,
-        style: Theme.of(context).textTheme.labelMedium,
+        style: Theme.of(context).textTheme.labelLarge,
       ),
     );
   }

--- a/lib/features/family/shared/widgets/content/coin_widget.dart
+++ b/lib/features/family/shared/widgets/content/coin_widget.dart
@@ -16,7 +16,7 @@ class CoinWidget extends StatelessWidget {
       children: [
         Text(
           '\$${user.wallet.balance.round()}',
-          style: Theme.of(context).textTheme.labelMedium,
+          style: Theme.of(context).textTheme.labelLarge,
         ),
         const SizedBox(width: 8),
         SvgPicture.asset(

--- a/lib/features/family/shared/widgets/content/wallet.dart
+++ b/lib/features/family/shared/widgets/content/wallet.dart
@@ -17,7 +17,7 @@ class Wallet extends StatelessWidget {
       children: [
         Text(
           '\$${activeProfile.wallet.balance.toStringAsFixed(2)}',
-          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          style: Theme.of(context).textTheme.labelMedium?.copyWith(
                 color: AppTheme.info20,
               ),
         ),

--- a/lib/features/family/shared/widgets/layout/top_app_bar.dart
+++ b/lib/features/family/shared/widgets/layout/top_app_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
 import 'package:givt_app/utils/utils.dart';
 
 class TopAppBar extends StatelessWidget implements PreferredSizeWidget {
@@ -19,11 +20,8 @@ class TopAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
-      title: Text(
+      title: TitleMediumText.primary30(
         title,
-        style: Theme.of(context).textTheme.titleLarge!.copyWith(
-              color: AppTheme.primary30,
-            ),
       ),
       backgroundColor: color ?? Theme.of(context).colorScheme.onPrimary,
       systemOverlayStyle: SystemUiOverlayStyle(

--- a/lib/features/family/shared/widgets/texts/body_large_text.dart
+++ b/lib/features/family/shared/widgets/texts/body_large_text.dart
@@ -74,7 +74,7 @@ class BodyLargeText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.bodyLarge.copyWith(color: color),
+      style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/body_large_text.dart
+++ b/lib/features/family/shared/widgets/texts/body_large_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class BodyLargeText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const BodyLargeText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory BodyLargeText.primary30(String text) =>
+      BodyLargeText(text, color: FamilyAppTheme.primary30);
+
+  factory BodyLargeText.primary40(String text) =>
+      BodyLargeText(text, color: FamilyAppTheme.primary40);
+
+  factory BodyLargeText.secondary20(String text) =>
+      BodyLargeText(text, color: FamilyAppTheme.secondary20);
+
+  factory BodyLargeText.secondary30(String text) =>
+      BodyLargeText(text, color: FamilyAppTheme.secondary30);
+
+  factory BodyLargeText.secondary40(String text) =>
+      BodyLargeText(text, color: FamilyAppTheme.secondary40);
+
+  factory BodyLargeText.tertiary20(String text) =>
+      BodyLargeText(text, color: FamilyAppTheme.tertiary20);
+
+  factory BodyLargeText.tertiary40(String text) =>
+      BodyLargeText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.bodyLarge.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/body_medium_text.dart
+++ b/lib/features/family/shared/widgets/texts/body_medium_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class BodyMediumText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const BodyMediumText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory BodyMediumText.primary30(String text) =>
+      BodyMediumText(text, color: FamilyAppTheme.primary30);
+
+  factory BodyMediumText.primary40(String text) =>
+      BodyMediumText(text, color: FamilyAppTheme.primary40);
+
+  factory BodyMediumText.secondary20(String text) =>
+      BodyMediumText(text, color: FamilyAppTheme.secondary20);
+
+  factory BodyMediumText.secondary30(String text) =>
+      BodyMediumText(text, color: FamilyAppTheme.secondary30);
+
+  factory BodyMediumText.secondary40(String text) =>
+      BodyMediumText(text, color: FamilyAppTheme.secondary40);
+
+  factory BodyMediumText.tertiary20(String text) =>
+      BodyMediumText(text, color: FamilyAppTheme.tertiary20);
+
+  factory BodyMediumText.tertiary40(String text) =>
+      BodyMediumText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.bodyMedium.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/body_medium_text.dart
+++ b/lib/features/family/shared/widgets/texts/body_medium_text.dart
@@ -74,7 +74,7 @@ class BodyMediumText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.bodyMedium.copyWith(color: color),
+      style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/body_small_text.dart
+++ b/lib/features/family/shared/widgets/texts/body_small_text.dart
@@ -74,7 +74,7 @@ class BodySmallText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.bodySmall.copyWith(color: color),
+      style: Theme.of(context).textTheme.bodySmall?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/body_small_text.dart
+++ b/lib/features/family/shared/widgets/texts/body_small_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class BodySmallText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const BodySmallText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory BodySmallText.primary30(String text) =>
+      BodySmallText(text, color: FamilyAppTheme.primary30);
+
+  factory BodySmallText.primary40(String text) =>
+      BodySmallText(text, color: FamilyAppTheme.primary40);
+
+  factory BodySmallText.secondary20(String text) =>
+      BodySmallText(text, color: FamilyAppTheme.secondary20);
+
+  factory BodySmallText.secondary30(String text) =>
+      BodySmallText(text, color: FamilyAppTheme.secondary30);
+
+  factory BodySmallText.secondary40(String text) =>
+      BodySmallText(text, color: FamilyAppTheme.secondary40);
+
+  factory BodySmallText.tertiary20(String text) =>
+      BodySmallText(text, color: FamilyAppTheme.tertiary20);
+
+  factory BodySmallText.tertiary40(String text) =>
+      BodySmallText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.bodySmall.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/display_large_text.dart
+++ b/lib/features/family/shared/widgets/texts/display_large_text.dart
@@ -74,7 +74,7 @@ class DisplayLargeText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.displayLarge.copyWith(color: color),
+      style: Theme.of(context).textTheme.displayLarge?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/display_large_text.dart
+++ b/lib/features/family/shared/widgets/texts/display_large_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class DisplayLargeText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const DisplayLargeText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory DisplayLargeText.primary30(String text) =>
+      DisplayLargeText(text, color: FamilyAppTheme.primary30);
+
+  factory DisplayLargeText.primary40(String text) =>
+      DisplayLargeText(text, color: FamilyAppTheme.primary40);
+
+  factory DisplayLargeText.secondary20(String text) =>
+      DisplayLargeText(text, color: FamilyAppTheme.secondary20);
+
+  factory DisplayLargeText.secondary30(String text) =>
+      DisplayLargeText(text, color: FamilyAppTheme.secondary30);
+
+  factory DisplayLargeText.secondary40(String text) =>
+      DisplayLargeText(text, color: FamilyAppTheme.secondary40);
+
+  factory DisplayLargeText.tertiary20(String text) =>
+      DisplayLargeText(text, color: FamilyAppTheme.tertiary20);
+
+  factory DisplayLargeText.tertiary40(String text) =>
+      DisplayLargeText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.displayLarge.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/display_medium_text.dart
+++ b/lib/features/family/shared/widgets/texts/display_medium_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class DisplayMediumText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const DisplayMediumText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory DisplayMediumText.primary30(String text) =>
+      DisplayMediumText(text, color: FamilyAppTheme.primary30);
+
+  factory DisplayMediumText.primary40(String text) =>
+      DisplayMediumText(text, color: FamilyAppTheme.primary40);
+
+  factory DisplayMediumText.secondary20(String text) =>
+      DisplayMediumText(text, color: FamilyAppTheme.secondary20);
+
+  factory DisplayMediumText.secondary30(String text) =>
+      DisplayMediumText(text, color: FamilyAppTheme.secondary30);
+
+  factory DisplayMediumText.secondary40(String text) =>
+      DisplayMediumText(text, color: FamilyAppTheme.secondary40);
+
+  factory DisplayMediumText.tertiary20(String text) =>
+      DisplayMediumText(text, color: FamilyAppTheme.tertiary20);
+
+  factory DisplayMediumText.tertiary40(String text) =>
+      DisplayMediumText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.displayMedium.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/display_medium_text.dart
+++ b/lib/features/family/shared/widgets/texts/display_medium_text.dart
@@ -74,7 +74,7 @@ class DisplayMediumText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.displayMedium.copyWith(color: color),
+      style: Theme.of(context).textTheme.displayMedium?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/display_small_text.dart
+++ b/lib/features/family/shared/widgets/texts/display_small_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class DisplaySmallText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const DisplaySmallText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory DisplaySmallText.primary30(String text) =>
+      DisplaySmallText(text, color: FamilyAppTheme.primary30);
+
+  factory DisplaySmallText.primary40(String text) =>
+      DisplaySmallText(text, color: FamilyAppTheme.primary40);
+
+  factory DisplaySmallText.secondary20(String text) =>
+      DisplaySmallText(text, color: FamilyAppTheme.secondary20);
+
+  factory DisplaySmallText.secondary30(String text) =>
+      DisplaySmallText(text, color: FamilyAppTheme.secondary30);
+
+  factory DisplaySmallText.secondary40(String text) =>
+      DisplaySmallText(text, color: FamilyAppTheme.secondary40);
+
+  factory DisplaySmallText.tertiary20(String text) =>
+      DisplaySmallText(text, color: FamilyAppTheme.tertiary20);
+
+  factory DisplaySmallText.tertiary40(String text) =>
+      DisplaySmallText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.displaySmall.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/display_small_text.dart
+++ b/lib/features/family/shared/widgets/texts/display_small_text.dart
@@ -74,7 +74,7 @@ class DisplaySmallText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.displaySmall.copyWith(color: color),
+      style: Theme.of(context).textTheme.displaySmall?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/headline_large_text.dart
+++ b/lib/features/family/shared/widgets/texts/headline_large_text.dart
@@ -74,7 +74,7 @@ class HeadlineLargeText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.headlineLarge.copyWith(color: color),
+      style: Theme.of(context).textTheme.headlineLarge?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/headline_large_text.dart
+++ b/lib/features/family/shared/widgets/texts/headline_large_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class HeadlineLargeText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const HeadlineLargeText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory HeadlineLargeText.primary30(String text) =>
+      HeadlineLargeText(text, color: FamilyAppTheme.primary30);
+
+  factory HeadlineLargeText.primary40(String text) =>
+      HeadlineLargeText(text, color: FamilyAppTheme.primary40);
+
+  factory HeadlineLargeText.secondary20(String text) =>
+      HeadlineLargeText(text, color: FamilyAppTheme.secondary20);
+
+  factory HeadlineLargeText.secondary30(String text) =>
+      HeadlineLargeText(text, color: FamilyAppTheme.secondary30);
+
+  factory HeadlineLargeText.secondary40(String text) =>
+      HeadlineLargeText(text, color: FamilyAppTheme.secondary40);
+
+  factory HeadlineLargeText.tertiary20(String text) =>
+      HeadlineLargeText(text, color: FamilyAppTheme.tertiary20);
+
+  factory HeadlineLargeText.tertiary40(String text) =>
+      HeadlineLargeText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.headlineLarge.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/headline_medium_text.dart
+++ b/lib/features/family/shared/widgets/texts/headline_medium_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class HeadlineMediumText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const HeadlineMediumText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory HeadlineMediumText.primary30(String text) =>
+      HeadlineMediumText(text, color: FamilyAppTheme.primary30);
+
+  factory HeadlineMediumText.primary40(String text) =>
+      HeadlineMediumText(text, color: FamilyAppTheme.primary40);
+
+  factory HeadlineMediumText.secondary20(String text) =>
+      HeadlineMediumText(text, color: FamilyAppTheme.secondary20);
+
+  factory HeadlineMediumText.secondary30(String text) =>
+      HeadlineMediumText(text, color: FamilyAppTheme.secondary30);
+
+  factory HeadlineMediumText.secondary40(String text) =>
+      HeadlineMediumText(text, color: FamilyAppTheme.secondary40);
+
+  factory HeadlineMediumText.tertiary20(String text) =>
+      HeadlineMediumText(text, color: FamilyAppTheme.tertiary20);
+
+  factory HeadlineMediumText.tertiary40(String text) =>
+      HeadlineMediumText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.headlineMedium.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/headline_medium_text.dart
+++ b/lib/features/family/shared/widgets/texts/headline_medium_text.dart
@@ -74,7 +74,7 @@ class HeadlineMediumText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.headlineMedium.copyWith(color: color),
+      style: Theme.of(context).textTheme.headlineMedium?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/headline_small_text.dart
+++ b/lib/features/family/shared/widgets/texts/headline_small_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class HeadlineSmallText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const HeadlineSmallText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory HeadlineSmallText.primary30(String text) =>
+      HeadlineSmallText(text, color: FamilyAppTheme.primary30);
+
+  factory HeadlineSmallText.primary40(String text) =>
+      HeadlineSmallText(text, color: FamilyAppTheme.primary40);
+
+  factory HeadlineSmallText.secondary20(String text) =>
+      HeadlineSmallText(text, color: FamilyAppTheme.secondary20);
+
+  factory HeadlineSmallText.secondary30(String text) =>
+      HeadlineSmallText(text, color: FamilyAppTheme.secondary30);
+
+  factory HeadlineSmallText.secondary40(String text) =>
+      HeadlineSmallText(text, color: FamilyAppTheme.secondary40);
+
+  factory HeadlineSmallText.tertiary20(String text) =>
+      HeadlineSmallText(text, color: FamilyAppTheme.tertiary20);
+
+  factory HeadlineSmallText.tertiary40(String text) =>
+      HeadlineSmallText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.headlineSmall.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/headline_small_text.dart
+++ b/lib/features/family/shared/widgets/texts/headline_small_text.dart
@@ -74,7 +74,7 @@ class HeadlineSmallText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.headlineSmall.copyWith(color: color),
+      style: Theme.of(context).textTheme.headlineSmall?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/label_large_text.dart
+++ b/lib/features/family/shared/widgets/texts/label_large_text.dart
@@ -74,7 +74,7 @@ class LabelLargeText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.labelLarge.copyWith(color: color),
+      style: Theme.of(context).textTheme.labelLarge?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/label_large_text.dart
+++ b/lib/features/family/shared/widgets/texts/label_large_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class LabelLargeText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const LabelLargeText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory LabelLargeText.primary30(String text) =>
+      LabelLargeText(text, color: FamilyAppTheme.primary30);
+
+  factory LabelLargeText.primary40(String text) =>
+      LabelLargeText(text, color: FamilyAppTheme.primary40);
+
+  factory LabelLargeText.secondary20(String text) =>
+      LabelLargeText(text, color: FamilyAppTheme.secondary20);
+
+  factory LabelLargeText.secondary30(String text) =>
+      LabelLargeText(text, color: FamilyAppTheme.secondary30);
+
+  factory LabelLargeText.secondary40(String text) =>
+      LabelLargeText(text, color: FamilyAppTheme.secondary40);
+
+  factory LabelLargeText.tertiary20(String text) =>
+      LabelLargeText(text, color: FamilyAppTheme.tertiary20);
+
+  factory LabelLargeText.tertiary40(String text) =>
+      LabelLargeText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.labelLarge.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/label_medium_text.dart
+++ b/lib/features/family/shared/widgets/texts/label_medium_text.dart
@@ -74,7 +74,7 @@ class LabelMediumText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.labelMedium.copyWith(color: color),
+      style: Theme.of(context).textTheme.labelMedium?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/label_medium_text.dart
+++ b/lib/features/family/shared/widgets/texts/label_medium_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class LabelMediumText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const LabelMediumText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory LabelMediumText.primary30(String text) =>
+      LabelMediumText(text, color: FamilyAppTheme.primary30);
+
+  factory LabelMediumText.primary40(String text) =>
+      LabelMediumText(text, color: FamilyAppTheme.primary40);
+
+  factory LabelMediumText.secondary20(String text) =>
+      LabelMediumText(text, color: FamilyAppTheme.secondary20);
+
+  factory LabelMediumText.secondary30(String text) =>
+      LabelMediumText(text, color: FamilyAppTheme.secondary30);
+
+  factory LabelMediumText.secondary40(String text) =>
+      LabelMediumText(text, color: FamilyAppTheme.secondary40);
+
+  factory LabelMediumText.tertiary20(String text) =>
+      LabelMediumText(text, color: FamilyAppTheme.tertiary20);
+
+  factory LabelMediumText.tertiary40(String text) =>
+      LabelMediumText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.labelMedium.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/label_small_text.dart
+++ b/lib/features/family/shared/widgets/texts/label_small_text.dart
@@ -74,7 +74,7 @@ class LabelSmallText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.labelSmall.copyWith(color: color),
+      style: Theme.of(context).textTheme.labelSmall?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/label_small_text.dart
+++ b/lib/features/family/shared/widgets/texts/label_small_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class LabelSmallText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const LabelSmallText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory LabelSmallText.primary30(String text) =>
+      LabelSmallText(text, color: FamilyAppTheme.primary30);
+
+  factory LabelSmallText.primary40(String text) =>
+      LabelSmallText(text, color: FamilyAppTheme.primary40);
+
+  factory LabelSmallText.secondary20(String text) =>
+      LabelSmallText(text, color: FamilyAppTheme.secondary20);
+
+  factory LabelSmallText.secondary30(String text) =>
+      LabelSmallText(text, color: FamilyAppTheme.secondary30);
+
+  factory LabelSmallText.secondary40(String text) =>
+      LabelSmallText(text, color: FamilyAppTheme.secondary40);
+
+  factory LabelSmallText.tertiary20(String text) =>
+      LabelSmallText(text, color: FamilyAppTheme.tertiary20);
+
+  factory LabelSmallText.tertiary40(String text) =>
+      LabelSmallText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.labelSmall.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/shared_texts.dart
+++ b/lib/features/family/shared/widgets/texts/shared_texts.dart
@@ -1,0 +1,15 @@
+export 'package:givt_app/features/family/shared/widgets/texts/body_large_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/body_medium_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/body_small_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/display_large_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/display_medium_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/display_small_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/headline_large_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/headline_medium_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/headline_small_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/label_large_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/label_medium_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/label_small_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/title_large_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/title_medium_text.dart';
+export 'package:givt_app/features/family/shared/widgets/texts/title_small_text.dart';

--- a/lib/features/family/shared/widgets/texts/title_large_text.dart
+++ b/lib/features/family/shared/widgets/texts/title_large_text.dart
@@ -74,7 +74,7 @@ class TitleLargeText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.titleLarge.copyWith(color: color),
+      style: Theme.of(context).textTheme.titleLarge?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/title_large_text.dart
+++ b/lib/features/family/shared/widgets/texts/title_large_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class TitleLargeText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const TitleLargeText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory TitleLargeText.primary30(String text) =>
+      TitleLargeText(text, color: FamilyAppTheme.primary30);
+
+  factory TitleLargeText.primary40(String text) =>
+      TitleLargeText(text, color: FamilyAppTheme.primary40);
+
+  factory TitleLargeText.secondary20(String text) =>
+      TitleLargeText(text, color: FamilyAppTheme.secondary20);
+
+  factory TitleLargeText.secondary30(String text) =>
+      TitleLargeText(text, color: FamilyAppTheme.secondary30);
+
+  factory TitleLargeText.secondary40(String text) =>
+      TitleLargeText(text, color: FamilyAppTheme.secondary40);
+
+  factory TitleLargeText.tertiary20(String text) =>
+      TitleLargeText(text, color: FamilyAppTheme.tertiary20);
+
+  factory TitleLargeText.tertiary40(String text) =>
+      TitleLargeText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.titleLarge.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/title_medium_text.dart
+++ b/lib/features/family/shared/widgets/texts/title_medium_text.dart
@@ -74,7 +74,7 @@ class TitleMediumText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.titleMedium.copyWith(color: color),
+      style: Theme.of(context).textTheme.titleMedium?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/title_medium_text.dart
+++ b/lib/features/family/shared/widgets/texts/title_medium_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class TitleMediumText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const TitleMediumText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory TitleMediumText.primary30(String text) =>
+      TitleMediumText(text, color: FamilyAppTheme.primary30);
+
+  factory TitleMediumText.primary40(String text) =>
+      TitleMediumText(text, color: FamilyAppTheme.primary40);
+
+  factory TitleMediumText.secondary20(String text) =>
+      TitleMediumText(text, color: FamilyAppTheme.secondary20);
+
+  factory TitleMediumText.secondary30(String text) =>
+      TitleMediumText(text, color: FamilyAppTheme.secondary30);
+
+  factory TitleMediumText.secondary40(String text) =>
+      TitleMediumText(text, color: FamilyAppTheme.secondary40);
+
+  factory TitleMediumText.tertiary20(String text) =>
+      TitleMediumText(text, color: FamilyAppTheme.tertiary20);
+
+  factory TitleMediumText.tertiary40(String text) =>
+      TitleMediumText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.titleMedium.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/shared/widgets/texts/title_small_text.dart
+++ b/lib/features/family/shared/widgets/texts/title_small_text.dart
@@ -74,7 +74,7 @@ class TitleSmallText extends StatelessWidget {
       selectionColor: selectionColor,
       textWidthBasis: textWidthBasis,
       strutStyle: strutStyle,
-      style: FamilyTextStyles.titleSmall.copyWith(color: color),
+      style: Theme.of(context).textTheme.titleSmall?.copyWith(color: color),
     );
   }
 }

--- a/lib/features/family/shared/widgets/texts/title_small_text.dart
+++ b/lib/features/family/shared/widgets/texts/title_small_text.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
+import 'package:givt_app/features/family/utils/family_app_theme.dart';
+
+class TitleSmallText extends StatelessWidget {
+  // when color is not defined it will default to primary20
+  const TitleSmallText(
+    this.text, {
+    super.key,
+    this.color,
+    this.textAlign,
+    this.maxLines,
+    this.semanticsLabel,
+    this.overflow,
+    this.textDirection,
+    this.locale,
+    this.textHeightBehavior,
+    this.softWrap,
+    this.textScaler,
+    this.selectionColor,
+    this.textWidthBasis,
+    this.strutStyle,
+  });
+
+  factory TitleSmallText.primary30(String text) =>
+      TitleSmallText(text, color: FamilyAppTheme.primary30);
+
+  factory TitleSmallText.primary40(String text) =>
+      TitleSmallText(text, color: FamilyAppTheme.primary40);
+
+  factory TitleSmallText.secondary20(String text) =>
+      TitleSmallText(text, color: FamilyAppTheme.secondary20);
+
+  factory TitleSmallText.secondary30(String text) =>
+      TitleSmallText(text, color: FamilyAppTheme.secondary30);
+
+  factory TitleSmallText.secondary40(String text) =>
+      TitleSmallText(text, color: FamilyAppTheme.secondary40);
+
+  factory TitleSmallText.tertiary20(String text) =>
+      TitleSmallText(text, color: FamilyAppTheme.tertiary20);
+
+  factory TitleSmallText.tertiary40(String text) =>
+      TitleSmallText(text, color: FamilyAppTheme.tertiary40);
+
+  final String text;
+  final Color? color;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final String? semanticsLabel;
+  final TextOverflow? overflow;
+  final TextDirection? textDirection;
+  final Locale? locale;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool? softWrap;
+  final TextScaler? textScaler;
+  final Color? selectionColor;
+  final TextWidthBasis? textWidthBasis;
+  final StrutStyle? strutStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      overflow: overflow,
+      textDirection: textDirection,
+      locale: locale,
+      textHeightBehavior: textHeightBehavior,
+      softWrap: softWrap,
+      textScaler: textScaler,
+      selectionColor: selectionColor,
+      textWidthBasis: textWidthBasis,
+      strutStyle: strutStyle,
+      style: FamilyTextStyles.titleSmall.copyWith(color: color),
+    );
+  }
+}

--- a/lib/features/family/utils/family_app_theme.dart
+++ b/lib/features/family/utils/family_app_theme.dart
@@ -16,6 +16,7 @@ class FamilyAppTheme extends ThemeExtension<FamilyAppTheme> {
 
 // extra colors within pallette
   static const primary20 = Color(0xFF003920);
+  static const primary30 = Color(0xFF005231);
   static const primary40 = Color(0xFF006D42);
   static const primary50 = Color(0xFF008954);
   static const primary60 = Color(0xFF15A569);
@@ -25,6 +26,7 @@ class FamilyAppTheme extends ThemeExtension<FamilyAppTheme> {
   static const primary90 = Color(0xFF6BFCAB);
   static const primary98 = Color(0xFFE9FFED);
 
+  static const secondary20 = Color(0xFF003737);
   static const secondary30 = Color(0xFF004F50);
   static const secondary40 = Color(0xFF00696A);
   static const secondary80 = Color(0xFF4CDADB);
@@ -32,6 +34,7 @@ class FamilyAppTheme extends ThemeExtension<FamilyAppTheme> {
   static const secondary98 = Color(0xFFE2FFFE);
   static const secondary99 = Color(0xFFF1FFFE);
 
+  static const tertiary20 = Color(0xFF431573);
   static const tertiary40 = Color(0xFF744AA5);
   static const tertiary50 = Color(0xFF8E63C0);
   static const tertiary80 = Color(0xFFDAB9FF);

--- a/lib/features/family/utils/family_app_theme.dart
+++ b/lib/features/family/utils/family_app_theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:givt_app/features/family/shared/design/family_text_styles.dart';
 import 'package:material_color_utilities/material_color_utilities.dart';
 
 @immutable
@@ -135,72 +136,21 @@ class FamilyAppTheme extends ThemeExtension<FamilyAppTheme> {
 
   ThemeData _base(ColorScheme colorScheme) {
     const textTheme = TextTheme(
-      titleLarge: TextStyle(
-        color: FamilyAppTheme.defaultTextColor,
-        fontSize: 26,
-        fontWeight: FontWeight.w700,
-        letterSpacing: 0,
-        height: 1.2,
-      ),
-      titleMedium: TextStyle(
-        color: FamilyAppTheme.defaultTextColor,
-        fontSize: 22,
-        fontWeight: FontWeight.w700,
-        letterSpacing: 0,
-        height: 1.2,
-      ),
-      titleSmall: TextStyle(
-        color: FamilyAppTheme.defaultTextColor,
-        fontSize: 18,
-        fontWeight: FontWeight.w700,
-        letterSpacing: 0,
-        height: 1.2,
-      ),
-      headlineMedium: TextStyle(
-        color: FamilyAppTheme.defaultTextColor,
-        fontSize: 30,
-        fontWeight: FontWeight.w700,
-        letterSpacing: 0,
-        height: 1.2,
-      ),
-      headlineLarge: TextStyle(
-        color: FamilyAppTheme.defaultTextColor,
-        fontSize: 45,
-        fontWeight: FontWeight.w700,
-        letterSpacing: 0,
-        height: 1.2,
-      ),
-      labelSmall: TextStyle(
-        color: FamilyAppTheme.defaultTextColor,
-        fontSize: 16,
-        fontWeight: FontWeight.w700,
-        letterSpacing: 0,
-        height: 1,
-      ),
-      labelMedium: TextStyle(
-        color: FamilyAppTheme.defaultTextColor,
-        fontSize: 20,
-        fontWeight: FontWeight.w700,
-        letterSpacing: 0,
-      ),
-      labelLarge: TextStyle(
-        color: FamilyAppTheme.defaultTextColor,
-        fontSize: 20,
-        fontWeight: FontWeight.w700,
-        letterSpacing: 0,
-      ),
-      bodySmall: TextStyle(
-        color: FamilyAppTheme.defaultTextColor,
-        fontSize: 15,
-        fontWeight: FontWeight.w400,
-        letterSpacing: 0,
-      ),
-      bodyMedium: TextStyle(
-        color: FamilyAppTheme.defaultTextColor,
-        fontSize: 18,
-        fontWeight: FontWeight.w500,
-        letterSpacing: 0,
-      ),
+      displayLarge: FamilyTextStyles.displayLarge,
+      displayMedium: FamilyTextStyles.displayMedium,
+      displaySmall: FamilyTextStyles.displaySmall,
+      titleLarge: FamilyTextStyles.titleLarge,
+      titleMedium: FamilyTextStyles.titleMedium,
+      titleSmall: FamilyTextStyles.titleSmall,
+      headlineSmall: FamilyTextStyles.headlineSmall,
+      headlineMedium: FamilyTextStyles.headlineMedium,
+      headlineLarge: FamilyTextStyles.headlineLarge,
+      labelSmall: FamilyTextStyles.labelSmall,
+      labelMedium: FamilyTextStyles.labelMedium,
+      labelLarge: FamilyTextStyles.labelLarge,
+      bodySmall: FamilyTextStyles.bodySmall,
+      bodyMedium: FamilyTextStyles.bodyMedium,
+      bodyLarge: FamilyTextStyles.bodyLarge,
     );
 
     return ThemeData(

--- a/lib/shared/widgets/buttons/givt_elevated_button.dart
+++ b/lib/shared/widgets/buttons/givt_elevated_button.dart
@@ -85,12 +85,12 @@ class GivtElevatedButton extends StatelessWidget {
             text,
             textAlign: TextAlign.center,
             style: isDisabled == true
-                ? themeData.textTheme.labelMedium?.copyWith(
+                ? themeData.textTheme.labelLarge?.copyWith(
                     color: themeData.colorScheme.outline,
                     fontWeight: FontWeight.w700,
                     fontFamily: 'Rouna',
                   )
-                : themeData.textTheme.labelMedium?.copyWith(
+                : themeData.textTheme.labelLarge?.copyWith(
                     color: borderColor,
                     fontWeight: FontWeight.w700,
                     fontFamily: 'Rouna',
@@ -108,12 +108,12 @@ class GivtElevatedButton extends StatelessWidget {
             text,
             textAlign: TextAlign.center,
             style: isDisabled == true
-                ? themeData.textTheme.labelMedium?.copyWith(
+                ? themeData.textTheme.labelLarge?.copyWith(
                     color: themeData.colorScheme.outline,
                     fontWeight: FontWeight.w700,
                     fontFamily: 'Rouna',
                   )
-                : themeData.textTheme.labelMedium?.copyWith(
+                : themeData.textTheme.labelLarge?.copyWith(
                     color: borderColor,
                     fontWeight: FontWeight.w700,
                     fontFamily: 'Rouna',
@@ -142,12 +142,12 @@ class GivtElevatedButton extends StatelessWidget {
               text,
               textAlign: TextAlign.center,
               style: isDisabled == true
-                  ? themeData.textTheme.labelMedium?.copyWith(
+                  ? themeData.textTheme.labelLarge?.copyWith(
                       color: themeData.colorScheme.outline,
                       fontWeight: FontWeight.w700,
                       fontFamily: 'Rouna',
                     )
-                  : themeData.textTheme.labelMedium?.copyWith(
+                  : themeData.textTheme.labelLarge?.copyWith(
                       color: borderColor,
                       fontWeight: FontWeight.w700,
                       fontFamily: 'Rouna',
@@ -165,12 +165,12 @@ class GivtElevatedButton extends StatelessWidget {
         text,
         textAlign: TextAlign.center,
         style: isDisabled == true
-            ? themeData.textTheme.labelMedium?.copyWith(
+            ? themeData.textTheme.labelLarge?.copyWith(
                 color: themeData.colorScheme.outline,
                 fontWeight: FontWeight.w700,
                 fontFamily: 'Rouna',
               )
-            : themeData.textTheme.labelMedium?.copyWith(
+            : themeData.textTheme.labelLarge?.copyWith(
                 color: borderColor,
                 fontWeight: FontWeight.w700,
                 fontFamily: 'Rouna',

--- a/lib/shared/widgets/buttons/givt_elevated_secondary_button.dart
+++ b/lib/shared/widgets/buttons/givt_elevated_secondary_button.dart
@@ -143,12 +143,12 @@ class _GivtElevatedSecondaryButtonState
           Text(
             widget.text,
             style: widget.isDisabled
-                ? theme.textTheme.labelMedium?.copyWith(
+                ? theme.textTheme.labelLarge?.copyWith(
                     color: theme.colorScheme.outline,
                     fontWeight: FontWeight.w700,
                     fontFamily: 'Rouna',
                   )
-                : theme.textTheme.labelMedium?.copyWith(
+                : theme.textTheme.labelLarge?.copyWith(
                     color: AppTheme.primary30,
                     fontWeight: FontWeight.w700,
                     fontFamily: 'Rouna',
@@ -165,12 +165,12 @@ class _GivtElevatedSecondaryButtonState
           Text(
             widget.text,
             style: widget.isDisabled
-                ? theme.textTheme.labelMedium?.copyWith(
+                ? theme.textTheme.labelLarge?.copyWith(
                     color: theme.colorScheme.outline,
                     fontWeight: FontWeight.w700,
                     fontFamily: 'Rouna',
                   )
-                : theme.textTheme.labelMedium?.copyWith(
+                : theme.textTheme.labelLarge?.copyWith(
                     color: AppTheme.primary30,
                     fontWeight: FontWeight.w700,
                     fontFamily: 'Rouna',
@@ -194,12 +194,12 @@ class _GivtElevatedSecondaryButtonState
             Text(
               widget.text,
               style: widget.isDisabled
-                  ? theme.textTheme.labelMedium?.copyWith(
+                  ? theme.textTheme.labelLarge?.copyWith(
                       color: theme.colorScheme.outline,
                       fontWeight: FontWeight.w700,
                       fontFamily: 'Rouna',
                     )
-                  : theme.textTheme.labelMedium?.copyWith(
+                  : theme.textTheme.labelLarge?.copyWith(
                       color: AppTheme.primary30,
                       fontWeight: FontWeight.w700,
                       fontFamily: 'Rouna',
@@ -216,12 +216,12 @@ class _GivtElevatedSecondaryButtonState
       child: Text(
         widget.text,
         style: widget.isDisabled
-            ? theme.textTheme.labelMedium?.copyWith(
+            ? theme.textTheme.labelLarge?.copyWith(
                 color: theme.colorScheme.outline,
                 fontWeight: FontWeight.w700,
                 fontFamily: 'Rouna',
               )
-            : theme.textTheme.labelMedium?.copyWith(
+            : theme.textTheme.labelLarge?.copyWith(
                 color: AppTheme.primary30,
                 fontWeight: FontWeight.w700,
                 fontFamily: 'Rouna',


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
https://linear.app/givt/issue/KIDS-1217/create-text-styles-in-1-place
https://linear.app/givt/issue/KIDS-1200/implement-text-style-components

In the future I can use the text styles of the context theme but right now that's not possible because there's a discrepancy between the currently defined styles and names (and we don't want to change all previously defined widgets).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced customizable text widgets for various sizes and styles, improving design consistency and flexibility across the app.
	- Added new color constants to the app's theme for enhanced visual customization.
- **Documentation**
	- Added a shared module to streamline access to the new text components across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->