### PR TITLE
Bug: Remove last q twice and always show confetti (kids-1718)

### DIFF
--- a/lib/features/family/features/reflect/bloc/interview_cubit.dart
+++ b/lib/features/family/features/reflect/bloc/interview_cubit.dart
@@ -93,11 +93,6 @@ class InterviewCubit extends CommonCubit<InterviewUIModel, InterviewCustom> {
     advanceToNext();
   }
 
-  // Get button text for current state
-  String getButtonText() {
-    return _hasOnlyOneReporter() ? 'Next Question' : 'Next Reporter';
-  }
-
   bool _hasOnlyOneReporter() => _reporters.length == 1;
 
   void _emitData() {
@@ -108,7 +103,7 @@ class InterviewCubit extends CommonCubit<InterviewUIModel, InterviewCustom> {
         InterviewUIModel.recordAnswer(
           reporter: getCurrentReporter(),
           question: getCurrentQuestion(),
-          buttonText: getButtonText(),
+          buttonText: 'Next Question',
           questionNumber: _nrOfQuestionsAsked + 1,
         ),
       );

--- a/lib/features/family/features/reflect/bloc/interview_cubit.dart
+++ b/lib/features/family/features/reflect/bloc/interview_cubit.dart
@@ -95,7 +95,6 @@ class InterviewCubit extends CommonCubit<InterviewUIModel, InterviewCustom> {
 
   // Get button text for current state
   String getButtonText() {
-    if (_nextQuestionIsLast()) return 'Last question';
     return _hasOnlyOneReporter() ? 'Next Question' : 'Next Reporter';
   }
 

--- a/lib/features/family/features/reflect/presentation/pages/summary_screen.dart
+++ b/lib/features/family/features/reflect/presentation/pages/summary_screen.dart
@@ -116,9 +116,7 @@ class _SummaryScreenState extends State<SummaryScreen> {
                     sendAudioAndNavigate(details.audioPath);
                     return;
                   }
-                  context.goNamed(
-                    FamilyPages.profileSelection.name,
-                  );
+                  navigateWithConfetti();
                 },
                 isPressedDown: pressDown,
                 text: (showPlayer || showRecorder)
@@ -139,7 +137,10 @@ class _SummaryScreenState extends State<SummaryScreen> {
 
   Future<void> sendAudioAndNavigate(String path) async {
     await _cubit.shareAudio(path);
-    if (!mounted) return;
+    await navigateWithConfetti();
+  }
+
+  Future<void> navigateWithConfetti() async {
     setState(() {
       pressDown = true;
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new navigation method with confetti animation to enhance user experience during transitions.
  
- **Bug Fixes**
	- Improved error handling to prevent navigation issues during asynchronous operations.

- **Refactor**
	- Simplified button text logic in the interview flow by hardcoding the button text to 'Next Question'.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->