### PR TITLE
Bug: Make sure first use pop ups are permanently dismissed (kids-335)

### DIFF
--- a/lib/features/personal_summary/overview/dialogs/first_use_summary_dialog.dart
+++ b/lib/features/personal_summary/overview/dialogs/first_use_summary_dialog.dart
@@ -24,6 +24,13 @@ class _FirstUseSummaryDialogState extends State<FirstUseSummaryDialog> {
   int currentIndex = 0;
   final CarouselSliderController _controller = CarouselSliderController();
 
+  void permanentlyDismiss() {
+    getIt<SharedPreferences>().setBool(
+      Util.testimonialsSummaryKey,
+      true,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final locals = context.l10n;
@@ -119,12 +126,14 @@ class _FirstUseSummaryDialogState extends State<FirstUseSummaryDialog> {
                     Positioned(
                       right: -5,
                       child: IconButton(
-                        icon: const Icon(
-                          Icons.close_rounded,
-                          size: 32,
-                        ),
-                        onPressed: () => Navigator.of(context).pop(),
-                      ),
+                          icon: const Icon(
+                            Icons.close_rounded,
+                            size: 32,
+                          ),
+                          onPressed: () {
+                            permanentlyDismiss();
+                            Navigator.of(context).pop();
+                          }),
                     ),
                   ],
                 );
@@ -146,10 +155,7 @@ class _FirstUseSummaryDialogState extends State<FirstUseSummaryDialog> {
                 width: 200,
                 child: ElevatedButton(
                   onPressed: () {
-                    getIt<SharedPreferences>().setBool(
-                      Util.testimonialsSummaryKey,
-                      true,
-                    );
+                    permanentlyDismiss();
                     Navigator.of(context).pop();
                     switch (currentIndex) {
                       case 1:

--- a/lib/features/personal_summary/overview/dialogs/first_use_summary_dialog.dart
+++ b/lib/features/personal_summary/overview/dialogs/first_use_summary_dialog.dart
@@ -1,15 +1,12 @@
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:givt_app/app/injection/injection.dart';
 import 'package:givt_app/app/routes/routes.dart';
 import 'package:givt_app/features/personal_summary/giving_goal/pages/setup_giving_goal_bottom_sheet.dart';
 import 'package:givt_app/features/personal_summary/overview/bloc/personal_summary_bloc.dart';
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/shared/models/models.dart';
-import 'package:givt_app/utils/utils.dart';
 import 'package:go_router/go_router.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 class FirstUseSummaryDialog extends StatefulWidget {
   const FirstUseSummaryDialog({
@@ -23,13 +20,6 @@ class FirstUseSummaryDialog extends StatefulWidget {
 class _FirstUseSummaryDialogState extends State<FirstUseSummaryDialog> {
   int currentIndex = 0;
   final CarouselSliderController _controller = CarouselSliderController();
-
-  void permanentlyDismiss() {
-    getIt<SharedPreferences>().setBool(
-      Util.testimonialsSummaryKey,
-      true,
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -126,14 +116,12 @@ class _FirstUseSummaryDialogState extends State<FirstUseSummaryDialog> {
                     Positioned(
                       right: -5,
                       child: IconButton(
-                          icon: const Icon(
-                            Icons.close_rounded,
-                            size: 32,
-                          ),
-                          onPressed: () {
-                            permanentlyDismiss();
-                            Navigator.of(context).pop();
-                          }),
+                        icon: const Icon(
+                          Icons.close_rounded,
+                          size: 32,
+                        ),
+                        onPressed: () => Navigator.of(context).pop(),
+                      ),
                     ),
                   ],
                 );
@@ -155,7 +143,6 @@ class _FirstUseSummaryDialogState extends State<FirstUseSummaryDialog> {
                 width: 200,
                 child: ElevatedButton(
                   onPressed: () {
-                    permanentlyDismiss();
                     Navigator.of(context).pop();
                     switch (currentIndex) {
                       case 1:

--- a/lib/features/personal_summary/overview/pages/personal_summary_page.dart
+++ b/lib/features/personal_summary/overview/pages/personal_summary_page.dart
@@ -136,6 +136,10 @@ class PersonalSummary extends StatelessWidget {
       );
 
   void _showFirstUseDialogs(BuildContext context) {
+    getIt<SharedPreferences>().setBool(
+      Util.testimonialsSummaryKey,
+      true,
+    );
     showDialog<void>(
       context: context,
       barrierDismissible: false,

--- a/lib/features/personal_summary/overview/pages/personal_summary_page.dart
+++ b/lib/features/personal_summary/overview/pages/personal_summary_page.dart
@@ -142,7 +142,6 @@ class PersonalSummary extends StatelessWidget {
     );
     showDialog<void>(
       context: context,
-      barrierDismissible: false,
       builder: (_) => BlocProvider.value(
         value: context.read<PersonalSummaryBloc>(),
         child: const FirstUseSummaryDialog(),

--- a/lib/features/personal_summary/overview/pages/personal_summary_page.dart
+++ b/lib/features/personal_summary/overview/pages/personal_summary_page.dart
@@ -138,6 +138,7 @@ class PersonalSummary extends StatelessWidget {
   void _showFirstUseDialogs(BuildContext context) {
     showDialog<void>(
       context: context,
+      barrierDismissible: false,
       builder: (_) => BlocProvider.value(
         value: context.read<PersonalSummaryBloc>(),
         child: const FirstUseSummaryDialog(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to permanently dismiss the first-use summary dialog, improving user experience by remembering user preferences.
	- Enhanced dialog control by preventing dismissal when tapping outside, ensuring users interact with the dialog until they choose to close it.

- **Bug Fixes**
	- Streamlined dismissal logic for better maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->