### PR TITLE
Bug: Save time played after everyone donated/pledged

### DIFF
--- a/lib/features/family/features/reflect/bloc/grateful_cubit.dart
+++ b/lib/features/family/features/reflect/bloc/grateful_cubit.dart
@@ -226,6 +226,7 @@ class GratefulCubit extends CommonCubit<GratefulUIModel, GratefulCustom> {
   }
 
   void _onEveryoneDonated() {
+    _reflectAndShareRepository.saveSummaryStats();
     emitCustom(const GratefulCustom.goToGameSummary());
   }
 


### PR DESCRIPTION
Without this the time played is only saved on exit game, strange, where did this use to be?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality to save summary statistics when all profiles have donated, enhancing the tracking of donation activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->