### PR TITLE
Bug: Manage family screen is not updated after topup (KIDS-1306)

### DIFF
--- a/lib/features/family/features/profiles/repository/profiles_repository.dart
+++ b/lib/features/family/features/profiles/repository/profiles_repository.dart
@@ -130,6 +130,7 @@ class ProfilesRepositoryImpl with ProfilesRepository {
   }
 
   Future<Profile> _fetchChildDetails(String childGuid) async {
+    unawaited(_fetchProfiles());
     final response = await _apiService.fetchChildDetails(childGuid);
     response['type'] = 'Child';
     final profile = Profile.fromMap(response);


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
When refetching a child we should also refetch all the profiles.