### PR TITLE
Disable going back from first time set up family

### DIFF
--- a/lib/features/children/add_member/pages/add_member_counter_page.dart
+++ b/lib/features/children/add_member/pages/add_member_counter_page.dart
@@ -30,9 +30,10 @@ class _AddMemberCounterPageState extends State<AddMemberCounterPage> {
   @override
   Widget build(BuildContext context) {
     return FunScaffold(
+      canPop: widget.showTopUp,
       appBar: FunTopAppBar.primary99(
         title: 'Set up Family',
-        leading: const GivtBackButtonFlat(),
+        leading: widget.showTopUp ? const GivtBackButtonFlat() : null,
       ),
       body: Column(
         children: [


### PR DESCRIPTION
Maybe not the best solution, but prevents error screen