### PR TITLE
Bug: Reset the give cubit after donation (kids-1442)

### DIFF
--- a/lib/features/family/features/parent_giving_flow/presentation/pages/parent_giving_page.dart
+++ b/lib/features/family/features/parent_giving_flow/presentation/pages/parent_giving_page.dart
@@ -60,6 +60,8 @@ class _ParentGivingPageState extends State<ParentGivingPage> {
       return;
     }
 
+    give.add(const GiveReset());
+
     unawaited(
       context.read<ImpactGroupsCubit>().fetchImpactGroups(),
     );

--- a/lib/features/give/bloc/give/give_bloc.dart
+++ b/lib/features/give/bloc/give/give_bloc.dart
@@ -49,6 +49,8 @@ class GiveBloc extends Bloc<GiveEvent, GiveState> {
     on<GiveToLastOrganisation>(_onGiveToLastOrganisation);
 
     on<GiveStripeRegistrationError>(_onStripeRegistrationError);
+
+    on<GiveReset>(_onGiveReset);
   }
 
   final CampaignRepository _campaignRepository;
@@ -609,5 +611,12 @@ class GiveBloc extends Bloc<GiveEvent, GiveState> {
     Emitter<GiveState> emit,
   ) {
     emit(state.copyWith(status: GiveStatus.error));
+  }
+
+  FutureOr<void> _onGiveReset(
+    GiveReset event,
+    Emitter<GiveState> emit,
+  ) {
+    emit(const GiveState());
   }
 }

--- a/lib/features/give/bloc/give/give_event.dart
+++ b/lib/features/give/bloc/give/give_event.dart
@@ -148,3 +148,10 @@ class GiveStripeRegistrationError extends GiveEvent {
   @override
   List<Object> get props => [];
 }
+
+class GiveReset extends GiveEvent {
+  const GiveReset();
+
+  @override
+  List<Object> get props => [];
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `GiveReset` event to allow users to reset the giving flow.
	- Enhanced state management to trigger a reset before fetching impact groups.

- **Bug Fixes**
	- Improved control flow to ensure proper state handling during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->