### PR TITLE
Bug: Also check that summary isn't empty (KIDS-1717)

### DIFF
--- a/lib/features/family/features/gratitude-summary/domain/models/parent_summary_item.dart
+++ b/lib/features/family/features/gratitude-summary/domain/models/parent_summary_item.dart
@@ -26,6 +26,8 @@ class ParentSummaryItem {
   final String? audio;
   final DateTime? date;
 
+  bool isEmpty() => conversations.isEmpty;
+
   ParentSummaryUIModel toUIModel() {
     return ParentSummaryUIModel(
       conversations: conversations.map((e) => e.toUIModel()).toList(),

--- a/lib/features/family/features/home_screen/cubit/family_home_screen_cubit.dart
+++ b/lib/features/family/features/home_screen/cubit/family_home_screen_cubit.dart
@@ -100,7 +100,8 @@ class FamilyHomeScreenCubit
           .toList(),
       familyGroupName: _familyGroup?.name,
       gameStats: _gameStats,
-      showLatestSummaryBtn: _latestSummary != null,
+      showLatestSummaryBtn:
+          _latestSummary != null && !_latestSummary!.isEmpty(),
     );
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to check if there are any conversations in the Parent Summary Item.
	- Updated logic to display the latest summary button only when a valid, non-empty summary is available.

- **Bug Fixes**
	- Enhanced conditions for showing the latest summary button to improve user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->