### PR TITLE
Bugfix: Remove child history duplicates (kids-1639)

### DIFF
--- a/lib/features/family/features/history/history_cubit/history_cubit.dart
+++ b/lib/features/family/features/history/history_cubit/history_cubit.dart
@@ -41,10 +41,20 @@ class HistoryCubit extends Cubit<HistoryState> {
       final donationHistory = await donationHistoryFuture;
       final allowanceHistory = await allowanceHistoryFuture;
 
+      // Remove duplicates from current state
+      final updatedDonations = donationHistory.where((item) => !state.history
+          .any((existing) =>
+              existing.type == HistoryTypes.donation && existing == item));
+      final updatedAllowances = allowanceHistory.where((item) => !state.history
+          .any((existing) =>
+              (existing.type == HistoryTypes.allowance ||
+                  existing.type == HistoryTypes.topUp) &&
+              existing == item));
+
       final history = <HistoryItem>[
         ...state.history,
-        ...donationHistory,
-        ...allowanceHistory,
+        ...updatedDonations,
+        ...updatedAllowances,
       ]
         // sort from newest to oldest
         ..sort((a, b) => b.date.compareTo(a.date));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of fetched history items by removing duplicate entries from donation and allowance histories.
	- Enhanced data integrity in the history list, ensuring only unique items are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->