### PR TITLE
Feature: change token retry policy to use correct repo (KIDS-1601)

### DIFF
--- a/lib/core/network/expired_token_retry_policy.dart
+++ b/lib/core/network/expired_token_retry_policy.dart
@@ -1,0 +1,34 @@
+import 'dart:developer';
+
+import 'package:givt_app/app/injection/injection.dart';
+import 'package:givt_app/features/auth/repositories/auth_repository.dart';
+import 'package:http/http.dart';
+import 'package:http_interceptor/models/retry_policy.dart';
+
+/// This is the retry policy that will be used by the [InterceptedClient]
+/// to retry requests that failed due to an expired token.
+class ExpiredTokenRetryPolicy extends RetryPolicy {
+  @override
+  int maxRetryAttempts = 2;
+
+  @override
+  Future<bool> shouldAttemptRetryOnResponse(BaseResponse response) async {
+    ///This is where we need to update our token on 401 response
+    if (response.statusCode == 401) {
+      await _refreshToken();
+      return true;
+    }
+    return false;
+  }
+
+  /// This method will be called
+  /// when a request fails and the [shouldAttemptRetryOnResponse]
+  /// Handle the [SocketException] when there is no internet connection
+  Future<void> _refreshToken() async {
+    try {
+      await getIt<AuthRepository>().refreshToken();
+    } catch (e) {
+      log('No internet connection');
+    }
+  }
+}

--- a/lib/core/network/family_expired_token_retry_policy.dart
+++ b/lib/core/network/family_expired_token_retry_policy.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:givt_app/core/logging/logging.dart';
+import 'package:givt_app/features/family/app/injection.dart';
+import 'package:givt_app/features/family/features/auth/data/family_auth_repository.dart';
+import 'package:http/http.dart';
+import 'package:http_interceptor/models/retry_policy.dart';
+
+/// This is the retry policy that will be used by the [InterceptedClient]
+/// to retry requests that failed due to an expired token.
+class FamilyExpiredTokenRetryPolicy extends RetryPolicy {
+  @override
+  int maxRetryAttempts = 2;
+
+  @override
+  Future<bool> shouldAttemptRetryOnResponse(BaseResponse response) async {
+    ///This is where we need to update our token on 401 response
+    if (response.statusCode == 401) {
+      try {
+        await _refreshToken();
+        return true;
+      } catch (e, s) {
+        if (e is SocketException) {
+          // we failed to refresh the token but the user probably had an internet oopsie, let's retry again
+          return true;
+        } else {
+          // we failed to refresh the token, do not attempt to retry the call
+          LoggingInfo.instance.error(e.toString(), methodName: s.toString());
+          return false;
+        }
+      }
+    }
+    return false;
+  }
+
+  Future<void> _refreshToken() async {
+    await getIt<FamilyAuthRepository>().refreshToken();
+  }
+}

--- a/lib/core/network/token_interceptor.dart
+++ b/lib/core/network/token_interceptor.dart
@@ -68,31 +68,3 @@ class TokenInterceptor implements InterceptorContract {
   @override
   Future<bool> shouldInterceptResponse() => Future.value(true);
 }
-
-/// This is the retry policy that will be used by the [InterceptedClient]
-/// to retry requests that failed due to an expired token.
-class ExpiredTokenRetryPolicy extends RetryPolicy {
-  @override
-  int maxRetryAttempts = 2;
-
-  @override
-  Future<bool> shouldAttemptRetryOnResponse(BaseResponse response) async {
-    ///This is where we need to update our token on 401 response
-    if (response.statusCode == 401) {
-      await _refreshToken();
-      return true;
-    }
-    return false;
-  }
-
-  /// This method will be called
-  /// when a request fails and the [shouldAttemptRetryOnResponse]
-  /// Handle the [SocketException] when there is no internet connection
-  Future<void> _refreshToken() async {
-    try {
-      await getIt<AuthRepository>().refreshToken();
-    } catch (e) {
-      log('No internet connection');
-    }
-  }
-}

--- a/lib/features/family/app/injection.dart
+++ b/lib/features/family/app/injection.dart
@@ -2,6 +2,7 @@ import 'package:get_it/get_it.dart';
 import 'package:givt_app/core/network/request_helper.dart';
 import 'package:givt_app/features/family/features/admin_fee/application/admin_fee_cubit.dart';
 import 'package:givt_app/features/family/features/admin_fee/data/repositories/admin_fee_repository.dart';
+import 'package:givt_app/features/family/features/auth/data/family_auth_repository.dart';
 import 'package:givt_app/features/family/features/avatars/cubit/avatars_cubit.dart';
 import 'package:givt_app/features/family/features/avatars/repositories/avatars_repository.dart';
 import 'package:givt_app/features/family/features/edit_profile/repositories/edit_profile_repository.dart';
@@ -123,6 +124,12 @@ void initRepositories() {
   getIt
     ..registerSingleton<AdminFeeRepository>(
       AdminFeeRepository(
+        getIt(),
+      ),
+    )
+    ..registerLazySingleton<FamilyAuthRepository>(
+          () => FamilyAuthRepositoryImpl(
+        getIt(),
         getIt(),
       ),
     )


### PR DESCRIPTION
Do not merge this PR until FamilyAuthRepo is in getit. Also we might want to merge this one to a different branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `ExpiredTokenRetryPolicy` and `FamilyExpiredTokenRetryPolicy` classes to manage retry attempts for HTTP requests with expired authentication tokens.
	- Added methods to create EU and US specific clients with appropriate retry policies.

- **Bug Fixes**
	- Enhanced error handling during token refresh attempts, allowing for retries in case of transient internet issues.

- **Refactor**
	- Updated client creation logic to distinguish between EU and US configurations more clearly.
	- Integrated `FamilyAuthRepository` into the dependency injection setup.

- **Chores**
	- Removed the previous `ExpiredTokenRetryPolicy` implementation from the `TokenInterceptor`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->