### PR TITLE
Fix: Play Gratitude game multiple times (kids-1431)

### DIFF
--- a/lib/features/family/app/injection.dart
+++ b/lib/features/family/app/injection.dart
@@ -45,12 +45,12 @@ Future<void> initAPIService() async {
 void initCubits() {
   getIt
     ..registerFactory(() => AdminFeeCubit(getIt()))
-    ..registerLazySingleton(() => GratefulCubit(getIt(), getIt()))
+    ..registerFactory(() => GratefulCubit(getIt(), getIt()))
     ..registerLazySingleton<InterviewCubit>(
       () => InterviewCubit(getIt()),
     )
     ..registerLazySingleton<GratitudeSelectionCubit>(
-          () => GratitudeSelectionCubit(getIt()),
+      () => GratitudeSelectionCubit(getIt()),
     )
     ..registerLazySingleton<CameraCubit>(
       CameraCubit.new,


### PR DESCRIPTION
The grateful cubit is disposed after game so we need a factory instead of a singleton in order to re-instantiate on second play

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the instantiation method for `GratefulCubit` to create a new instance each time it is requested, enhancing flexibility in its usage.
- **Bug Fixes**
	- Minor formatting adjustments made to the registration of `GratitudeSelectionCubit`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->