### PR TITLE
Feature: Remove summary screen back button (KIDS-1579)

### DIFF
--- a/lib/features/family/features/reflect/presentation/pages/summary_screen.dart
+++ b/lib/features/family/features/reflect/presentation/pages/summary_screen.dart
@@ -7,7 +7,6 @@ import 'package:givt_app/features/family/app/family_pages.dart';
 import 'package:givt_app/features/family/app/injection.dart';
 import 'package:givt_app/features/family/features/reflect/bloc/summary_cubit.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
-import 'package:givt_app/features/family/shared/widgets/buttons/givt_back_button_flat.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
 import 'package:givt_app/shared/models/analytics_event.dart';
 import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
@@ -34,7 +33,6 @@ class _SummaryScreenState extends State<SummaryScreen> {
     return FunScaffold(
       appBar: const FunTopAppBar(
         title: 'Awesome work heroes!',
-        leading: GivtBackButtonFlat(),
       ),
       body: BaseStateConsumer(
         cubit: _cubit,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the back button from the app bar on the summary screen, streamlining the navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->