### PR TITLE
Fix: Await refresh profiles when kid makes transaction (kids-1640)

### DIFF
--- a/lib/features/family/app/injection.dart
+++ b/lib/features/family/app/injection.dart
@@ -138,7 +138,6 @@ void initRepositories() {
         getIt(),
         getIt(),
         getIt(),
-        getIt(),
       ),
     )
     ..registerLazySingleton<OrganisationDetailsRepository>(
@@ -153,6 +152,7 @@ void initRepositories() {
     )
     ..registerLazySingleton<CreateTransactionRepository>(
       () => CreateTransactionRepositoryImpl(
+        getIt(),
         getIt(),
       ),
     )

--- a/lib/features/family/features/giving_flow/create_transaction/repositories/create_transaction_repository.dart
+++ b/lib/features/family/features/giving_flow/create_transaction/repositories/create_transaction_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:givt_app/features/family/features/giving_flow/create_transaction/models/transaction.dart';
+import 'package:givt_app/features/family/features/profiles/repository/profiles_repository.dart';
 import 'package:givt_app/features/family/network/family_api_service.dart';
 
 mixin CreateTransactionRepository {
@@ -12,15 +13,18 @@ mixin CreateTransactionRepository {
 class CreateTransactionRepositoryImpl with CreateTransactionRepository {
   CreateTransactionRepositoryImpl(
     this._apiService,
+    this._profilesRepository,
   );
 
   final FamilyAPIService _apiService;
   final StreamController<void> _transactionCreatedController =
       StreamController<void>.broadcast();
+  final ProfilesRepository _profilesRepository;
 
   @override
   Future<void> createTransaction({required Transaction transaction}) async {
     await _apiService.createTransaction(transaction: transaction);
+    await _profilesRepository.refreshProfiles();
     _transactionCreatedController.add(null);
   }
 

--- a/lib/features/family/features/profiles/repository/profiles_repository.dart
+++ b/lib/features/family/features/profiles/repository/profiles_repository.dart
@@ -8,7 +8,6 @@ import 'package:givt_app/features/children/edit_child/repositories/edit_child_re
 import 'package:givt_app/features/children/edit_profile/repositories/edit_parent_profile_repository.dart';
 import 'package:givt_app/features/children/parental_approval/repositories/parental_approval_repository.dart';
 import 'package:givt_app/features/family/features/edit_profile/repositories/edit_profile_repository.dart';
-import 'package:givt_app/features/family/features/giving_flow/create_transaction/repositories/create_transaction_repository.dart';
 import 'package:givt_app/features/family/features/profiles/models/profile.dart';
 import 'package:givt_app/features/family/network/family_api_service.dart';
 import 'package:givt_app/features/impact_groups/repo/impact_groups_repository.dart';
@@ -40,10 +39,9 @@ class ProfilesRepositoryImpl with ProfilesRepository {
     this._givtRepository,
     this._authRepository,
     this._parentalApprovalRepository,
-    this._createTransactionRepository,
     this._editChildProfileRepository,
     this._editParentProfileRepository,
-      this._registrationRepository,
+    this._registrationRepository,
   ) {
     _init();
   }
@@ -55,7 +53,6 @@ class ProfilesRepositoryImpl with ProfilesRepository {
   final GivtRepository _givtRepository;
   final AuthRepository _authRepository;
   final ParentalApprovalRepository _parentalApprovalRepository;
-  final CreateTransactionRepository _createTransactionRepository;
   final EditProfileRepository _editChildProfileRepository;
   final EditParentProfileRepository _editParentProfileRepository;
   final RegistrationRepository _registrationRepository;
@@ -100,10 +97,6 @@ class ProfilesRepositoryImpl with ProfilesRepository {
         }
       },
     );
-
-    _createTransactionRepository
-        .onTransaction()
-        .listen((_) => refreshProfiles());
 
     _editParentProfileRepository
         .onProfileChanged()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction creation process now includes profile management, refreshing profiles after a transaction is created.
- **Bug Fixes**
	- Simplified `ProfilesRepositoryImpl` by removing unnecessary dependencies related to transaction management, streamlining profile handling.
- **Refactor**
	- Updated dependency injection setup to accommodate new repository requirements, ensuring proper initialization of components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->