### PR TITLE
Remove auth on US personal info page - you are already verified (KIDS-760)

### DIFF
--- a/lib/features/family/features/account/presentation/pages/us_personal_info_edit_page.dart
+++ b/lib/features/family/features/account/presentation/pages/us_personal_info_edit_page.dart
@@ -275,13 +275,8 @@ class _USPersonalInfoEditPageState extends State<USPersonalInfoEditPage> {
               FontAwesomeIcons.userXmark,
             ),
             value: locals.unregister,
-            onTap: () async => FamilyAuthUtils.authenticateUser(
-              context,
-              checkAuthRequest: FamilyCheckAuthRequest(
-                navigate: (context) async => context.pushNamed(
-                  FamilyPages.unregisterUS.name,
-                ),
-              ),
+            onTap: () async => context.pushNamed(
+              FamilyPages.unregisterUS.name,
             ),
           ),
           const Divider(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined the unregistration process by simplifying navigation to the unregistration page.
  
- **Bug Fixes**
	- Retained error handling for various states, ensuring appropriate warning dialogs are displayed for issues like no internet and invalid email.

- **Chores**
	- Overall structure and functionality of the personal info edit page remain intact with no public entity declarations altered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->