### PR TITLE
fix word minutes

### DIFF
--- a/lib/features/family/features/reflect/presentation/pages/summary_screen.dart
+++ b/lib/features/family/features/reflect/presentation/pages/summary_screen.dart
@@ -53,8 +53,9 @@ class _SummaryScreenState extends State<SummaryScreen> {
                 children: [
                   Expanded(
                     child: FunTile.gold(
-                      titleBig:
-                          '${secretWord.minutesPlayed} minutes family time',
+                      titleBig: secretWord.minutesPlayed == 1
+                          ? '1 minute family time'
+                          : '${secretWord.minutesPlayed} minutes family time',
                       iconData: FontAwesomeIcons.solidClock,
                       assetSize: 32,
                     ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved display of family time minutes with correct singular/plural formatting.
	- Now shows "1 minute family time" for one minute and pluralized format for multiple minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->