### PR TITLE
Bug: Give to previous should not be goal specific, only org namespace (kids-1350)

### DIFF
--- a/lib/features/give/bloc/give/give_bloc.dart
+++ b/lib/features/give/bloc/give/give_bloc.dart
@@ -194,8 +194,9 @@ class GiveBloc extends Bloc<GiveEvent, GiveState> {
   ) async {
     emit(state.copyWith(status: GiveStatus.loading));
     try {
+      final namespace = state.organisation.mediumId!.split('.').first;
       await _processGivts(
-        namespace: state.organisation.mediumId!,
+        namespace: namespace,
         userGUID: event.userGUID,
         emit: emit,
       );

--- a/lib/features/give/bloc/give/give_bloc.dart
+++ b/lib/features/give/bloc/give/give_bloc.dart
@@ -194,9 +194,8 @@ class GiveBloc extends Bloc<GiveEvent, GiveState> {
   ) async {
     emit(state.copyWith(status: GiveStatus.loading));
     try {
-      final namespace = state.organisation.mediumId!.split('.').first;
       await _processGivts(
-        namespace: namespace,
+        namespace: state.organisation.mediumId!.split('.').first,
         userGUID: event.userGUID,
         emit: emit,
       );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling with consistent logging of exceptions and stack traces.
  
- **Refactor**
	- Enhanced the logic for processing the `namespace` parameter in donation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->