### PR TITLE
Fix: Set up family form layout, btn text, and go directly to counter page (kids-1215)

### DIFF
--- a/lib/features/children/add_member/pages/family_member_form_page.dart
+++ b/lib/features/children/add_member/pages/family_member_form_page.dart
@@ -13,6 +13,7 @@ import 'package:givt_app/features/children/generosity_challenge/widgets/generosi
 import 'package:givt_app/features/children/shared/profile_type.dart';
 import 'package:givt_app/features/family/extensions/extensions.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
+import 'package:givt_app/features/family/utils/utils.dart';
 import 'package:givt_app/shared/widgets/fun_scaffold.dart';
 import 'package:givt_app/utils/analytics_helper.dart';
 import 'package:givt_app/utils/utils.dart';
@@ -112,44 +113,42 @@ class _FamilyMemberFormPageState extends State<FamilyMemberFormPage> {
           title: 'Set up Family',
           leading: const GenerosityBackButton(),
         ),
-        body: Center(
-          child: SingleChildScrollView(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                SmileyCounter(
-                  totalCount: widget.totalCount,
-                  index: widget.index,
-                ),
-                ChildOrParentSelector(
-                  selections: selections,
-                  onPressed: (int index) {
-                    setState(() {
-                      selections = [index == 0, index == 1];
-                    });
-                  },
-                ),
-                const SizedBox(height: 16),
-                FamilyMemberForm(
-                  formKey: _formKey,
-                  nameController: _nameController,
-                  emailController: _emailController,
-                  ageController: _ageController,
-                  allowanceAmount: _amount,
-                  onAmountChanged: (amount) {
-                    setState(() {
-                      _amount = amount;
-                    });
-                  },
-                  isChildSelected: isChildSelected,
-                ),
-                const SizedBox(height: 40),
-                if (keyboardIsVisible && isLast)
-                  _primaryButton(isChildSelected)
-                else if (keyboardIsVisible)
-                  _secondaryButton(isChildSelected),
-              ],
-            ),
+        body: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SmileyCounter(
+                totalCount: widget.totalCount,
+                index: widget.index,
+              ),
+              ChildOrParentSelector(
+                selections: selections,
+                onPressed: (int index) {
+                  setState(() {
+                    selections = [index == 0, index == 1];
+                  });
+                },
+              ),
+              const SizedBox(height: 16),
+              FamilyMemberForm(
+                formKey: _formKey,
+                nameController: _nameController,
+                emailController: _emailController,
+                ageController: _ageController,
+                allowanceAmount: _amount,
+                onAmountChanged: (amount) {
+                  setState(() {
+                    _amount = amount;
+                  });
+                },
+                isChildSelected: isChildSelected,
+              ),
+              const SizedBox(height: 40),
+              if (keyboardIsVisible && isLast)
+                _primaryButton(isChildSelected)
+              else if (keyboardIsVisible)
+                _secondaryButton(isChildSelected),
+            ],
           ),
         ),
         floatingActionButton: keyboardIsVisible
@@ -184,8 +183,11 @@ class _FamilyMemberFormPageState extends State<FamilyMemberFormPage> {
           );
         }
       },
-      text: 'Continue',
-      rightIcon: const Icon(FontAwesomeIcons.arrowRight),
+      text: 'Add next member',
+      rightIcon: const Icon(
+        FontAwesomeIcons.arrowRight,
+        color: FamilyAppTheme.defaultTextColor,
+      ),
     );
   }
 }

--- a/lib/features/children/overview/pages/family_overview_page.dart
+++ b/lib/features/children/overview/pages/family_overview_page.dart
@@ -5,14 +5,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:givt_app/core/enums/amplitude_events.dart';
-import 'package:givt_app/features/children/add_member/pages/add_member_counter_page.dart';
-import 'package:givt_app/features/children/add_member/pages/family_member_form_page.dart';
 import 'package:givt_app/features/children/overview/cubit/family_overview_cubit.dart';
 import 'package:givt_app/features/children/overview/widgets/allowance_warning_dialog.dart';
 import 'package:givt_app/features/children/overview/widgets/children_loading_page.dart';
 import 'package:givt_app/features/children/overview/widgets/family_available_page.dart';
 import 'package:givt_app/features/children/overview/widgets/no_children_page.dart';
-import 'package:givt_app/features/family/extensions/extensions.dart';
+import 'package:givt_app/features/children/utils/add_member_util.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/shared/widgets/buttons/leading_back_button.dart';
 import 'package:givt_app/shared/widgets/fun_scaffold.dart';
@@ -105,30 +103,6 @@ class FamilyOverviewPage extends StatelessWidget {
         eventName: AmplitudeEvents.addMemerClicked,
       ),
     );
-
-    final dynamic result = await Navigator.push(
-      context,
-      const AddMemberCounterPage(
-        initialAmount: 1,
-      ).toRoute(context),
-    );
-    if (result != null && result is int && context.mounted) {
-      unawaited(
-        AnalyticsHelper.logEvent(
-          eventName: AmplitudeEvents.numberOfMembersSelected,
-          eventProperties: {
-            'nrOfMembers': result,
-          },
-        ),
-      );
-      await Navigator.push(
-        context,
-        FamilyMemberFormPage(
-          index: 1,
-          totalCount: result,
-          membersToCombine: [],
-        ).toRoute(context),
-      );
-    }
+    await AddMemberUtil.addMemberPushPages(context);
   }
 }

--- a/lib/features/children/utils/add_member_util.dart
+++ b/lib/features/children/utils/add_member_util.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:givt_app/core/enums/amplitude_events.dart';
+import 'package:givt_app/features/children/add_member/pages/add_member_counter_page.dart';
+import 'package:givt_app/features/children/add_member/pages/family_member_form_page.dart';
+import 'package:givt_app/shared/widgets/extensions/route_extensions.dart';
+import 'package:givt_app/utils/analytics_helper.dart';
+
+class AddMemberUtil {
+  static Future<void> addMemberPushPages(BuildContext context) async {
+    final dynamic result = await Navigator.push(
+      context,
+      const AddMemberCounterPage(
+        initialAmount: 1,
+      ).toRoute(context),
+    );
+    if (result != null && result is int && context.mounted) {
+      unawaited(
+        AnalyticsHelper.logEvent(
+          eventName: AmplitudeEvents.numberOfMembersSelected,
+          eventProperties: {
+            'nrOfMembers': result,
+          },
+        ),
+      );
+      await Navigator.push(
+        context,
+        FamilyMemberFormPage(
+          index: 1,
+          totalCount: result,
+          membersToCombine: [],
+        ).toRoute(context),
+      );
+    }
+  }
+}

--- a/lib/features/family/features/profiles/screens/profile_selection_screen.dart
+++ b/lib/features/family/features/profiles/screens/profile_selection_screen.dart
@@ -12,6 +12,7 @@ import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/features/children/add_member/models/member.dart';
 import 'package:givt_app/features/children/add_member/pages/failed_vpc_bottomsheet.dart';
 import 'package:givt_app/features/children/shared/profile_type.dart';
+import 'package:givt_app/features/children/utils/add_member_util.dart';
 import 'package:givt_app/features/family/app/family_pages.dart';
 import 'package:givt_app/features/family/features/flows/cubit/flow_type.dart';
 import 'package:givt_app/features/family/features/flows/cubit/flows_cubit.dart';
@@ -96,7 +97,7 @@ class _ProfileSelectionScreenState extends State<ProfileSelectionScreen> {
           if (state.cachedMembers.isNotEmpty) {
             showCachedMembersBottomsheet(state);
           } else {
-            await context.pushNamed(FamilyPages.childrenOverview.name);
+            await AddMemberUtil.addMemberPushPages(context);
           }
         }
       },

--- a/lib/features/family/shared/design/components/actions/fun_secondary_button.dart
+++ b/lib/features/family/shared/design/components/actions/fun_secondary_button.dart
@@ -32,12 +32,10 @@ class FunSecondaryButton extends StatefulWidget {
   final AmplitudeEvents? amplitudeEvent;
 
   @override
-  State<FunSecondaryButton> createState() =>
-      _FunSecondaryButtonState();
+  State<FunSecondaryButton> createState() => _FunSecondaryButtonState();
 }
 
-class _FunSecondaryButtonState
-    extends State<FunSecondaryButton> {
+class _FunSecondaryButtonState extends State<FunSecondaryButton> {
   double dropShadowHeight = 4;
   double paddingtop = 4;
   bool isPressed = false;
@@ -179,7 +177,7 @@ class _FunSecondaryButtonState
           ),
           Padding(
             padding: const EdgeInsets.only(left: 8),
-            child: widget.leftIcon,
+            child: widget.rightIcon,
           ),
         ],
       );

--- a/lib/features/registration/pages/registration_success_us.dart
+++ b/lib/features/registration/pages/registration_success_us.dart
@@ -28,7 +28,6 @@ class RegistrationSuccessUs extends StatelessWidget {
         child: FunScaffold(
           appBar: FunTopAppBar.primary99(
             title: 'Registration complete',
-            leading: null,
           ),
           body: Center(
             child: Column(


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `FamilyMemberFormPage` for improved user experience with clearer button text and updated visuals.
	- Introduced a utility class for streamlined navigation between family member management pages.
  
- **Bug Fixes**
	- Improved navigation flow in the `ProfileSelectionScreen` when no cached members are available.

- **Style**
	- Minor formatting adjustments in the `FunSecondaryButton` for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->