### PR TITLE
Fix: If new member is child, fetch profile  again after 1 sec (kids-1314)

### DIFF
--- a/lib/features/children/add_member/repository/add_member_repository.dart
+++ b/lib/features/children/add_member/repository/add_member_repository.dart
@@ -20,24 +20,16 @@ class AddMemberRepositoryImpl with AddMemberRepository {
   @override
   Future<void> addMembers(List<Member> members, {required bool isRGA}) async {
     final profilesJsonList = members.map((member) => member.toJson()).toList();
-    final hasChild = members.any((member) => member.isChild);
     final body = {
       'profiles': profilesJsonList,
       'allowanceType': isRGA ? 0 : 1,
     };
 
     await apiService.addMember(body);
-    _memberAddedStreamController.add(null);
 
-    if (hasChild) {
-      _addMemberEventAfterOneSecond();
-    }
-  }
-
-  // The reason we are adding this event to the stream is
-  // because money-related calls require an update from Stripe for the BE
-  // which takes a bit of time
-  void _addMemberEventAfterOneSecond() {
+    // We add this event to the stream delayed
+    // because money-related calls require an update from Stripe for the BE
+    // which takes a bit of time
     Future.delayed(const Duration(seconds: 1), () {
       _memberAddedStreamController.add(null);
     });

--- a/lib/features/children/add_member/repository/add_member_repository.dart
+++ b/lib/features/children/add_member/repository/add_member_repository.dart
@@ -20,6 +20,7 @@ class AddMemberRepositoryImpl with AddMemberRepository {
   @override
   Future<void> addMembers(List<Member> members, {required bool isRGA}) async {
     final profilesJsonList = members.map((member) => member.toJson()).toList();
+    final hasChild = members.any((member) => member.isChild);
     final body = {
       'profiles': profilesJsonList,
       'allowanceType': isRGA ? 0 : 1,
@@ -27,6 +28,19 @@ class AddMemberRepositoryImpl with AddMemberRepository {
 
     await apiService.addMember(body);
     _memberAddedStreamController.add(null);
+
+    if (hasChild) {
+      _addMemberEventAfterOneSecond();
+    }
+  }
+
+  // The reason we are adding this event to the stream is
+  // because money-related calls require an update from Stripe for the BE
+  // which takes a bit of time
+  void _addMemberEventAfterOneSecond() {
+    Future.delayed(const Duration(seconds: 1), () {
+      _memberAddedStreamController.add(null);
+    });
   }
 
   @override


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced functionality for adding members, specifically for scenarios involving children, with a delayed event handling mechanism for improved responsiveness.
  
- **Bug Fixes**
	- Improved the flow of events after member additions, addressing potential delays in external service updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->