### PR TITLE
Only show reflect and share button when having more then 3 members (KIDS)

### DIFF
--- a/lib/features/family/features/profiles/screens/profile_selection_screen.dart
+++ b/lib/features/family/features/profiles/screens/profile_selection_screen.dart
@@ -163,13 +163,16 @@ class _ProfileSelectionScreenState extends State<ProfileSelectionScreen> {
                                 ),
                               ),
                             const SizedBox(height: 8),
-                            FunButton(
+                            if (state.profiles.length >= 3) ...[
+                              FunButton(
                                 isTertiary: true,
                                 onTap: () => context.goNamed(
-                                      FamilyPages.reflectIntro.name,
-                                    ),
-                                text: 'Reflect & Share'),
-                            const SizedBox(height: 8),
+                                  FamilyPages.reflectIntro.name,
+                                ),
+                                text: 'Reflect & Share',
+                              ),
+                              const SizedBox(height: 8),
+                            ],
                             FunSecondaryButton(
                               onTap: () async {
                                 if (!context.mounted) return;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The visibility of the FunButton has been enhanced; it now only appears when there are three or more profiles available, improving the user experience.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->