### PR TITLE
Bug: Gamestats moves up when give tile is clicked (KIDS-1752)

### DIFF
--- a/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
@@ -100,16 +100,17 @@ class _FamilyHomeScreenState extends State<FamilyHomeScreen> {
                           ),
                         ),
                         const SizedBox(height: 16),
-                        if (!overlayVisible)
-                          AvatarBar(
+                        Visibility(
+                          visible: !overlayVisible,
+                          maintainSize: true,
+                          child: AvatarBar(
                             circleSize: 58,
                             uiModel: AvatarBarUIModel(
                               avatarUIModels: uiModel.avatars,
                             ),
                             onAvatarTapped: onAvatarTapped,
-                          )
-                        else
-                          const SizedBox(height: 116),
+                          ),
+                        ),
                         StatsContainer(uiModel.gameStats),
                       ],
                     ),

--- a/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
@@ -107,7 +107,9 @@ class _FamilyHomeScreenState extends State<FamilyHomeScreen> {
                               avatarUIModels: uiModel.avatars,
                             ),
                             onAvatarTapped: onAvatarTapped,
-                          ),
+                          )
+                        else
+                          const SizedBox(height: 116),
                         StatsContainer(uiModel.gameStats),
                       ],
                     ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified the rendering of the `AvatarBar` on the `FamilyHomeScreen` using a `Visibility` widget.
  
- **Bug Fixes**
	- Improved layout management to preserve space for the `AvatarBar` even when it is not visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->