### PR TITLE
Add stats to homepage, refresh stats after playing a game (KIDS-1435)

### DIFF
--- a/lib/features/family/app/injection.dart
+++ b/lib/features/family/app/injection.dart
@@ -110,6 +110,7 @@ void initCubits() {
       () => FamilyHomeScreenCubit(
         getIt(),
         getIt(),
+        getIt(),
       ),
     )
     ..registerLazySingleton<AvatarsCubit>(

--- a/lib/features/family/features/home_screen/cubit/family_home_screen_cubit.dart
+++ b/lib/features/family/features/home_screen/cubit/family_home_screen_cubit.dart
@@ -2,6 +2,8 @@ import 'package:collection/collection.dart';
 import 'package:givt_app/features/family/features/home_screen/presentation/models/family_home_screen.uimodel.dart';
 import 'package:givt_app/features/family/features/profiles/models/profile.dart';
 import 'package:givt_app/features/family/features/profiles/repository/profiles_repository.dart';
+import 'package:givt_app/features/family/features/reflect/domain/models/game_stats.dart';
+import 'package:givt_app/features/family/features/reflect/domain/reflect_and_share_repository.dart';
 import 'package:givt_app/features/family/shared/design/components/content/models/avatar_uimodel.dart';
 import 'package:givt_app/features/impact_groups/models/impact_group.dart';
 import 'package:givt_app/features/impact_groups/repo/impact_groups_repository.dart';
@@ -13,22 +15,28 @@ class FamilyHomeScreenCubit
   FamilyHomeScreenCubit(
     this._profilesRepository,
     this._impactGroupsRepository,
+    this._reflectAndShareRepository,
   ) : super(const BaseState.loading());
 
   final ProfilesRepository _profilesRepository;
   final ImpactGroupsRepository _impactGroupsRepository;
+  final ReflectAndShareRepository _reflectAndShareRepository;
 
   List<Profile> profiles = [];
   ImpactGroup? _familyGroup;
+  GameStats? _gameStats;
 
   Future<void> init() async {
     _profilesRepository.onProfilesChanged().listen(_onProfilesChanged);
     _impactGroupsRepository.onImpactGroupsChanged().listen(_onGroupsChanged);
+    _reflectAndShareRepository.onGameStatsChanged().listen(_onGameStatsChanged);
 
     _onProfilesChanged(await _profilesRepository.getProfiles());
     _onGroupsChanged(
       await _impactGroupsRepository.getImpactGroups(fetchWhenEmpty: true),
     );
+    _onGameStatsChanged(await _reflectAndShareRepository.getGameStats());
+    _emitData();
   }
 
   void _onProfilesChanged(List<Profile> profiles) {
@@ -40,6 +48,12 @@ class FamilyHomeScreenCubit
     _familyGroup = groups.firstWhereOrNull(
       (element) => element.isFamilyGroup,
     );
+
+    _emitData();
+  }
+
+  void _onGameStatsChanged(GameStats gameStats) {
+    this._gameStats = gameStats;
 
     _emitData();
   }
@@ -66,6 +80,7 @@ class FamilyHomeScreenCubit
           )
           .toList(),
       familyGroupName: _familyGroup?.name,
+      gameStats: _gameStats,
     );
   }
 

--- a/lib/features/family/features/home_screen/presentation/models/family_home_screen.uimodel.dart
+++ b/lib/features/family/features/home_screen/presentation/models/family_home_screen.uimodel.dart
@@ -1,12 +1,14 @@
-
+import 'package:givt_app/features/family/features/reflect/domain/models/game_stats.dart';
 import 'package:givt_app/features/family/shared/design/components/content/models/avatar_uimodel.dart';
 
 class FamilyHomeScreenUIModel {
   const FamilyHomeScreenUIModel({
     required this.avatars,
     this.familyGroupName,
+    this.gameStats,
   });
 
   final List<AvatarUIModel> avatars;
   final String? familyGroupName;
+  final GameStats? gameStats;
 }

--- a/lib/features/family/features/home_screen/presentation/pages/family_home_overlay.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/family_home_overlay.dart
@@ -2,8 +2,8 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:givt_app/features/family/features/home_screen/presentation/models/family_home_screen.uimodel.dart';
-import 'package:givt_app/features/family/shared/design/components/content/models/avatar_bar_uimodel.dart';
 import 'package:givt_app/features/family/shared/design/components/content/avatar_bar.dart';
+import 'package:givt_app/features/family/shared/design/components/content/models/avatar_bar_uimodel.dart';
 import 'package:givt_app/features/family/shared/design/components/navigation/fun_top_app_bar.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/title_large_text.dart';
 import 'package:givt_app/features/family/utils/family_app_theme.dart';

--- a/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
@@ -14,12 +14,13 @@ import 'package:givt_app/features/family/features/home_screen/presentation/model
 import 'package:givt_app/features/family/features/home_screen/presentation/pages/family_home_overlay.dart';
 import 'package:givt_app/features/family/features/home_screen/widgets/give_button.dart';
 import 'package:givt_app/features/family/features/home_screen/widgets/gratitude_game_button.dart';
+import 'package:givt_app/features/family/features/home_screen/widgets/stats_container.dart';
 import 'package:givt_app/features/family/features/profiles/cubit/profiles_cubit.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/features/family/shared/design/components/content/avatar_bar.dart';
 import 'package:givt_app/features/family/shared/design/components/content/models/avatar_bar_uimodel.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
-import 'package:givt_app/features/family/utils/family_auth_utils.dart';
+import 'package:givt_app/features/family/utils/utils.dart';
 import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
 import 'package:givt_app/shared/widgets/fun_scaffold.dart';
 import 'package:givt_app/utils/analytics_helper.dart';
@@ -104,6 +105,7 @@ class _FamilyHomeScreenState extends State<FamilyHomeScreen> {
                           ),
                           onAvatarTapped: onAvatarTapped,
                         ),
+                        StatsContainer(uiModel.gameStats),
                     ],
                   ),
                 ],
@@ -146,7 +148,7 @@ class _FamilyHomeScreenState extends State<FamilyHomeScreen> {
       closeOverlay();
     }
 
-    var profile = _cubit.profiles[index];
+    final profile = _cubit.profiles[index];
 
     unawaited(
       context.read<ProfilesCubit>().setActiveProfile(

--- a/lib/features/family/features/home_screen/widgets/stats_chip.dart
+++ b/lib/features/family/features/home_screen/widgets/stats_chip.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
+import 'package:givt_app/features/family/utils/utils.dart';
+
+class StatsChip extends StatelessWidget {
+  const StatsChip({required this.text, required this.icon, super.key});
+
+  final String text;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: FamilyAppTheme.primary90,
+        borderRadius: BorderRadius.circular(50),
+      ),
+      child: Row(
+        children: [
+          FaIcon(
+            icon,
+            size: 15,
+          ),
+          const SizedBox(width: 8),
+          LabelSmallText(text),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/family/features/home_screen/widgets/stats_container.dart
+++ b/lib/features/family/features/home_screen/widgets/stats_container.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:givt_app/features/family/features/home_screen/widgets/stats_chip.dart';
+import 'package:givt_app/features/family/features/reflect/domain/models/game_stats.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
+import 'package:givt_app/features/family/utils/utils.dart';
+
+class StatsContainer extends StatelessWidget {
+  const StatsContainer(this.gameStats, {super.key});
+
+  final GameStats? gameStats;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: FamilyAppTheme.primary98,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      width: double.infinity,
+      margin: const EdgeInsets.symmetric(
+        horizontal: 24,
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: 8,
+        vertical: 16,
+      ),
+      child: gameStats == null || gameStats!.totalSecondsPlayed == 0
+          ? showEmptyState()
+          : showStatsColumn(),
+    );
+  }
+
+  Widget showEmptyState() {
+    return const Column(
+      children: [
+        LabelMediumText('Your stats this week'),
+        SizedBox(height: 8),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            StatsChip(
+              icon: FontAwesomeIcons.arrowDown,
+              text: 'Play the gratitude game'
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget showStatsColumn() {
+    return Column(
+      children: [
+        const LabelMediumText('Your stats this week'),
+        const SizedBox(height: 8),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            StatsChip(
+              icon: FontAwesomeIcons.solidClock,
+              text:
+                  '${(gameStats!.totalSecondsPlayed / 60).ceil()} min together',
+            ),
+            StatsChip(
+              icon: FontAwesomeIcons.solidHeart,
+              text: '${gameStats!.totalActions} deeds',
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/family/features/reflect/bloc/guess_secret_word_cubit.dart
+++ b/lib/features/family/features/reflect/bloc/guess_secret_word_cubit.dart
@@ -53,7 +53,7 @@ class GuessSecretWordCubit
             await _reflectAndShareRepository.getKidsWithoutBedtime();
         // Check if it's the last game and delay for 2 seconds before continuing
         if (_reflectAndShareRepository.isGameFinished()) {
-          _reflectAndShareRepository.saveSummaryStats();
+          unawaited(_reflectAndShareRepository.saveSummaryStats());
           Timer(const Duration(seconds: 2), () {
             if (kidsWithoutBedtime.isNotEmpty) {
               redirectToBedtimeSelection(kidsWithoutBedtime);
@@ -62,13 +62,14 @@ class GuessSecretWordCubit
             emitCustom(const GuessTheWordCustom.redirectToSummary());
           });
         }
-        AnalyticsHelper.logEvent(
+
+        unawaited(AnalyticsHelper.logEvent(
           eventName:
               AmplitudeEvents.reflectAndShareGuessTotalAttemptsUntilCorrect,
           eventProperties: {
             'total': _attempts,
           },
-        );
+        ));
       }
       _hasSuccess = true;
     }

--- a/lib/features/family/features/reflect/domain/models/game_stats.dart
+++ b/lib/features/family/features/reflect/domain/models/game_stats.dart
@@ -1,0 +1,13 @@
+class GameStats {
+  GameStats({required this.totalActions, required this.totalSecondsPlayed});
+
+  factory GameStats.fromJson(Map<String, dynamic> json) {
+    return GameStats(
+      totalActions: json['totalActions'] as int,
+      totalSecondsPlayed: json['totalSecondsPlayed'] as int,
+    );
+  }
+
+  int totalActions;
+  int totalSecondsPlayed;
+}

--- a/lib/features/family/network/family_api_service.dart
+++ b/lib/features/family/network/family_api_service.dart
@@ -301,6 +301,21 @@ class FamilyAPIService {
     return response.statusCode == 200;
   }
 
+  Future<Map<String, dynamic>> fetchGameStats() async {
+    final url = Uri.https(_apiURL, '/givtservice/v1/game/statistics');
+    final response = await client.get(url);
+
+    if (response.statusCode >= 400) {
+      throw GivtServerFailure(
+        statusCode: response.statusCode,
+        body: jsonDecode(response.body) as Map<String, dynamic>,
+      );
+    } else {
+      final decodedBody = jsonDecode(response.body) as Map<String, dynamic>;
+      return decodedBody['item'] as Map<String, dynamic>;
+    }
+  }
+
   Future<bool> _postRequest(String endpoint, Map<String, dynamic> body) async {
     final url = Uri.https(_apiURL, endpoint);
     final response = await client.post(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Integrated game statistics into the Family Home Screen, enhancing user experience with real-time data.
  - Introduced new widgets (`StatsChip` and `StatsContainer`) for displaying game statistics visually.

- **Improvements**
  - Updated the `FamilyHomeScreenCubit` to manage and reflect game statistics.
  - Enhanced the `FamilyHomeScreen` UI to include game statistics via the new `StatsContainer`.

- **Bug Fixes**
  - Improved handling of asynchronous operations in analytics tracking.

These changes enhance the app's functionality and provide users with valuable insights into their game statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->