### PR TITLE
FIX: Emit state if top up failed (kids-1538)

### DIFF
--- a/lib/features/children/add_member/cubit/add_member_cubit.dart
+++ b/lib/features/children/add_member/cubit/add_member_cubit.dart
@@ -54,6 +54,12 @@ class AddMemberCubit extends Cubit<AddMemberState> {
             eventName: AmplitudeEvents.topupFailed,
           ),
         );
+        emit(
+          state.copyWith(
+            status: AddMemberStateStatus.topupFailed,
+            error: 'Top up failed, child created!',
+          ),
+        );
       } else {
         unawaited(
           AnalyticsHelper.logEvent(

--- a/lib/features/children/add_member/cubit/add_member_state.dart
+++ b/lib/features/children/add_member/cubit/add_member_state.dart
@@ -5,6 +5,7 @@ enum AddMemberStateStatus {
   loading,
   success,
   successCached,
+  topupFailed,
   error,
 }
 

--- a/lib/features/children/add_member/widgets/add_member_loading_page.dart
+++ b/lib/features/children/add_member/widgets/add_member_loading_page.dart
@@ -23,7 +23,8 @@ class AddMemberLoadingPage extends StatelessWidget {
         listener: (context, state) {
           if (state.status == AddMemberStateStatus.success) {
             _navigateToProfileSelection(context);
-          } else if (state.status == AddMemberStateStatus.error) {
+          } else if (state.status == AddMemberStateStatus.error ||
+              state.status == AddMemberStateStatus.topupFailed) {
             _navigateToProfileSelection(context);
             SnackBarHelper.showMessage(context, text: state.error);
           } else if (state.status == AddMemberStateStatus.successCached) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new status for member creation failure: "Top up failed, child created!" for improved error handling.
  
- **Bug Fixes**
	- Enhanced error handling in the member loading page to display relevant messages for top-up failures alongside existing error states.

- **Documentation**
	- Updated state management documentation to reflect the addition of the new `topupFailed` status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->