### PR TITLE
Don't start bluetooth scan, should go automatically when turned on (KIDS-1353)

### DIFF
--- a/lib/features/give/pages/bt_scan_page.dart
+++ b/lib/features/give/pages/bt_scan_page.dart
@@ -80,7 +80,7 @@ class _BTScanPageState extends State<BTScanPage> {
             }
           case BluetoothAdapterState.unauthorized:
             LoggingInfo.instance.info('Bluetooth adapter is unauthorized');
-            if (!context.mounted) {
+            if (!mounted) {
               return;
             }
             await showDialog<void>(
@@ -90,7 +90,6 @@ class _BTScanPageState extends State<BTScanPage> {
                 content:
                     '''${context.l10n.authoriseBluetoothErrorMessage}\n ${context.l10n.authoriseBluetoothExtraText}''',
                 onConfirm: () async {
-                  await startBluetoothScan();
                   if (!context.mounted) {
                     return;
                   }
@@ -135,6 +134,9 @@ class _BTScanPageState extends State<BTScanPage> {
     } catch (e) {
       LoggingInfo.instance
           .error('Error in BT scan page: $e', methodName: 'initBluetooth');
+      if (!mounted) {
+        return;
+      }
       Navigator.of(context).pop();
     }
   }

--- a/lib/features/give/pages/bt_scan_page.dart
+++ b/lib/features/give/pages/bt_scan_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -27,6 +28,9 @@ class _BTScanPageState extends State<BTScanPage> {
   bool isVisible = false;
   bool isSearching = false;
 
+  StreamSubscription<List<ScanResult>>? adapterStateStream;
+  StreamSubscription<BluetoothAdapterState>? scanResultsStream;
+
   // Every 30 seconds we will restart the scan for new devices
   final scanTimeout = 30;
 
@@ -55,7 +59,7 @@ class _BTScanPageState extends State<BTScanPage> {
       }
 
       // Set listen method for scan results
-      FlutterBluePlus.scanResults.listen(
+      adapterStateStream = FlutterBluePlus.scanResults.listen(
         _onPeripheralsDetectedData,
         onError: (dynamic e) {
           LoggingInfo.instance
@@ -71,7 +75,8 @@ class _BTScanPageState extends State<BTScanPage> {
       });
 
       // Listen to scan mode changes
-      FlutterBluePlus.adapterState.listen((BluetoothAdapterState state) async {
+      scanResultsStream = FlutterBluePlus.adapterState
+          .listen((BluetoothAdapterState state) async {
         switch (state) {
           case BluetoothAdapterState.on:
             if (!FlutterBluePlus.isScanningNow) {
@@ -220,8 +225,11 @@ class _BTScanPageState extends State<BTScanPage> {
 
   @override
   void dispose() {
-    super.dispose();
     FlutterBluePlus.stopScan();
+    adapterStateStream?.cancel();
+    scanResultsStream?.cancel();
+
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved error handling in the Bluetooth scanning process to prevent exceptions when the widget is unmounted.

- **Refactor**
	- Streamlined state management by simplifying checks for the widget's mounted state, enhancing code readability and clarity.
	- Centralized subscription logic for scan results and adapter state changes, improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->