### PR TITLE
hotfix for api selection country whatever

### DIFF
--- a/lib/features/email_signup/cubit/email_signup_cubit.dart
+++ b/lib/features/email_signup/cubit/email_signup_cubit.dart
@@ -92,18 +92,6 @@ class EmailSignupCubit
   Future<void> updateCountry(Country country) async {
     _currentCountry = country;
 
-    var baseUrl = const String.fromEnvironment('API_URL_EU');
-    var baseUrlAWS = const String.fromEnvironment('API_URL_AWS_EU');
-
-    if (country.isUS) {
-      baseUrl = const String.fromEnvironment('API_URL_US');
-      baseUrlAWS = const String.fromEnvironment('API_URL_AWS_US');
-    }
-
-    log('Using API URL: $baseUrl');
-    get_it.getIt<RequestHelper>().updateApiUrl(baseUrl, baseUrlAWS);
-    get_it.getIt<RequestHelper>().country = country.countryCode;
-
     // update country iso in shared preferences
     final prefs = get_it.getIt<SharedPreferences>();
     unawaited(prefs.setString(Util.countryIso, country.countryCode));
@@ -115,6 +103,20 @@ class EmailSignupCubit
         continueButtonEnabled: validateEmail(_currentEmail),
       ),
     );
+  }
+
+  void updateApi() {
+    var baseUrl = const String.fromEnvironment('API_URL_EU');
+    var baseUrlAWS = const String.fromEnvironment('API_URL_AWS_EU');
+
+    if (_currentCountry.isUS) {
+      baseUrl = const String.fromEnvironment('API_URL_US');
+      baseUrlAWS = const String.fromEnvironment('API_URL_AWS_US');
+    }
+
+    log('Using API URL: $baseUrl');
+    get_it.getIt<RequestHelper>().updateApiUrl(baseUrl, baseUrlAWS);
+    get_it.getIt<RequestHelper>().country = _currentCountry.countryCode;
   }
 
   Future<void> updateEmail(String email) async {

--- a/lib/features/email_signup/presentation/pages/email_signup_page.dart
+++ b/lib/features/email_signup/presentation/pages/email_signup_page.dart
@@ -198,6 +198,7 @@ class _EmailSignupPageState extends State<EmailSignupPage> {
                             isLoading: _isLoading,
                             onTap: state.continueButtonEnabled
                                 ? () async {
+                                    _cubit.updateApi();
                                     if (state.country.isUS) {
                                       await _cubit.login();
                                     } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- API URL updates are now triggered when the continue button is tapped on the email signup page, ensuring consistency regardless of the user's country.
  
- **Bug Fixes**
	- Improved control flow in the handling of custom events to prevent unintended execution through proper case handling in the switch statement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->