### PR TITLE
Hotfix: do nothing if secondary parent avatar is clicked

### DIFF
--- a/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:givt_app/core/enums/amplitude_events.dart';
+import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/features/children/shared/profile_type.dart';
 import 'package:givt_app/features/family/app/family_pages.dart';
 import 'package:givt_app/features/family/app/injection.dart';
@@ -165,6 +166,10 @@ class _FamilyHomeScreenState extends State<FamilyHomeScreen> {
     );
 
     if (profile.profileType == ProfileType.Parent) {
+      if (profile.id != context.read<AuthCubit>().state.user.guid) {
+        return;
+      }
+
       await FamilyAuthUtils.authenticateUser(
         context,
         checkAuthRequest: CheckAuthRequest(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced authentication checks on the Family Home Screen, ensuring that only the authenticated user can access their profile.
- **Bug Fixes**
	- Improved logic flow for avatar tapping, preventing unauthorized profile access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->