### PR TITLE
Always logout when going back from registration (KIDS-1360)

### DIFF
--- a/lib/features/registration/pages/us_signup_page.dart
+++ b/lib/features/registration/pages/us_signup_page.dart
@@ -83,7 +83,7 @@ class _UsSignUpPageState extends State<UsSignUpPage> {
           appBar: GenerosityAppBar(
             leading: GenerosityBackButton(
                     onPressed: () {
-                      logout(context);
+                      logout(context, fromLogoutBtn: true);
                     },
                   ),
             title: 'Enter your details',

--- a/lib/features/registration/pages/us_signup_page.dart
+++ b/lib/features/registration/pages/us_signup_page.dart
@@ -9,6 +9,7 @@ import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/features/children/generosity_challenge/widgets/generosity_app_bar.dart';
 import 'package:givt_app/features/children/generosity_challenge/widgets/generosity_back_button.dart';
 import 'package:givt_app/features/family/app/family_pages.dart';
+import 'package:givt_app/features/family/features/auth/helpers/logout_helper.dart';
 import 'package:givt_app/features/family/shared/widgets/loading/custom_progress_indicator.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
 import 'package:givt_app/features/registration/bloc/registration_bloc.dart';
@@ -80,13 +81,11 @@ class _UsSignUpPageState extends State<UsSignUpPage> {
 
         return FamilyScaffold(
           appBar: GenerosityAppBar(
-            leading: context.canPop()
-                ? GenerosityBackButton(
+            leading: GenerosityBackButton(
                     onPressed: () {
-                      context.pop();
+                      logout(context);
                     },
-                  )
-                : null,
+                  ),
             title: 'Enter your details',
             actions: [
               IconButton(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The signup page now includes a `GenerosityBackButton` that always appears, allowing users to log out instead of navigating back.
  
- **User Experience Changes**
	- The back navigation functionality has been replaced with a logout action, altering how users interact with the signup page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->