### PR TITLE
Show max 9 kids (KIDS-1347)

### DIFF
--- a/lib/features/family/features/reflect/presentation/pages/family_roles_screen.dart
+++ b/lib/features/family/features/reflect/presentation/pages/family_roles_screen.dart
@@ -54,7 +54,7 @@ class _FamilyRolesScreenState extends State<FamilyRolesScreen> {
                       childAspectRatio: 0.9,
                       crossAxisCount: 3,
                       children: createGridItems(
-                        profiles.take(6).toList(),
+                        profiles.take(9).toList(),
                       ),
                     ),
                   ),


### PR DESCRIPTION
## Description
<!--- Describe your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased the number of profiles displayed in the grid view from 6 to 9, enhancing the visual representation of profiles on the Family Roles screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->