### PR TITLE
Fix typo in title US registration (KIDS-1316)

### DIFF
--- a/lib/features/registration/pages/us_signup_page.dart
+++ b/lib/features/registration/pages/us_signup_page.dart
@@ -83,7 +83,7 @@ class _UsSignUpPageState extends State<UsSignUpPage> {
                 FamilyPages.generosityChallengeRedirect.name,
               ),
             ),
-            title: 'Enter you details',
+            title: 'Enter your details',
             actions: [
               IconButton(
                 onPressed: () => showModalBottomSheet<void>(


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a grammatical error in the signup page title for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->