### PR TITLE
Navigate to homescreen only via go router

### DIFF
--- a/lib/features/family/features/reflect/presentation/pages/summary_screen.dart
+++ b/lib/features/family/features/reflect/presentation/pages/summary_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:givt_app/app/routes/app_router.dart';
 import 'package:givt_app/core/enums/amplitude_events.dart';
 import 'package:givt_app/features/family/app/family_pages.dart';
 import 'package:givt_app/features/family/app/injection.dart';
@@ -11,6 +12,7 @@ import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart'
 import 'package:givt_app/shared/models/analytics_event.dart';
 import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
 import 'package:givt_app/shared/widgets/fun_scaffold.dart';
+import 'package:go_router/go_router.dart';
 
 class SummaryScreen extends StatefulWidget {
   const SummaryScreen({super.key});
@@ -79,13 +81,13 @@ class _SummaryScreenState extends State<SummaryScreen> {
                   ),
                 ],
               ),
+              //hmm
+
               const Spacer(),
               FunButton(
                 onTap: () {
-                  Navigator.of(context).popUntil(
-                    ModalRoute.withName(
-                      FamilyPages.profileSelection.name,
-                    ),
+                  context.goNamed(
+                    FamilyPages.profileSelection.name,
                   );
                 },
                 text: 'Back to home',

--- a/lib/features/family/features/reflect/presentation/widgets/leave_game_dialog.dart
+++ b/lib/features/family/features/reflect/presentation/widgets/leave_game_dialog.dart
@@ -7,6 +7,7 @@ import 'package:givt_app/features/family/shared/design/components/components.dar
 import 'package:givt_app/features/family/shared/design/illustrations/fun_icon.dart';
 import 'package:givt_app/features/family/utils/utils.dart';
 import 'package:givt_app/shared/models/analytics_event.dart';
+import 'package:go_router/go_router.dart';
 
 class LeaveGameDialog extends StatelessWidget {
   const LeaveGameDialog({super.key});
@@ -23,10 +24,8 @@ class LeaveGameDialog extends StatelessWidget {
         FunButton.destructive(
           onTap: () {
             getIt<SummaryCubit>().saveSummary();
-            Navigator.of(context).popUntil(
-              ModalRoute.withName(
-                FamilyPages.profileSelection.name,
-              ),
+            context.goNamed(
+              FamilyPages.profileSelection.name,
             );
           },
           text: 'Leave game',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated navigation logic in the Summary Screen and Leave Game Dialog to use named routes for improved user experience.
  
- **Bug Fixes**
	- Streamlined transitions to the profile selection page, enhancing navigation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->