### PR TITLE
Add age to member created event (KIDS-1392)

### DIFF
--- a/lib/features/children/add_member/cubit/add_member_cubit.dart
+++ b/lib/features/children/add_member/cubit/add_member_cubit.dart
@@ -29,6 +29,7 @@ class AddMemberCubit extends Cubit<AddMemberState> {
     );
     final members = state.members;
     final memberNames = members.map((member) => member.firstName).toList();
+    final memberAges = members.map((member) => member.age).toList();
 
     emit(state.copyWith(status: AddMemberStateStatus.loading));
 
@@ -42,6 +43,7 @@ class AddMemberCubit extends Cubit<AddMemberState> {
           eventProperties: {
             'nrOfMembers': members.length,
             'memberNames': memberNames,
+            'memberAges': memberAges,
           },
         ),
       );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to capture and process member ages alongside their names, enhancing data tracking and potential analytics.
  
- **Bug Fixes**
	- Improved event properties emitted during state updates to include the new member ages list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->