### PR TITLE
Bug: Gratitude game navigation stack (kids-1470)

### DIFF
--- a/lib/features/family/features/reflect/presentation/pages/family_roles_screen.dart
+++ b/lib/features/family/features/reflect/presentation/pages/family_roles_screen.dart
@@ -35,10 +35,10 @@ class _FamilyRolesScreenState extends State<FamilyRolesScreen> {
     return FunScaffold(
       canPop: false,
       minimumPadding: const EdgeInsets.fromLTRB(0, 24, 0, 40),
-      appBar: const FunTopAppBar(
+      appBar: FunTopAppBar(
         title: 'Your roles',
-        leading: GivtBackButtonFlat(),
-        actions: [
+        leading: (_cubit.isFirstRound()) ? const GivtBackButtonFlat() : null,
+        actions: const [
           LeaveGameButton(),
         ],
       ),

--- a/lib/features/family/features/reflect/presentation/pages/reveal_secret_word.dart
+++ b/lib/features/family/features/reflect/presentation/pages/reveal_secret_word.dart
@@ -101,7 +101,7 @@ class _RevealSecretWordScreenState extends State<RevealSecretWordScreen> {
             FunButton(
               isDisabled: !_isScratched,
               onTap: () {
-                Navigator.of(context).push(
+                Navigator.of(context).pushReplacement(
                   const StartInterviewScreen().toRoute(context),
                 );
               },

--- a/lib/features/family/features/reflect/presentation/pages/start_interview.dart
+++ b/lib/features/family/features/reflect/presentation/pages/start_interview.dart
@@ -64,7 +64,7 @@ class _StartInterviewScreenState extends State<StartInterviewScreen> {
                       child: FunButton(
                         onTap: () {
                           // push recording screen
-                          Navigator.push(
+                          Navigator.pushReplacement(
                             context,
                             BaseStateConsumer(
                               cubit: cubit,


### PR DESCRIPTION
### Navigation logic for the gratitude game looks like:
.goNamed(FamilyPages.reflectIntro.name,
.push(const FamilySelectionScreen().toRoute(context));
.push(const FamilyRolesScreen().toRoute(context));
^— Last back buttons, no more back buttons past this point since it messes with logic. Can only quit game
.push(ReflectionRuleSuperheroScreen(
.pushReplacement(ReflectionRuleReporterScreen(
.pushReplacement(ReflectionRuleSidekickScreen
.pushReplacement(PassThePhone.toSuperhero
.pushReplacement(const RevealSecretWordScreen()
.pushReplacement( const StartInterviewScreen() // modified from.push
.pushReplacement(  return RecordAnswerScreen() // modified from.push
.pushReplacement(PassThePhone.toSidekick
.pushReplacement(const GratitudeSelectionScreen()
.pushReplacement(const GuessSecretWordScreen()
.pushReplacement(ResultScreen(
.pushReplacement(const FamilyRolesScreen()  
^— entered second loop, remove back button on this screen
.pushReplacement(PassThePhone.toSuperhero 
.pushReplacement(const RevealSecretWordScreen()
… continue loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced navigation logic across various screens, improving user flow during gameplay.
	- Introduced conditional display of navigation elements based on game state.

- **Bug Fixes**
	- Streamlined interaction handling for the scratch and shuffle functionalities, ensuring clearer user experience.

- **Refactor**
	- Updated navigation methods to replace screens instead of pushing them onto the stack, optimizing back navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->