### PR TITLE
Bug: Fix rounds navigation and reveal secret word ui fix (KIDS-1498 & KIDS-1467)

### DIFF
--- a/lib/features/family/features/reflect/presentation/pages/pass_the_phone_screen.dart
+++ b/lib/features/family/features/reflect/presentation/pages/pass_the_phone_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter_svg/svg.dart';
 import 'package:givt_app/core/enums/enums.dart';
 import 'package:givt_app/features/family/extensions/extensions.dart';
 import 'package:givt_app/features/family/features/reflect/domain/models/game_profile.dart';
+import 'package:givt_app/features/family/features/reflect/presentation/models/interview_custom.dart';
+import 'package:givt_app/features/family/features/reflect/presentation/pages/gratitude_selection_screen.dart';
 import 'package:givt_app/features/family/features/reflect/presentation/pages/rule_screen.dart';
 import 'package:givt_app/features/family/features/reflect/presentation/widgets/game_profile_item.dart';
 import 'package:givt_app/features/family/features/reflect/presentation/widgets/reporters_widget.dart';
@@ -29,11 +31,14 @@ class PassThePhone extends StatelessWidget {
     );
   }
 
-  factory PassThePhone.toSidekick(GameProfile sidekick) {
+  factory PassThePhone.toSidekick(GameProfile sidekick,
+      {bool toRules = false}) {
     return PassThePhone(
       user: sidekick,
       onTap: (context) => Navigator.of(context).pushReplacement(
-        RuleScreen.toSidekick(sidekick).toRoute(context),
+        toRules
+            ? RuleScreen.toSidekick(sidekick).toRoute(context)
+            : const GratitudeSelectionScreen().toRoute(context),
       ),
     );
   }

--- a/lib/features/family/features/reflect/presentation/pages/reveal_secret_word.dart
+++ b/lib/features/family/features/reflect/presentation/pages/reveal_secret_word.dart
@@ -28,13 +28,16 @@ class RevealSecretWordScreen extends StatefulWidget {
 class _RevealSecretWordScreenState extends State<RevealSecretWordScreen> {
   final SecretWordCubit _cubit = SecretWordCubit(getIt());
   final scratchKey = GlobalKey<ScratcherState>();
-  bool _isScratched = false;
+  bool _isSecretWordVisible = false;
   bool _isSecondWord = false;
-  String text = 'Scratch to reveal\nyour secret word';
+  String wordNotVisibleText = 'Scratch to reveal\nyour secret word';
+  String wordVisibleText = 'Sneak your secret word\ninto ONE of your answers!';
+  late String text;
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _cubit.init();
+    text = wordNotVisibleText;
   }
 
   @override
@@ -70,10 +73,9 @@ class _RevealSecretWordScreenState extends State<RevealSecretWordScreen> {
                   threshold: 50,
                   color: Colors.grey,
                   onChange: (value) => setState(() {
-                    _isScratched = value > 25;
-                    if (_isScratched) {
-                      text =
-                          'Sneak your secret word\ninto ONE of your answers!';
+                    _isSecretWordVisible = value > 25;
+                    if (_isSecretWordVisible) {
+                      text = wordVisibleText;
                     }
                   }),
                   child: Stack(
@@ -103,7 +105,7 @@ class _RevealSecretWordScreenState extends State<RevealSecretWordScreen> {
             ),
             const SizedBox(height: 8),
             FunButton(
-              isDisabled: !_isScratched,
+              isDisabled: !_isSecretWordVisible,
               onTap: () {
                 final sidekick = _cubit.getSidekick();
                 Navigator.of(context).pushReplacement(
@@ -126,13 +128,13 @@ class _RevealSecretWordScreenState extends State<RevealSecretWordScreen> {
 
   Widget shuffleButton() => GestureDetector(
         behavior: HitTestBehavior.translucent,
-        onTap: _isScratched
+        onTap: _isSecretWordVisible
             ? () {
                 _cubit.onShuffleClicked();
                 setState(() {
-                  _isScratched = false;
+                  _isSecretWordVisible = false;
                   _isSecondWord = true;
-                  text = 'Scratch to reveal\nyour secret word';
+                  text = wordNotVisibleText;
                   scratchKey.currentState?.reset();
                 });
 
@@ -146,7 +148,7 @@ class _RevealSecretWordScreenState extends State<RevealSecretWordScreen> {
           children: [
             LabelLargeText(
               'Change',
-              color: _isScratched
+              color: _isSecretWordVisible
                   ? FamilyAppTheme.primary30
                   : FamilyAppTheme.neutralVariant60,
             ),
@@ -155,7 +157,7 @@ class _RevealSecretWordScreenState extends State<RevealSecretWordScreen> {
               child: Icon(
                 FontAwesomeIcons.shuffle,
                 size: 24,
-                color: _isScratched
+                color: _isSecretWordVisible
                     ? FamilyAppTheme.primary30
                     : FamilyAppTheme.neutralVariant60,
               ),

--- a/lib/features/family/features/reflect/presentation/pages/reveal_secret_word.dart
+++ b/lib/features/family/features/reflect/presentation/pages/reveal_secret_word.dart
@@ -71,7 +71,10 @@ class _RevealSecretWordScreenState extends State<RevealSecretWordScreen> {
                   color: Colors.grey,
                   onChange: (value) => setState(() {
                     _isScratched = value > 25;
-                    text = 'Sneak your secret word\ninto ONE of your answers!';
+                    if (_isScratched) {
+                      text =
+                          'Sneak your secret word\ninto ONE of your answers!';
+                    }
                   }),
                   child: Stack(
                     alignment: Alignment.center,
@@ -104,7 +107,10 @@ class _RevealSecretWordScreenState extends State<RevealSecretWordScreen> {
               onTap: () {
                 final sidekick = _cubit.getSidekick();
                 Navigator.of(context).pushReplacement(
-                  PassThePhone.toSidekick(sidekick).toRoute(context),
+                  PassThePhone.toSidekick(
+                    sidekick,
+                    toRules: true,
+                  ).toRoute(context),
                 );
               },
               text: 'Next',
@@ -126,6 +132,7 @@ class _RevealSecretWordScreenState extends State<RevealSecretWordScreen> {
                 setState(() {
                   _isScratched = false;
                   _isSecondWord = true;
+                  text = 'Scratch to reveal\nyour secret word';
                   scratchKey.currentState?.reset();
                 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced conditional navigation in the Pass The Phone feature, allowing users to navigate to different screens based on the new `toRules` parameter.
	- Enhanced the Reveal Secret Word feature by refining the scratching interaction and updating navigation logic.

- **Bug Fixes**
	- Improved text update logic in the Reveal Secret Word screen to ensure it only updates when the scratching state is confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->