### PR TITLE
Fix: Remove family history duplicates (KIDS-1632)

### DIFF
--- a/lib/features/children/family_history/family_history_cubit/family_history_cubit.dart
+++ b/lib/features/children/family_history/family_history_cubit/family_history_cubit.dart
@@ -61,7 +61,8 @@ class FamilyHistoryCubit extends Cubit<FamilyHistoryState> {
       final newPageHistory =
           await historyRepo.getHistory(pageNumber: state.pageNr);
 
-      resultHistory.addAll(newPageHistory);
+      resultHistory.addAll(newPageHistory.where((item) => !resultHistory
+          .any((existing) => existing.type == item.type && existing == item)));
 
       emit(
         state.copyWith(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced history data integrity by preventing the addition of duplicate items in the family history.
- **Bug Fixes**
	- Improved error handling during the fetching process to ensure users receive accurate error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->