### PR TITLE
Bug: Show bedtime setup screens when aborting game after a full round (KIDS-1784)

### DIFF
--- a/lib/core/enums/amplitude_events.dart
+++ b/lib/core/enums/amplitude_events.dart
@@ -280,6 +280,9 @@ enum AmplitudeEvents {
   reflectAndShareNextJournalistClicked(
     'reflect_and_share_next_journalist_clicked',
   ),
+  reflectAndShareLeaveGameButtonClicked(
+    'reflect_and_share_leave_game_button_clicked',
+  ),
   reflectAndShareChangeWordClicked('reflect_and_share_change_word_clicked'),
   reflectAndShareConfirmExitClicked('reflect_and_share_confirm_exit_clicked'),
   reflectAndShareKeepPlayingClicked('reflect_and_share_keep_playing_clicked'),

--- a/lib/features/family/features/reflect/bloc/leave_game_cubit.dart
+++ b/lib/features/family/features/reflect/bloc/leave_game_cubit.dart
@@ -1,3 +1,4 @@
+import 'package:givt_app/features/family/features/profiles/models/profile.dart';
 import 'package:givt_app/features/family/features/reflect/domain/models/game_profile.dart';
 import 'package:givt_app/features/family/features/reflect/domain/reflect_and_share_repository.dart';
 import 'package:givt_app/features/family/features/reflect/presentation/models/leave_game_custom.dart';
@@ -10,12 +11,20 @@ class LeaveGameCubit extends CommonCubit<dynamic, LeaveGameCustom> {
 
   final ReflectAndShareRepository _reflectAndShareRepository;
 
-  void onConfirmLeaveGameClicked() {
+  Future<void> onConfirmLeaveGameClicked() async {
+    var kidsWithoutBedtimeSetup = <Profile>[];
+    try {
+      kidsWithoutBedtimeSetup =
+          await _reflectAndShareRepository.getKidsWithoutBedtime();
+    } catch (e) {
+      // do nothing, as a fallback we just don't navigate to the bedtime screens
+    }
     emitCustom(
       LeaveGameCustom(
         isFirstRound: _reflectAndShareRepository.isFirstRound(),
         hasAtLeastStartedInterview:
             _reflectAndShareRepository.hasStartedInterview(),
+        kidsWithoutBedtimeSetup: kidsWithoutBedtimeSetup,
       ),
     );
   }

--- a/lib/features/family/features/reflect/presentation/models/leave_game_custom.dart
+++ b/lib/features/family/features/reflect/presentation/models/leave_game_custom.dart
@@ -1,9 +1,13 @@
+import 'package:givt_app/features/family/features/profiles/models/profile.dart';
+
 class LeaveGameCustom {
   const LeaveGameCustom({
     required this.isFirstRound,
     required this.hasAtLeastStartedInterview,
+    required this.kidsWithoutBedtimeSetup,
   });
 
   final bool isFirstRound;
   final bool hasAtLeastStartedInterview;
+  final List<Profile> kidsWithoutBedtimeSetup;
 }

--- a/lib/features/family/features/reflect/presentation/widgets/leave_game_button.dart
+++ b/lib/features/family/features/reflect/presentation/widgets/leave_game_button.dart
@@ -1,13 +1,20 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:givt_app/core/enums/amplitude_events.dart';
 import 'package:givt_app/features/family/app/family_pages.dart';
 import 'package:givt_app/features/family/app/injection.dart';
 import 'package:givt_app/features/family/extensions/extensions.dart';
+import 'package:givt_app/features/family/features/bedtime/presentation/models/bedtime.dart';
+import 'package:givt_app/features/family/features/bedtime/presentation/models/bedtime_arguments.dart';
+import 'package:givt_app/features/family/features/bedtime/presentation/pages/intro_bedtime_screen.dart';
 import 'package:givt_app/features/family/features/reflect/bloc/leave_game_cubit.dart';
 import 'package:givt_app/features/family/features/reflect/presentation/pages/grateful_screen.dart';
 import 'package:givt_app/features/family/features/reflect/presentation/pages/summary_screen.dart';
 import 'package:givt_app/features/family/features/reflect/presentation/widgets/leave_game_dialog.dart';
 import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
+import 'package:givt_app/utils/analytics_helper.dart';
 import 'package:go_router/go_router.dart';
 
 class LeaveGameButton extends StatefulWidget {
@@ -30,7 +37,19 @@ class _LeaveGameButtonState extends State<LeaveGameButton> {
     return BaseStateConsumer(
       cubit: _cubit,
       onCustom: (context, custom) {
-        if (custom.isFirstRound && custom.hasAtLeastStartedInterview) {
+        if (!custom.isFirstRound && custom.kidsWithoutBedtimeSetup.isNotEmpty) {
+          Navigator.of(context).push(
+            IntroBedtimeScreen(
+              arguments: BedtimeArguments(
+                BedtimeConfig.defaultBedtimeHour,
+                BedtimeConfig.defaultWindDownMinutes,
+                profiles: custom.kidsWithoutBedtimeSetup,
+                bedtimes: const [],
+                index: 0,
+              ),
+            ).toRoute(context),
+          );
+        } else if (custom.isFirstRound && custom.hasAtLeastStartedInterview) {
           Navigator.of(context).push(const SummaryScreen().toRoute(context));
         } else if (!custom.isFirstRound && custom.hasAtLeastStartedInterview) {
           Navigator.of(context).push(const GratefulScreen().toRoute(context));
@@ -48,6 +67,12 @@ class _LeaveGameButtonState extends State<LeaveGameButton> {
                 LeaveGameDialog(
                   onConfirmLeaveGame: _cubit.onConfirmLeaveGameClicked,
                 ).show(context);
+                unawaited(
+                  AnalyticsHelper.logEvent(
+                    eventName:
+                        AmplitudeEvents.reflectAndShareLeaveGameButtonClicked,
+                  ),
+                );
               },
         );
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new event tracking for the "Reflect and Share" functionality.
	- Enhanced navigation logic in the Leave Game feature based on children's bedtime setup.
	- Added analytics tracking for user interactions when the leave game dialog is shown.

- **Bug Fixes**
	- Improved error handling in the Leave Game confirmation process.

- **Documentation**
	- Updated method and class signatures to reflect new parameters and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->