### PR TITLE
Bug: Preferred church modal is showing up even though church is already set (KIDS-1564)

### DIFF
--- a/lib/features/family/features/home_screen/usecases/preferred_church_usecase.dart
+++ b/lib/features/family/features/home_screen/usecases/preferred_church_usecase.dart
@@ -25,7 +25,7 @@ mixin class PreferredChurchUseCase {
   Future<bool> shouldShowPreferredChurchModal() async {
     try {
       return (!await _impactGroupsRepository.wasPreferredChurchModalShown()) &&
-          _impactGroupsRepository.getPreferredChurch() == null;
+          await _impactGroupsRepository.getPreferredChurch() == null;
     } catch (e, s) {
       return false;
     }

--- a/lib/features/impact_groups/repo/impact_groups_repository.dart
+++ b/lib/features/impact_groups/repo/impact_groups_repository.dart
@@ -29,7 +29,7 @@ mixin ImpactGroupsRepository {
 
   Future<bool> setPreferredChurch(String churchId);
 
-  Organisation? getPreferredChurch();
+  Future<Organisation?> getPreferredChurch();
 
   Future<void> setPreferredChurchModalShown();
 
@@ -184,8 +184,11 @@ class ImpactGroupsRepositoryImpl with ImpactGroupsRepository {
   }
 
   @override
-  Organisation? getPreferredChurch() {
+  Future<Organisation?> getPreferredChurch() async {
     try {
+      if(_impactGroups == null || _impactGroups!.isEmpty) {
+        await getImpactGroups(fetchWhenEmpty: true);
+      }
       return _impactGroups
           ?.firstWhere((element) => element.type == ImpactGroupType.family)
           .preferredChurch;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of preferred church retrieval with asynchronous operations for better responsiveness.
  
- **Bug Fixes**
	- Ensured that impact groups are fetched correctly when needed, enhancing data availability.

- **Refactor**
	- Updated method signatures for preferred church retrieval to support asynchronous processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->