### PR TITLE
Bug: Get gamestats on cubit init (kids-1710)

### DIFF
--- a/lib/features/family/features/home_screen/cubit/family_home_screen_cubit.dart
+++ b/lib/features/family/features/home_screen/cubit/family_home_screen_cubit.dart
@@ -35,6 +35,7 @@ class FamilyHomeScreenCubit
     _onGroupsChanged(
       await _impactGroupsRepository.getImpactGroups(fetchWhenEmpty: true),
     );
+    _gameStats = await _reflectAndShareRepository.getGameStats();
     _emitData();
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced initialization of the Family Home Screen to include real-time game statistics.
- **Bug Fixes**
	- Ensured that game statistics are reset properly during logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->