### PR TITLE
Bug: You can swipe back on the success screen when you gave (KIDS-1584)

### DIFF
--- a/lib/features/family/features/coin_flow/screens/success_coin_screen.dart
+++ b/lib/features/family/features/coin_flow/screens/success_coin_screen.dart
@@ -37,52 +37,55 @@ class _SuccessCoinScreenState extends State<SuccessCoinScreen> {
   @override
   Widget build(BuildContext context) {
     final profilesState = context.read<ProfilesCubit>().state;
-    return Scaffold(
-      appBar: AppBar(
-        toolbarHeight: 0,
-        systemOverlayStyle: const SystemUiOverlayStyle(
-          statusBarColor: FamilyAppTheme.secondary98,
-          statusBarIconBrightness: Brightness.dark,
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        appBar: AppBar(
+          toolbarHeight: 0,
+          systemOverlayStyle: const SystemUiOverlayStyle(
+            statusBarColor: FamilyAppTheme.secondary98,
+            statusBarIconBrightness: Brightness.dark,
+          ),
+          backgroundColor: FamilyAppTheme.secondary98,
         ),
         backgroundColor: FamilyAppTheme.secondary98,
-      ),
-      backgroundColor: FamilyAppTheme.secondary98,
-      body: SafeArea(
-        bottom: false,
-        child: Stack(
-          children: [
-            Positioned.fill(
-              child: Lottie.asset(
-                'assets/family/lotties/rays.json',
-                fit: BoxFit.fill,
-                alignment: Alignment.bottomCenter,
-                width: double.infinity,
+        body: SafeArea(
+          bottom: false,
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: Lottie.asset(
+                  'assets/family/lotties/rays.json',
+                  fit: BoxFit.fill,
+                  alignment: Alignment.bottomCenter,
+                  width: double.infinity,
+                ),
               ),
-            ),
-            Positioned.fill(
-              child: SvgPicture.asset(
-                'assets/family/images/box_success.svg',
-                fit: BoxFit.fitWidth,
-                alignment: Alignment.bottomCenter,
-                width: double.infinity,
+              Positioned.fill(
+                child: SvgPicture.asset(
+                  'assets/family/images/box_success.svg',
+                  fit: BoxFit.fitWidth,
+                  alignment: Alignment.bottomCenter,
+                  width: double.infinity,
+                ),
               ),
-            ),
-            Positioned.fill(
-              child: Lottie.asset(
-                'assets/family/lotties/coin_drop_b.json',
-                fit: BoxFit.fitWidth,
-                alignment: Alignment.bottomCenter,
-                width: double.infinity,
+              Positioned.fill(
+                child: Lottie.asset(
+                  'assets/family/lotties/coin_drop_b.json',
+                  fit: BoxFit.fitWidth,
+                  alignment: Alignment.bottomCenter,
+                  width: double.infinity,
+                ),
               ),
-            ),
-            _buildSuccessText(),
-          ],
+              _buildSuccessText(),
+            ],
+          ),
         ),
-      ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
-      floatingActionButton: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24),
-        child: _buildFAB(profilesState.isOnlyChild),
+        floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+        floatingActionButton: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: _buildFAB(profilesState.isOnlyChild),
+        ),
       ),
     );
   }

--- a/lib/features/family/features/giving_flow/screens/success_screen.dart
+++ b/lib/features/family/features/giving_flow/screens/success_screen.dart
@@ -41,94 +41,97 @@ class _SuccessScreenState extends State<SuccessScreen> {
         context.read<CollectGroupDetailsCubit>().state.collectgroup;
     final profilesState = context.read<ProfilesCubit>().state;
 
-    return Scaffold(
-      appBar: AppBar(
-        toolbarHeight: 0,
-        backgroundColor: FamilyAppTheme.secondary98,
-        systemOverlayStyle: const SystemUiOverlayStyle(
-          statusBarColor: FamilyAppTheme.secondary98,
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        appBar: AppBar(
+          toolbarHeight: 0,
+          backgroundColor: FamilyAppTheme.secondary98,
+          systemOverlayStyle: const SystemUiOverlayStyle(
+            statusBarColor: FamilyAppTheme.secondary98,
+          ),
         ),
-      ),
-      backgroundColor: FamilyAppTheme.secondary98,
-      body: SafeArea(
-        bottom: false,
-        child: Stack(
-          children: [
-            Positioned.fill(
-              child: Lottie.asset(
-                'assets/family/lotties/rays.json',
-                fit: BoxFit.fill,
-                alignment: Alignment.bottomCenter,
-                width: double.infinity,
-              ),
-            ),
-            Positioned.fill(
-              child: SvgPicture.asset(
-                'assets/family/images/box_success.svg',
-                fit: BoxFit.fitWidth,
-                alignment: Alignment.bottomCenter,
-                width: double.infinity,
-              ),
-            ),
-            Positioned.fill(
-              child: Lottie.asset(
-                'assets/family/lotties/coin_drop_b.json',
-                fit: BoxFit.fitWidth,
-                alignment: Alignment.bottomCenter,
-                width: double.infinity,
-              ),
-            ),
-            if (widget.isActOfService)
+        backgroundColor: FamilyAppTheme.secondary98,
+        body: SafeArea(
+          bottom: false,
+          child: Stack(
+            children: [
               Positioned.fill(
                 child: Lottie.asset(
-                  'assets/family/lotties/success_heart.json',
+                  'assets/family/lotties/rays.json',
                   fit: BoxFit.fill,
-                  alignment: Alignment.center,
+                  alignment: Alignment.bottomCenter,
                   width: double.infinity,
                 ),
               ),
-            Container(
-              padding: const EdgeInsets.all(40),
-              width: double.infinity,
-              child: Column(
-                children: [
-                  TitleLargeText(
-                    organisation.thankYou ?? 'Awesome!',
-                    textAlign: TextAlign.center,
-                  ),
-                  Text(
-                    widget.isActOfService
-                        ? 'Good luck in completing your act of service'
-                        : 'Thank you for your donation \n to ${organisation.name}',
-                    textAlign: TextAlign.center,
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
-      floatingActionButton: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24),
-        child: widget.onCustomSuccess != null
-            ? FunButton(
-                onTap: widget.onCustomSuccess,
-                text: 'Continue',
-                analyticsEvent: AnalyticsEvent(
-                  AmplitudeEvents.continueClicked,
+              Positioned.fill(
+                child: SvgPicture.asset(
+                  'assets/family/images/box_success.svg',
+                  fit: BoxFit.fitWidth,
+                  alignment: Alignment.bottomCenter,
+                  width: double.infinity,
                 ),
-              )
-            : profilesState.isOnlyChild
-                ? const BackHomeButton()
-                : const Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      BackHomeButton(),
-                      SizedBox(height: 12),
-                      SwitchProfileSuccessButton(),
-                    ],
+              ),
+              Positioned.fill(
+                child: Lottie.asset(
+                  'assets/family/lotties/coin_drop_b.json',
+                  fit: BoxFit.fitWidth,
+                  alignment: Alignment.bottomCenter,
+                  width: double.infinity,
+                ),
+              ),
+              if (widget.isActOfService)
+                Positioned.fill(
+                  child: Lottie.asset(
+                    'assets/family/lotties/success_heart.json',
+                    fit: BoxFit.fill,
+                    alignment: Alignment.center,
+                    width: double.infinity,
                   ),
+                ),
+              Container(
+                padding: const EdgeInsets.all(40),
+                width: double.infinity,
+                child: Column(
+                  children: [
+                    TitleLargeText(
+                      organisation.thankYou ?? 'Awesome!',
+                      textAlign: TextAlign.center,
+                    ),
+                    Text(
+                      widget.isActOfService
+                          ? 'Good luck in completing your act of service'
+                          : 'Thank you for your donation \n to ${organisation.name}',
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+        floatingActionButton: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: widget.onCustomSuccess != null
+              ? FunButton(
+                  onTap: widget.onCustomSuccess,
+                  text: 'Continue',
+                  analyticsEvent: AnalyticsEvent(
+                    AmplitudeEvents.continueClicked,
+                  ),
+                )
+              : profilesState.isOnlyChild
+                  ? const BackHomeButton()
+                  : const Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        BackHomeButton(),
+                        SizedBox(height: 12),
+                        SwitchProfileSuccessButton(),
+                      ],
+                    ),
+        ),
       ),
     );
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced widget structure for the Success Coin and Success screens, improving layout clarity.
  
- **Bug Fixes**
	- Prevented navigation stack popping for both Success Coin and Success screens by implementing a `PopScope` widget.

- **Refactor**
	- Improved readability and organization of widget declarations and layout within the screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->