### PR TITLE
Bug: do not show latest summary button on homescreen when it isnt available (KIDS-1717)

### DIFF
--- a/lib/core/enums/amplitude_events.dart
+++ b/lib/core/enums/amplitude_events.dart
@@ -317,10 +317,13 @@ enum AmplitudeEvents {
     'family_mission_acceptance_screen_accept_long_press_release_to_accept',
   ),
   // Family Home Screen
-  FamilyHomeScreenGratitudeGameButtonClicked(
+  familyHomeScreenGratitudeGameButtonClicked(
     'family_home_screen_gratitude_game_button_clicked',
   ),
-  FamilyHomeScreenGiveButtonClicked('family_home_screen_give_button_clicked'),
+  familyHomeScreenGiveButtonClicked('family_home_screen_give_button_clicked'),
+  familyHomeScreenLatestSummaryClicked(
+    'family_home_screen_latest_summary_clicked',
+  ),
 
   // Fun Counter
   funCounterDecrementClicked('fun_counter_decrement_clicked'),

--- a/lib/features/family/app/injection.dart
+++ b/lib/features/family/app/injection.dart
@@ -120,6 +120,7 @@ void initCubits() {
         getIt(),
         getIt(),
         getIt(),
+        getIt(),
       ),
     )
     ..registerLazySingleton<AvatarsCubit>(

--- a/lib/features/family/features/gratitude-summary/bloc/parent_summary_cubit.dart
+++ b/lib/features/family/features/gratitude-summary/bloc/parent_summary_cubit.dart
@@ -26,79 +26,9 @@ class ParentSummaryCubit extends CommonCubit<ParentSummaryUIModel?, dynamic> {
       emitLoading();
       final summary = await _summaryRepository.fetchLatestGameSummary();
       _summary = summary;
-    } catch (e,s) {
+    } catch (e, s) {
       LoggingInfo.instance
           .error('Failed to fetch summary', methodName: 'fetchSummary');
-      _summary = ParentSummaryItem(
-        date: DateTime.now(),
-        audio: 'https://download.samplelib.com/mp3/sample-3s.mp3',
-        conversations: [
-          Conversation(
-              sentence:
-                  "Grateful for nature, I donated \$5 to Make-A-Wish to help make dreams come true.",
-              profile: Profile.fromMap(jsonDecode('''
-                {
-                  "id": "ea04efcc-f9c4-433d-90c3-8df1d14a9625",
-                  "firstName": "Debby",
-                  "lastName": null,
-                  "dateOfBirth": "2019-07-01T00:00:00",
-                  "givingAllowance": null,
-                  "bedTime": "18:00:00",
-                  "windDownTime": 30,
-                  "type": "Child",
-                  "picture": {
-                    "fileName": "Hero1.svg",
-                    "pictureURL": "https://givtstoragedebug.blob.core.windows.net/public/cdn/avatars/Hero7.svg"
-                  },
-                  "wallet": {
-                    "balance": 0.0,
-                    "total": 0.0,
-                    "pending": 0,
-                    "currency": "USD",
-                    "pendingAllowance": false,
-                    "givingAllowance": {
-                      "amount": 0,
-                      "nextGivingAllowance": "0001-01-01T00:00:00+00:00",
-                      "frequency": "None"
-                    }
-                  },
-                  "latestDonation": null
-                }
-              ''') as Map<String, dynamic>)),
-          Conversation(
-              sentence:
-              "Grateful for our home, I’m packing a care bag to help someone in need feel cared for.",
-              profile: Profile.fromMap(jsonDecode('''
-                {
-                  "id": "ea04efcc-f9c4-433d-90c3-8df1d14a9625",
-                  "firstName": "James",
-                  "lastName": null,
-                  "dateOfBirth": "2019-07-01T00:00:00",
-                  "givingAllowance": null,
-                  "bedTime": "18:00:00",
-                  "windDownTime": 30,
-                  "type": "Child",
-                  "picture": {
-                    "fileName": "Hero1.svg",
-                    "pictureURL": "https://givtstoragedebug.blob.core.windows.net/public/cdn/avatars/Hero4.svg"
-                  },
-                  "wallet": {
-                    "balance": 0.0,
-                    "total": 0.0,
-                    "pending": 0,
-                    "currency": "USD",
-                    "pendingAllowance": false,
-                    "givingAllowance": {
-                      "amount": 0,
-                      "nextGivingAllowance": "0001-01-01T00:00:00+00:00",
-                      "frequency": "None"
-                    }
-                  },
-                  "latestDonation": null
-                }
-              ''') as Map<String, dynamic>)),
-        ],
-      );
     }
     _emitData();
   }

--- a/lib/features/family/features/home_screen/cubit/family_home_screen_cubit.dart
+++ b/lib/features/family/features/home_screen/cubit/family_home_screen_cubit.dart
@@ -1,4 +1,6 @@
 import 'package:collection/collection.dart';
+import 'package:givt_app/features/family/features/gratitude-summary/domain/models/parent_summary_item.dart';
+import 'package:givt_app/features/family/features/gratitude-summary/domain/repositories/parent_summary_repository.dart';
 import 'package:givt_app/features/family/features/home_screen/presentation/models/family_home_screen.uimodel.dart';
 import 'package:givt_app/features/family/features/profiles/models/profile.dart';
 import 'package:givt_app/features/family/features/profiles/repository/profiles_repository.dart';
@@ -16,15 +18,17 @@ class FamilyHomeScreenCubit
     this._profilesRepository,
     this._impactGroupsRepository,
     this._reflectAndShareRepository,
+    this._summaryRepository,
   ) : super(const BaseState.loading());
 
   final ProfilesRepository _profilesRepository;
   final ImpactGroupsRepository _impactGroupsRepository;
   final ReflectAndShareRepository _reflectAndShareRepository;
-
+  final ParentSummaryRepository _summaryRepository;
   List<Profile> profiles = [];
   ImpactGroup? _familyGroup;
   GameStats? _gameStats;
+  ParentSummaryItem? _latestSummary;
 
   Future<void> init() async {
     _profilesRepository.onProfilesChanged().listen(_onProfilesChanged);
@@ -61,6 +65,16 @@ class FamilyHomeScreenCubit
   void _onGameStatsChanged(GameStats gameStats) {
     _gameStats = gameStats;
     _emitData();
+    _getLatestGameSummary();
+  }
+
+  Future<void> _getLatestGameSummary() async {
+    try {
+      _latestSummary = await _summaryRepository.fetchLatestGameSummary();
+      _emitData();
+    } catch (e, s) {
+      // do nothing, we don't have a summary that's all
+    }
   }
 
   void onGiveButtonPressed() {
@@ -86,6 +100,7 @@ class FamilyHomeScreenCubit
           .toList(),
       familyGroupName: _familyGroup?.name,
       gameStats: _gameStats,
+      showLatestSummaryBtn: _latestSummary != null,
     );
   }
 

--- a/lib/features/family/features/home_screen/presentation/models/family_home_screen.uimodel.dart
+++ b/lib/features/family/features/home_screen/presentation/models/family_home_screen.uimodel.dart
@@ -6,9 +6,11 @@ class FamilyHomeScreenUIModel {
     required this.avatars,
     this.familyGroupName,
     this.gameStats,
+    this.showLatestSummaryBtn = false,
   });
 
   final List<AvatarUIModel> avatars;
   final String? familyGroupName;
   final GameStats? gameStats;
+  final bool showLatestSummaryBtn;
 }

--- a/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
@@ -126,15 +126,17 @@ class _FamilyHomeScreenState extends State<FamilyHomeScreen> {
                       GiveButton(
                         onPressed: _cubit.onGiveButtonPressed,
                       ),
-                      if(uiModel.showLatestSummaryBtn) const SizedBox(height: 4),
-                      if(uiModel.showLatestSummaryBtn) FunButton.secondary(
-                        onTap: () => context.goNamed(
-                          FamilyPages.parentSummary.name,
+                      if (uiModel.showLatestSummaryBtn)
+                        const SizedBox(height: 4),
+                      if (true ?? uiModel.showLatestSummaryBtn)
+                        FunButton.secondary(
+                          onTap: () => context.goNamed(
+                            FamilyPages.parentSummary.name,
+                          ),
+                          text: 'Show Latest Summary',
+                          analyticsEvent: AnalyticsEvent(AmplitudeEvents
+                              .familyHomeScreenLatestSummaryClicked),
                         ),
-                        text: 'Show Latest Summary',
-                        analyticsEvent: AnalyticsEvent(
-                            AmplitudeEvents.FamilyHomeScreenGiveButtonClicked),
-                      ),
                     ],
                   ),
                 ),

--- a/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
@@ -126,8 +126,8 @@ class _FamilyHomeScreenState extends State<FamilyHomeScreen> {
                       GiveButton(
                         onPressed: _cubit.onGiveButtonPressed,
                       ),
-                      const SizedBox(height: 4),
-                      FunButton.secondary(
+                      if(uiModel.showLatestSummaryBtn) const SizedBox(height: 4),
+                      if(uiModel.showLatestSummaryBtn) FunButton.secondary(
                         onTap: () => context.goNamed(
                           FamilyPages.parentSummary.name,
                         ),

--- a/lib/features/family/features/home_screen/widgets/give_button.dart
+++ b/lib/features/family/features/home_screen/widgets/give_button.dart
@@ -16,7 +16,7 @@ class GiveButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return ActionContainer(
       analyticsEvent: AnalyticsEvent(
-        AmplitudeEvents.FamilyHomeScreenGiveButtonClicked,
+        AmplitudeEvents.familyHomeScreenGiveButtonClicked,
       ),
       onTap: onPressed,
       borderColor: FamilyAppTheme.secondary80,

--- a/lib/features/family/features/home_screen/widgets/gratitude_game_button.dart
+++ b/lib/features/family/features/home_screen/widgets/gratitude_game_button.dart
@@ -15,7 +15,7 @@ class GratitudeGameButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return ActionContainer(
       analyticsEvent: AnalyticsEvent(
-        AmplitudeEvents.FamilyHomeScreenGratitudeGameButtonClicked,
+        AmplitudeEvents.familyHomeScreenGratitudeGameButtonClicked,
       ),
       onTap: onPressed,
       borderColor: FamilyAppTheme.highlight80,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a "Show Latest Summary" button on the Family Home Screen, which dynamically appears based on the latest game summary availability.
  
- **Bug Fixes**
  - Improved error handling in the Parent Summary fetching process to enhance user experience.

- **Enhancements**
  - Updated the Family Home Screen UI model to support conditional rendering of the latest summary button.
  - Enhanced the Family Home Screen functionality to fetch and display the latest game summary.
  - Updated analytics event naming for consistency across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->