### PR TITLE
Fix layout issue with bottomsheets without close bottom

### DIFF
--- a/lib/features/family/shared/widgets/layout/givt_bottom_sheet.dart
+++ b/lib/features/family/shared/widgets/layout/givt_bottom_sheet.dart
@@ -74,11 +74,13 @@ class GivtBottomSheet extends StatelessWidget {
   }
 
   Widget showCloseButton() {
-    if (closeAction == null) return const SizedBox.shrink();
-
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
+        if(closeAction == null)
+        const SizedBox(height: 24),
+
+        if(closeAction != null)
         IconButton(
           icon: const FaIcon(FontAwesomeIcons.xmark),
           onPressed: () {


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the layout of the close button in the `GivtBottomSheet`, ensuring consistent appearance even when no close action is available.
	- Enhanced user interface by providing visual feedback through a designated space when the close action is not present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->