### PR TITLE
Feature: not playing a round ends up in summary screen for example (KIDS-1743)

### DIFF
--- a/lib/features/family/features/home_screen/cubit/navigation_bar_home_cubit.dart
+++ b/lib/features/family/features/home_screen/cubit/navigation_bar_home_cubit.dart
@@ -2,15 +2,14 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:givt_app/core/logging/logging.dart';
-import 'package:givt_app/features/auth/repositories/auth_repository.dart';
 import 'package:givt_app/features/family/features/auth/data/family_auth_repository.dart';
 import 'package:givt_app/features/family/features/home_screen/presentation/models/navigation_bar_home_custom.dart';
 import 'package:givt_app/features/family/features/home_screen/presentation/models/navigation_bar_home_screen_uimodel.dart';
 import 'package:givt_app/features/family/features/home_screen/usecases/box_origin_usecase.dart';
 import 'package:givt_app/features/family/features/home_screen/usecases/registration_usecase.dart';
+import 'package:givt_app/features/family/features/impact_groups/models/impact_group.dart';
 import 'package:givt_app/features/family/features/profiles/models/profile.dart';
 import 'package:givt_app/features/family/features/profiles/repository/profiles_repository.dart';
-import 'package:givt_app/features/family/features/impact_groups/models/impact_group.dart';
 import 'package:givt_app/features/impact_groups_legacy_logic/repo/impact_groups_repository.dart';
 import 'package:givt_app/shared/bloc/base_state.dart';
 import 'package:givt_app/shared/bloc/common_cubit.dart';

--- a/lib/features/family/features/home_screen/presentation/pages/navigation_bar_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/navigation_bar_home_screen.dart
@@ -18,13 +18,13 @@ import 'package:givt_app/features/family/features/home_screen/cubit/navigation_b
 import 'package:givt_app/features/family/features/home_screen/presentation/models/navigation_bar_home_custom.dart';
 import 'package:givt_app/features/family/features/home_screen/presentation/models/navigation_bar_home_screen_uimodel.dart';
 import 'package:givt_app/features/family/features/home_screen/presentation/pages/family_home_screen.dart';
+import 'package:givt_app/features/family/features/impact_groups/widgets/dialogs/impact_group_recieve_invite_sheet.dart';
 import 'package:givt_app/features/family/features/overview/pages/family_overview_page.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/features/family/shared/design/illustrations/fun_icon.dart';
 import 'package:givt_app/features/family/shared/widgets/loading/custom_progress_indicator.dart';
 import 'package:givt_app/features/family/shared/widgets/loading/full_screen_loading_widget.dart';
 import 'package:givt_app/features/family/utils/family_auth_utils.dart';
-import 'package:givt_app/features/family/features/impact_groups/widgets/dialogs/impact_group_recieve_invite_sheet.dart';
 import 'package:givt_app/features/internet_connection/internet_connection_cubit.dart';
 import 'package:givt_app/shared/dialogs/internet_connection_lost_dialog.dart';
 import 'package:givt_app/shared/models/analytics_event.dart';

--- a/lib/features/family/features/home_screen/presentation/pages/navigation_bar_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/navigation_bar_home_screen.dart
@@ -20,6 +20,7 @@ import 'package:givt_app/features/family/features/home_screen/presentation/model
 import 'package:givt_app/features/family/features/home_screen/presentation/pages/family_home_screen.dart';
 import 'package:givt_app/features/family/features/impact_groups/widgets/dialogs/impact_group_recieve_invite_sheet.dart';
 import 'package:givt_app/features/family/features/overview/pages/family_overview_page.dart';
+import 'package:givt_app/features/family/features/impact_groups/models/impact_group.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/features/family/shared/design/illustrations/fun_icon.dart';
 import 'package:givt_app/features/family/shared/widgets/loading/custom_progress_indicator.dart';

--- a/lib/features/family/features/reflect/bloc/interview_cubit.dart
+++ b/lib/features/family/features/reflect/bloc/interview_cubit.dart
@@ -22,6 +22,7 @@ class InterviewCubit extends CommonCubit<InterviewUIModel, InterviewCustom> {
     _currentReporterIndex = 0;
     _currentQuestionIndex = 0;
     _nrOfQuestionsAsked = 0;
+    _reflectAndShareRepository.onStartedInterview();
 
     _emitData();
   }

--- a/lib/features/family/features/reflect/bloc/leave_game_cubit.dart
+++ b/lib/features/family/features/reflect/bloc/leave_game_cubit.dart
@@ -1,15 +1,22 @@
 import 'package:givt_app/features/family/features/reflect/domain/models/game_profile.dart';
 import 'package:givt_app/features/family/features/reflect/domain/reflect_and_share_repository.dart';
+import 'package:givt_app/features/family/features/reflect/presentation/models/leave_game_custom.dart';
 import 'package:givt_app/shared/bloc/base_state.dart';
 import 'package:givt_app/shared/bloc/common_cubit.dart';
 
-class LeaveGameCubit extends CommonCubit<dynamic, bool> {
+class LeaveGameCubit extends CommonCubit<dynamic, LeaveGameCustom> {
   LeaveGameCubit(this._reflectAndShareRepository)
       : super(const BaseState.initial());
 
   final ReflectAndShareRepository _reflectAndShareRepository;
 
   void onConfirmLeaveGameClicked() {
-    emitCustom(_reflectAndShareRepository.isFirstRound());
+    emitCustom(
+      LeaveGameCustom(
+        isFirstRound: _reflectAndShareRepository.isFirstRound(),
+        hasAtLeastStartedInterview:
+            _reflectAndShareRepository.hasStartedInterview(),
+      ),
+    );
   }
 }

--- a/lib/features/family/features/reflect/domain/reflect_and_share_repository.dart
+++ b/lib/features/family/features/reflect/domain/reflect_and_share_repository.dart
@@ -36,6 +36,7 @@ class ReflectAndShareRepository {
   List<GameProfile> _selectedProfiles = [];
   final List<String> _usedSecretWords = [];
   String? _currentSecretWord;
+  bool _hasStartedInterview = false;
 
   GameStats? _gameStatsData;
 
@@ -521,10 +522,17 @@ class ReflectAndShareRepository {
     _usedSecretWords.clear();
     _currentSecretWord = null;
     _gameStatsData = null;
+    _hasStartedInterview = false;
   }
 
   void onCloseGame() {
     reset();
     _gameFinishedStreamController.add(null);
   }
+
+  void onStartedInterview() {
+    _hasStartedInterview = true;
+  }
+
+  bool hasStartedInterview() => _hasStartedInterview;
 }

--- a/lib/features/family/features/reflect/presentation/models/leave_game_custom.dart
+++ b/lib/features/family/features/reflect/presentation/models/leave_game_custom.dart
@@ -1,0 +1,9 @@
+class LeaveGameCustom {
+  const LeaveGameCustom({
+    required this.isFirstRound,
+    required this.hasAtLeastStartedInterview,
+  });
+
+  final bool isFirstRound;
+  final bool hasAtLeastStartedInterview;
+}

--- a/lib/features/family/features/reflect/presentation/widgets/leave_game_button.dart
+++ b/lib/features/family/features/reflect/presentation/widgets/leave_game_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:givt_app/features/family/app/family_pages.dart';
 import 'package:givt_app/features/family/app/injection.dart';
 import 'package:givt_app/features/family/extensions/extensions.dart';
 import 'package:givt_app/features/family/features/reflect/bloc/leave_game_cubit.dart';
@@ -7,6 +8,7 @@ import 'package:givt_app/features/family/features/reflect/presentation/pages/gra
 import 'package:givt_app/features/family/features/reflect/presentation/pages/summary_screen.dart';
 import 'package:givt_app/features/family/features/reflect/presentation/widgets/leave_game_dialog.dart';
 import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
+import 'package:go_router/go_router.dart';
 
 class LeaveGameButton extends StatefulWidget {
   const LeaveGameButton({
@@ -27,11 +29,15 @@ class _LeaveGameButtonState extends State<LeaveGameButton> {
   Widget build(BuildContext context) {
     return BaseStateConsumer(
       cubit: _cubit,
-      onCustom: (context, isFirstRound) {
-        if (isFirstRound) {
+      onCustom: (context, custom) {
+        if (custom.isFirstRound) {
           Navigator.of(context).push(const SummaryScreen().toRoute(context));
-        } else {
+        } else if (custom.hasAtLeastStartedInterview) {
           Navigator.of(context).push(const GratefulScreen().toRoute(context));
+        } else {
+          context.goNamed(
+            FamilyPages.profileSelection.name,
+          );
         }
       },
       onInitial: (context) {

--- a/lib/features/family/features/reflect/presentation/widgets/leave_game_button.dart
+++ b/lib/features/family/features/reflect/presentation/widgets/leave_game_button.dart
@@ -30,9 +30,9 @@ class _LeaveGameButtonState extends State<LeaveGameButton> {
     return BaseStateConsumer(
       cubit: _cubit,
       onCustom: (context, custom) {
-        if (custom.isFirstRound) {
+        if (custom.isFirstRound && custom.hasAtLeastStartedInterview) {
           Navigator.of(context).push(const SummaryScreen().toRoute(context));
-        } else if (custom.hasAtLeastStartedInterview) {
+        } else if (!custom.isFirstRound && custom.hasAtLeastStartedInterview) {
           Navigator.of(context).push(const GratefulScreen().toRoute(context));
         } else {
           context.goNamed(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced navigation capabilities with new conditional checks for impact group invitations.
	- Introduced wake lock management to keep the device awake during the `SummaryScreen`.
	- Added a new `LeaveGameCustom` class for improved state representation during game leaving.

- **Bug Fixes**
	- Improved navigation logic in the `LeaveGameButton` widget.

- **Chores**
	- Updated import statements for better organization and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->