### PR TITLE
Feature: Select avatars when adding members (kids-1550 & kids-1551)

### DIFF
--- a/lib/features/children/add_member/models/member.dart
+++ b/lib/features/children/add_member/models/member.dart
@@ -8,8 +8,8 @@ class Member extends Equatable {
     this.age,
     this.dateOfBirth,
     this.allowance,
-    this.pictureURL,
-    this.pictureName,
+    this.profilePictureURL,
+    this.profilePictureName,
     this.key,
     this.type,
     this.email,
@@ -21,8 +21,8 @@ class Member extends Equatable {
         age = null,
         dateOfBirth = null,
         allowance = null,
-        pictureURL = null,
-        pictureName = null,
+        profilePictureURL = null,
+        profilePictureName = null,
         key = null,
         type = null,
         email = null;
@@ -35,8 +35,8 @@ class Member extends Equatable {
         allowance: (json['givingAllowance'] ?? 0) as int,
         type: ProfileType.getByTypeName((json['type'] ?? '') as String),
         email: (json['email'] ?? '').toString(),
-        pictureName: json['profilePicture'] as String?,
-        pictureURL: json['profilePictureUrl'] as String?,
+        profilePictureName: json['profilePicture'] as String?,
+        profilePictureURL: json['profilePictureUrl'] as String?,
       );
 
   final String? firstName;
@@ -44,8 +44,8 @@ class Member extends Equatable {
   final int? age;
   final DateTime? dateOfBirth;
   final int? allowance;
-  final String? pictureName;
-  final String? pictureURL;
+  final String? profilePictureName;
+  final String? profilePictureURL;
   final String? key;
   final ProfileType? type;
   final String? email;
@@ -59,7 +59,7 @@ class Member extends Equatable {
       'givingAllowance': allowance,
       'type': type?.name,
       'email': email,
-      'profilePicture': pictureName,
+      'profilePicture': profilePictureName,
     };
   }
 
@@ -75,7 +75,7 @@ class Member extends Equatable {
         allowance,
         type,
         email,
-        pictureURL,
-        pictureName,
+        profilePictureURL,
+        profilePictureName,
       ];
 }

--- a/lib/features/children/add_member/models/member.dart
+++ b/lib/features/children/add_member/models/member.dart
@@ -8,6 +8,8 @@ class Member extends Equatable {
     this.age,
     this.dateOfBirth,
     this.allowance,
+    this.pictureURL,
+    this.pictureName,
     this.key,
     this.type,
     this.email,
@@ -19,6 +21,8 @@ class Member extends Equatable {
         age = null,
         dateOfBirth = null,
         allowance = null,
+        pictureURL = null,
+        pictureName = null,
         key = null,
         type = null,
         email = null;
@@ -31,6 +35,8 @@ class Member extends Equatable {
         allowance: (json['givingAllowance'] ?? 0) as int,
         type: ProfileType.getByTypeName((json['type'] ?? '') as String),
         email: (json['email'] ?? '').toString(),
+        pictureName: json['profilePicture'] as String?,
+        pictureURL: json['profilePictureUrl'] as String?,
       );
 
   final String? firstName;
@@ -38,6 +44,8 @@ class Member extends Equatable {
   final int? age;
   final DateTime? dateOfBirth;
   final int? allowance;
+  final String? pictureName;
+  final String? pictureURL;
   final String? key;
   final ProfileType? type;
   final String? email;
@@ -51,6 +59,7 @@ class Member extends Equatable {
       'givingAllowance': allowance,
       'type': type?.name,
       'email': email,
+      'profilePicture': pictureName,
     };
   }
 
@@ -58,6 +67,15 @@ class Member extends Equatable {
   bool get isChild => type == ProfileType.Child;
 
   @override
-  List<Object?> get props =>
-      [firstName, lastName, age, dateOfBirth, allowance, type, email];
+  List<Object?> get props => [
+        firstName,
+        lastName,
+        age,
+        dateOfBirth,
+        allowance,
+        type,
+        email,
+        pictureURL,
+        pictureName,
+      ];
 }

--- a/lib/features/children/add_member/pages/add_family_counter_page.dart
+++ b/lib/features/children/add_member/pages/add_family_counter_page.dart
@@ -5,49 +5,40 @@ import 'package:givt_app/features/children/add_member/pages/family_member_form_p
 import 'package:givt_app/features/children/add_member/widgets/smiley_counter.dart';
 import 'package:givt_app/features/family/extensions/extensions.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
-import 'package:givt_app/features/family/shared/widgets/buttons/givt_back_button_flat.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
 import 'package:givt_app/shared/models/analytics_event.dart';
 import 'package:givt_app/shared/widgets/fun_scaffold.dart';
 
-class AddMemberCounterPage extends StatefulWidget {
-  const AddMemberCounterPage(
-      {this.initialAmount,
-      this.showTopUp = false,
-      this.canPop = false,
-      super.key});
-  final int? initialAmount;
-  final bool showTopUp;
-  final bool canPop;
+class AddFamilyCounterPage extends StatefulWidget {
+  const AddFamilyCounterPage({super.key});
   @override
-  State<AddMemberCounterPage> createState() => _AddMemberCounterPageState();
+  State<AddFamilyCounterPage> createState() => _AddFamilyCounterPageState();
 }
 
-class _AddMemberCounterPageState extends State<AddMemberCounterPage> {
+class _AddFamilyCounterPageState extends State<AddFamilyCounterPage> {
   late int _amount;
 
   @override
   void initState() {
     super.initState();
-    _amount = 1;
+    _amount = 2;
   }
 
   @override
   Widget build(BuildContext context) {
     return FunScaffold(
-      canPop: widget.canPop,
+      canPop: false,
       appBar: FunTopAppBar.primary99(
         title: 'Set up Family',
-        leading: widget.canPop ? const GivtBackButtonFlat() : null,
       ),
       body: Column(
         children: [
-          const BodyMediumText(
-            'How many family members do you want to add?',
+          const TitleMediumText(
+            'How many people are in your family?',
             textAlign: TextAlign.center,
           ),
           const Spacer(),
-          SmileyCounter(totalCount: _amount, displayFamily: false),
+          SmileyCounter(totalCount: _amount - 1),
           const SizedBox(height: 24),
           FunCounter(
             currency: '',
@@ -56,19 +47,20 @@ class _AddMemberCounterPageState extends State<AddMemberCounterPage> {
               _amount = amount;
             }),
             maxAmount: 6,
+            minAmount: 2,
           ),
           const SizedBox(height: 40),
           const Spacer(),
           FunButton(
-            isDisabled: _amount < 1,
+            isDisabled: _amount < 2,
             onTap: () async {
               await Navigator.push(
                 context,
                 FamilyMemberFormPage(
                   index: 1,
-                  totalCount: _amount,
+                  totalCount: _amount -
+                      1, // -1 because the first member is already added
                   membersToCombine: const [],
-                  showTopUp: widget.showTopUp,
                 ).toRoute(context),
               );
             },
@@ -76,7 +68,7 @@ class _AddMemberCounterPageState extends State<AddMemberCounterPage> {
             rightIcon: FontAwesomeIcons.arrowRight,
             analyticsEvent: AnalyticsEvent(
               AmplitudeEvents.addMemberContinueClicked,
-              parameters: {'amount': _amount},
+              parameters: {'nrOfAddedMembers': _amount - 1},
             ),
           ),
         ],

--- a/lib/features/children/add_member/pages/add_family_counter_page.dart
+++ b/lib/features/children/add_member/pages/add_family_counter_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:givt_app/core/enums/amplitude_events.dart';
 import 'package:givt_app/features/children/add_member/pages/family_member_form_page.dart';
-import 'package:givt_app/features/children/add_member/widgets/smiley_counter.dart';
+import 'package:givt_app/features/children/add_member/widgets/member_counter.dart';
 import 'package:givt_app/features/family/extensions/extensions.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
@@ -38,7 +38,7 @@ class _AddFamilyCounterPageState extends State<AddFamilyCounterPage> {
             textAlign: TextAlign.center,
           ),
           const Spacer(),
-          SmileyCounter(totalCount: _amount - 1),
+          MemberCounter(totalCount: _amount - 1),
           const SizedBox(height: 24),
           FunCounter(
             currency: '',

--- a/lib/features/children/add_member/pages/add_member_counter_page.dart
+++ b/lib/features/children/add_member/pages/add_member_counter_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:givt_app/core/enums/amplitude_events.dart';
 import 'package:givt_app/features/children/add_member/pages/family_member_form_page.dart';
-import 'package:givt_app/features/children/add_member/widgets/smiley_counter.dart';
+import 'package:givt_app/features/children/add_member/widgets/member_counter.dart';
 import 'package:givt_app/features/family/extensions/extensions.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/features/family/shared/widgets/buttons/givt_back_button_flat.dart';
@@ -47,7 +47,7 @@ class _AddMemberCounterPageState extends State<AddMemberCounterPage> {
             textAlign: TextAlign.center,
           ),
           const Spacer(),
-          SmileyCounter(totalCount: _amount, displayFamily: false),
+          MemberCounter(totalCount: _amount, displayFamily: false),
           const SizedBox(height: 24),
           FunCounter(
             currency: '',

--- a/lib/features/children/add_member/pages/family_member_form_page.dart
+++ b/lib/features/children/add_member/pages/family_member_form_page.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:givt_app/app/injection/injection.dart';
 import 'package:givt_app/core/enums/amplitude_events.dart';
@@ -10,10 +12,15 @@ import 'package:givt_app/features/children/add_member/widgets/family_member_form
 import 'package:givt_app/features/children/add_member/widgets/smiley_counter.dart';
 import 'package:givt_app/features/children/shared/profile_type.dart';
 import 'package:givt_app/features/family/extensions/extensions.dart';
+import 'package:givt_app/features/family/features/avatars/cubit/avatars_cubit.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/features/family/shared/widgets/buttons/givt_back_button_flat.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/label_medium_text.dart';
+import 'package:givt_app/features/registration/widgets/avatar_selection_bottomsheet.dart';
+import 'package:givt_app/features/registration/widgets/random_avatar.dart';
 import 'package:givt_app/shared/models/analytics_event.dart';
 import 'package:givt_app/shared/widgets/fun_scaffold.dart';
+import 'package:givt_app/utils/app_theme.dart';
 
 class FamilyMemberFormPage extends StatefulWidget {
   const FamilyMemberFormPage({
@@ -40,26 +47,34 @@ class _FamilyMemberFormPageState extends State<FamilyMemberFormPage> {
   final _ageController = TextEditingController();
   List<bool> selections = [true, false];
   late int _amount;
+  late AvatarsCubit avatars;
 
   @override
   void initState() {
     _amount = widget.showTopUp ? 5 : 0;
+    avatars = getIt<AvatarsCubit>();
+
     super.initState();
   }
 
   Member? addMember({bool isChildSelected = false}) {
     if (_formKey.currentState!.validate()) {
+      final avatar = avatars.state.getAvatarByKey(widget.index.toString());
       final newMember = isChildSelected
           ? Member(
               firstName: _nameController.text,
               age: int.parse(_ageController.text),
               dateOfBirth: dateOfBirth(),
               allowance: _amount,
+              pictureURL: avatar.pictureURL,
+              pictureName: avatar.fileName,
               type: ProfileType.Child,
             )
           : Member(
               firstName: _nameController.text,
               email: _emailController.text,
+              pictureURL: avatar.pictureURL,
+              pictureName: avatar.fileName,
               type: ProfileType.Parent,
             );
       return newMember;
@@ -86,6 +101,7 @@ class _FamilyMemberFormPageState extends State<FamilyMemberFormPage> {
   }
 
   void submitMembersAndNavigate({List<Member> members = const []}) {
+    avatars.clear();
     getIt<AddMemberCubit>()
       ..addAllMembers(members)
       ..createMember();
@@ -111,8 +127,17 @@ class _FamilyMemberFormPageState extends State<FamilyMemberFormPage> {
                 SmileyCounter(
                   totalCount: widget.totalCount,
                   index: widget.index,
+                  otherMembersIcons: [
+                    ...widget.membersToCombine.map(
+                      (member) => _memberIcon(
+                        member.pictureURL ?? '',
+                        member.firstName ?? '',
+                      ),
+                    ),
+                    _buildCurrentMemberIcon(context, avatars),
+                  ],
                 ),
-                const SizedBox(height: 40),
+                const SizedBox(height: 24),
                 ChildOrParentSelector(
                   selections: selections,
                   onPressed: (int index) {
@@ -123,7 +148,17 @@ class _FamilyMemberFormPageState extends State<FamilyMemberFormPage> {
                     FocusScope.of(context).unfocus();
                   },
                 ),
-                const SizedBox(height: 24),
+                const SizedBox(height: 16),
+                RandomAvatar(
+                  id: widget.index.toString(),
+                  onClick: () {
+                    AvatarSelectionBottomsheet.show(
+                      context,
+                      widget.index.toString(),
+                    );
+                  },
+                ),
+                const SizedBox(height: 16),
                 FamilyMemberForm(
                   formKey: _formKey,
                   nameController: _nameController,
@@ -155,6 +190,41 @@ class _FamilyMemberFormPageState extends State<FamilyMemberFormPage> {
               ],
             ),
           ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCurrentMemberIcon(BuildContext context, AvatarsCubit avatars) {
+    return BlocBuilder<AvatarsCubit, AvatarsState>(
+      bloc: avatars,
+      builder: (context, state) {
+        if (state.status != AvatarsStatus.loaded) {
+          return Container(
+            height: 32,
+            width: 32,
+            color: AppTheme.primary80,
+          );
+        }
+        return _memberIcon(
+          state.getAvatarByKey(widget.index.toString()).pictureURL,
+          _nameController.text,
+        );
+      },
+    );
+  }
+
+  Widget _memberIcon(String pictureURL, String name) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Column(
+        children: [
+          SvgPicture.network(
+            height: 32,
+            width: 32,
+            pictureURL,
+          ),
+          LabelMediumText(name),
         ],
       ),
     );

--- a/lib/features/children/add_member/pages/family_member_form_page.dart
+++ b/lib/features/children/add_member/pages/family_member_form_page.dart
@@ -9,12 +9,13 @@ import 'package:givt_app/features/children/add_member/models/member.dart';
 import 'package:givt_app/features/children/add_member/widgets/add_member_loading_page.dart';
 import 'package:givt_app/features/children/add_member/widgets/child_or_parent_selector.dart';
 import 'package:givt_app/features/children/add_member/widgets/family_member_form.dart';
-import 'package:givt_app/features/children/add_member/widgets/smiley_counter.dart';
+import 'package:givt_app/features/children/add_member/widgets/member_counter.dart';
 import 'package:givt_app/features/children/shared/profile_type.dart';
 import 'package:givt_app/features/family/extensions/extensions.dart';
 import 'package:givt_app/features/family/features/avatars/cubit/avatars_cubit.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/features/family/shared/widgets/buttons/givt_back_button_flat.dart';
+import 'package:givt_app/features/family/shared/widgets/loading/custom_progress_indicator.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/label_medium_text.dart';
 import 'package:givt_app/features/registration/widgets/avatar_selection_bottomsheet.dart';
 import 'package:givt_app/features/registration/widgets/random_avatar.dart';
@@ -66,15 +67,15 @@ class _FamilyMemberFormPageState extends State<FamilyMemberFormPage> {
               age: int.parse(_ageController.text),
               dateOfBirth: dateOfBirth(),
               allowance: _amount,
-              pictureURL: avatar.pictureURL,
-              pictureName: avatar.fileName,
+              profilePictureURL: avatar.pictureURL,
+              profilePictureName: avatar.fileName,
               type: ProfileType.Child,
             )
           : Member(
               firstName: _nameController.text,
               email: _emailController.text,
-              pictureURL: avatar.pictureURL,
-              pictureName: avatar.fileName,
+              profilePictureURL: avatar.pictureURL,
+              profilePictureName: avatar.fileName,
               type: ProfileType.Parent,
             );
       return newMember;
@@ -124,13 +125,13 @@ class _FamilyMemberFormPageState extends State<FamilyMemberFormPage> {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                SmileyCounter(
+                MemberCounter(
                   totalCount: widget.totalCount,
                   index: widget.index,
                   otherMembersIcons: [
                     ...widget.membersToCombine.map(
                       (member) => _memberIcon(
-                        member.pictureURL ?? '',
+                        member.profilePictureURL ?? '',
                         member.firstName ?? '',
                       ),
                     ),
@@ -223,6 +224,8 @@ class _FamilyMemberFormPageState extends State<FamilyMemberFormPage> {
             height: 32,
             width: 32,
             pictureURL,
+            placeholderBuilder: (context) =>
+                const CustomCircularProgressIndicator(),
           ),
           LabelMediumText(name),
         ],

--- a/lib/features/children/add_member/widgets/member_counter.dart
+++ b/lib/features/children/add_member/widgets/member_counter.dart
@@ -5,8 +5,8 @@ import 'package:givt_app/features/family/features/profiles/cubit/profiles_cubit.
 import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
 import 'package:givt_app/shared/widgets/common_icons.dart';
 
-class SmileyCounter extends StatelessWidget {
-  const SmileyCounter({
+class MemberCounter extends StatelessWidget {
+  const MemberCounter({
     required this.totalCount,
     this.displayFamily = true,
     this.otherMembersIcons = const [],
@@ -27,14 +27,14 @@ class SmileyCounter extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (displayFamily) _buildFamilytIcons(context),
+        if (displayFamily) _buildFamilyIcons(context),
         ...otherMembersIcons,
         ...List.generate(placeholdercount, (_) => _buildSmileyIcon()),
       ],
     );
   }
 
-  Widget _buildFamilytIcons(BuildContext context) {
+  Widget _buildFamilyIcons(BuildContext context) {
     final familyMembersIcons = <Widget>[];
     return BlocBuilder<ProfilesCubit, ProfilesState>(
       builder: (context, state) {

--- a/lib/features/children/add_member/widgets/smiley_counter.dart
+++ b/lib/features/children/add_member/widgets/smiley_counter.dart
@@ -1,40 +1,76 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:givt_app/features/family/features/profiles/cubit/profiles_cubit.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
 import 'package:givt_app/shared/widgets/common_icons.dart';
 
 class SmileyCounter extends StatelessWidget {
   const SmileyCounter({
     required this.totalCount,
+    this.displayFamily = true,
+    this.otherMembersIcons = const [],
     this.index,
     super.key,
   });
 
   final int totalCount;
+  final bool displayFamily;
+  final List<Widget> otherMembersIcons;
   final int? index;
 
   @override
   Widget build(BuildContext context) {
-    final smileyCount = index != null ? index! : totalCount;
-    final remainingCount = totalCount - smileyCount;
-
-    return Padding(
-      padding: const EdgeInsets.all(0),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          ...List.generate(smileyCount, (_) => _buildSmileyIcon()),
-          ...List.generate(
-            remainingCount,
-            (_) => _buildSmileyIcon(isGrey: true),
-          ),
-        ],
-      ),
+    final avatarsCount = index != null ? index! : 0;
+    final placeholdercount = totalCount - avatarsCount;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (displayFamily) _buildFamilytIcons(context),
+        ...otherMembersIcons,
+        ...List.generate(placeholdercount, (_) => _buildSmileyIcon()),
+      ],
     );
   }
 
-  Widget _buildSmileyIcon({bool isGrey = false}) {
+  Widget _buildFamilytIcons(BuildContext context) {
+    final familyMembersIcons = <Widget>[];
+    return BlocBuilder<ProfilesCubit, ProfilesState>(
+      builder: (context, state) {
+        if (state.profiles.isEmpty) {
+          return const SizedBox();
+        }
+        for (final profile in state.profiles) {
+          familyMembersIcons.add(
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Column(
+                children: [
+                  SvgPicture.network(
+                    height: 32,
+                    width: 32,
+                    profile.pictureURL,
+                  ),
+                  LabelMediumText(profile.firstName),
+                ],
+              ),
+            ),
+          );
+        }
+        return Row(
+          children: [
+            ...familyMembersIcons,
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildSmileyIcon() {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8),
-      child: isGrey ? smileGreyIcon() : smilePurpleIcon(),
+      child: defaultHero(width: 32, height: 32),
     );
   }
 }

--- a/lib/features/children/utils/add_member_util.dart
+++ b/lib/features/children/utils/add_member_util.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:givt_app/features/children/add_member/pages/add_family_counter_page.dart';
 import 'package:givt_app/features/children/add_member/pages/add_member_counter_page.dart';
 import 'package:givt_app/shared/widgets/extensions/route_extensions.dart';
 
 class AddMemberUtil {
-  static Future<void> addMemberPushPages(BuildContext context, {bool showTopUp = false, bool canPop = false}) async {
+  static Future<void> addMemberPushPages(BuildContext context,
+      {bool showTopUp = false, bool canPop = false}) async {
     await Navigator.push(
       context,
       AddMemberCounterPage(
@@ -13,6 +15,13 @@ class AddMemberUtil {
         showTopUp: showTopUp,
         canPop: canPop,
       ).toRoute(context),
+    );
+  }
+
+  static Future<void> addFamilyPushPages(BuildContext context) async {
+    await Navigator.push(
+      context,
+      const AddFamilyCounterPage().toRoute(context),
     );
   }
 }

--- a/lib/features/family/features/avatars/cubit/avatars_cubit.dart
+++ b/lib/features/family/features/avatars/cubit/avatars_cubit.dart
@@ -74,4 +74,8 @@ class AvatarsCubit extends Cubit<AvatarsState> {
     final index = Random().nextInt(state.avatars.length);
     return state.avatars[index];
   }
+
+  void clear() {
+    emit(state.copyWith(assignedAvatars: []));
+  }
 }

--- a/lib/features/family/features/home_screen/presentation/pages/navigation_bar_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/navigation_bar_home_screen.dart
@@ -204,7 +204,7 @@ class _NavigationBarHomeScreenState extends State<NavigationBarHomeScreen> {
       // do nothing, screen is already showing
     } else {
       _isShowingSetupFamily = true;
-      await AddMemberUtil.addMemberPushPages(context);
+      await AddMemberUtil.addFamilyPushPages(context);
       _isShowingSetupFamily = false;
     }
   }

--- a/lib/features/family/shared/design/components/input/fun_counter.dart
+++ b/lib/features/family/shared/design/components/input/fun_counter.dart
@@ -14,6 +14,7 @@ class FunCounter extends StatefulWidget {
     this.initialAmount,
     this.onAmountChanged,
     this.maxAmount,
+    this.minAmount,
     this.canAmountBeZero = false,
     super.key,
   });
@@ -21,6 +22,7 @@ class FunCounter extends StatefulWidget {
   final String? currency;
   final int? initialAmount;
   final int? maxAmount;
+  final int? minAmount;
   final void Function(int amount)? onAmountChanged;
   final bool canAmountBeZero;
 
@@ -34,7 +36,7 @@ class _FunCounterState extends State<FunCounter> {
   static const int holdDownDuration2 = 2000;
   static const int amountIncrement = 5;
   static const int amountIncrement2 = 10;
-  static late int minAmount;
+  int minAmount = 0;
   int maxAmount = 999;
   late int _currentAmount;
   Timer? _timer;
@@ -43,7 +45,7 @@ class _FunCounterState extends State<FunCounter> {
   @override
   void initState() {
     super.initState();
-    minAmount = widget.canAmountBeZero ? 0 : 1;
+    minAmount = widget.minAmount ?? (widget.canAmountBeZero ? 0 : 1);
     maxAmount = widget.maxAmount ?? maxAmount;
     _currentAmount = widget.initialAmount ?? 15;
   }

--- a/lib/features/family/shared/design/components/input/fun_counter.dart
+++ b/lib/features/family/shared/design/components/input/fun_counter.dart
@@ -45,9 +45,14 @@ class _FunCounterState extends State<FunCounter> {
   @override
   void initState() {
     super.initState();
-    minAmount = widget.minAmount ?? (widget.canAmountBeZero ? 0 : 1);
     maxAmount = widget.maxAmount ?? maxAmount;
     _currentAmount = widget.initialAmount ?? 15;
+
+    minAmount = widget.minAmount ?? (widget.canAmountBeZero == true ? 0 : 1);
+    // If the min amount is less than 1 and the amount can't be zero, set it to 1
+    if (!widget.canAmountBeZero && minAmount < 1) {
+      minAmount = 1;
+    }
   }
 
   @override

--- a/lib/features/registration/pages/us_signup_page.dart
+++ b/lib/features/registration/pages/us_signup_page.dart
@@ -68,6 +68,12 @@ class _UsSignUpPageState extends State<UsSignUpPage> {
   }
 
   @override
+  void dispose() {
+    getIt<AvatarsCubit>().clear();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final locals = AppLocalizations.of(context);
     final size = MediaQuery.sizeOf(context);

--- a/lib/features/registration/widgets/random_avatar.dart
+++ b/lib/features/registration/widgets/random_avatar.dart
@@ -55,7 +55,7 @@ class _RandomAvatarState extends State<RandomAvatar> {
                   width: size.width * 0.25,
                   height: size.width * 0.25,
                   placeholderBuilder: (context) =>
-                      const CircularProgressIndicator(),
+                      const CustomCircularProgressIndicator(),
                 ),
               ),
               const Positioned(

--- a/lib/shared/widgets/common_icons.dart
+++ b/lib/shared/widgets/common_icons.dart
@@ -56,6 +56,11 @@ Widget smilePurpleIcon({double? width, double? height}) => SvgPicture.asset(
       width: width,
       height: height,
     );
+Widget defaultHero({double? width, double? height}) => SvgPicture.asset(
+      'assets/images/default_hero.svg',
+      width: width,
+      height: height,
+    );
 
 Widget smileGreyIcon({double? width, double? height}) => SvgPicture.asset(
       'assets/family/images/smiley_grey.svg',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced avatar selection in the Family Member form.
	- Added a new page for setting up family member count.
	- Enhanced the MemberCounter widget to display family member icons.
	- Implemented a new method for navigating to the family counter page.
	- Added a default hero widget for SVG images.

- **Bug Fixes**
	- Improved logic for enabling/disabling buttons based on member count.

- **Documentation**
	- Updated method signatures for clarity and readability.

- **Chores**
	- Added a method to clear avatar states upon widget disposal.
	- Replaced loading indicator in RandomAvatar with a custom widget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->