### PR TITLE
Feature: Make sure gratitude game analytics events are unique (KIDS-1730)

### DIFF
--- a/lib/core/enums/amplitude_events.dart
+++ b/lib/core/enums/amplitude_events.dart
@@ -256,10 +256,11 @@ enum AmplitudeEvents {
   parentGaveSuccessfully('parent_gave_successfully'),
 
   // Reflect and Share
-  reflectandShareAssignRolesClicked('reflect_and_share_assign_roles_clicked'),
+  reflectAndShareAssignRolesClicked('reflect_and_share_assign_roles_clicked'),
   reflectAndShareClicked('reflect_and_share_clicked'),
   reflectAndShareLetsGoClicked('reflect_and_share_lets_go_clicked'),
-  reflectAndShareStartClicked('reflect_and_share_start_clicked'),
+  assignedFamilyRolesStartClicked('assigned_family_roles_start_clicked'),
+  supersShowItsShowtimeClicked('supers_show_its_showtime_clicked'),
   reflectAndShareSeeTheRulesClicked('reflect_and_share_see_the_rules_clicked'),
   reflectAndShareRulesNextClicked('reflect_and_share_next_clicked'),
   reflectAndShareMemberAdded('reflect_and_share_member_added'),

--- a/lib/features/family/features/reflect/presentation/pages/family_roles_screen.dart
+++ b/lib/features/family/features/reflect/presentation/pages/family_roles_screen.dart
@@ -70,7 +70,7 @@ class _FamilyRolesScreenState extends State<FamilyRolesScreen> {
                     onTap: _cubit.onClickStart,
                     text: 'Start',
                     analyticsEvent: AnalyticsEvent(
-                      AmplitudeEvents.reflectAndShareStartClicked,
+                      AmplitudeEvents.assignedFamilyRolesStartClicked,
                     ),
                   ),
                 ],

--- a/lib/features/family/features/reflect/presentation/pages/reflect_intro_screen.dart
+++ b/lib/features/family/features/reflect/presentation/pages/reflect_intro_screen.dart
@@ -34,6 +34,7 @@ class ReflectIntroScreen extends StatelessWidget {
           FunButton(
             onTap: () {
               Navigator.of(context).push(StageScreen(
+                fromInitialExplanationScreen: true,
                 buttonText: 'Start',
                 onClickButton: (context) {
                   Navigator.of(context)

--- a/lib/features/family/features/reflect/presentation/pages/stage_screen.dart
+++ b/lib/features/family/features/reflect/presentation/pages/stage_screen.dart
@@ -10,10 +10,12 @@ class StageScreen extends StatelessWidget {
   const StageScreen({
     required this.buttonText,
     required this.onClickButton,
+    this.fromInitialExplanationScreen = false,
     super.key,
   });
 
   final String buttonText;
+  final bool fromInitialExplanationScreen;
   final void Function(BuildContext context) onClickButton;
 
   @override
@@ -35,10 +37,14 @@ class StageScreen extends StatelessWidget {
         ),
       ),
       floatingActionButton: FunButton(
-          onTap: () => onClickButton(context),
-          text: buttonText,
-          analyticsEvent:
-              AnalyticsEvent(AmplitudeEvents.reflectAndShareStartClicked)),
+        onTap: () => onClickButton(context),
+        text: buttonText,
+        analyticsEvent: AnalyticsEvent(
+            AmplitudeEvents.supersShowItsShowtimeClicked,
+            parameters: {
+              'fromInitialExplanationScreen': fromInitialExplanationScreen,
+            }),
+      ),
     );
   }
 }


### PR DESCRIPTION
https://linear.app/givt/issue/KIDS-1730/add-a-new-its-showtime-amplitude-event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new analytics events for better tracking: `supersShowItsShowtimeClicked` and `assignedFamilyRolesStartClicked`.
	- Enhanced the `StageScreen` with a new parameter to improve analytics detail.

- **Bug Fixes**
	- Corrected casing for `reflectAndShareAssignRolesClicked` event for consistent formatting.

- **Refactor**
	- Updated event tracking in the `FunButton` widget across multiple screens to reflect new event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->