### PR TITLE
Hotfix: Do not send empty profile picture (kids-1571)

### DIFF
--- a/lib/features/children/add_member/models/member.dart
+++ b/lib/features/children/add_member/models/member.dart
@@ -59,7 +59,10 @@ class Member extends Equatable {
       'givingAllowance': allowance,
       'type': type?.name,
       'email': email,
-      'profilePicture': profilePictureName,
+      'profilePicture':
+          (profilePictureName == null || profilePictureName!.isEmpty)
+              ? null
+              : profilePictureName,
     };
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the `profilePicture` field in JSON output to ensure it returns `null` instead of an empty string when `profilePictureName` is null or empty.
  
- **Refactor**
	- Enhanced readability of the `toJson` method's code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->