### PR TITLE
Bug: 'No Internet Connection' popup is shown when you put app to background for couple of minutes (KIDS-1737)

### DIFF
--- a/lib/features/family/features/home_screen/presentation/pages/navigation_bar_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/navigation_bar_home_screen.dart
@@ -59,6 +59,7 @@ class NavigationBarHomeScreen extends StatefulWidget {
 class _NavigationBarHomeScreenState extends State<NavigationBarHomeScreen> {
   final _cubit = getIt<NavigationBarHomeCubit>();
   final _connectionCubit = getIt<InternetConnectionCubit>();
+  late final AppLifecycleListener _listener;
 
   int _currentIndex = 0;
   static bool _isShowingBoxOrigin = false;
@@ -216,7 +217,18 @@ class _NavigationBarHomeScreenState extends State<NavigationBarHomeScreen> {
   @override
   void initState() {
     _setIndex(widget.index ?? 0);
+    _listener = AppLifecycleListener(
+      onResume: _connectionCubit.resume,
+      onHide: _connectionCubit.pause,
+      onPause: _connectionCubit.pause,
+    );
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    _listener.dispose();
+    super.dispose();
   }
 
   Future<void> _handleCustom(

--- a/lib/features/internet_connection/internet_connection_cubit.dart
+++ b/lib/features/internet_connection/internet_connection_cubit.dart
@@ -12,6 +12,7 @@ class InternetConnectionCubit extends Cubit<InternetConnectionState> {
   ) : super(InternetConnectionInitial()) {
     _init();
   }
+
   final NetworkInfo _networkInfo;
   StreamSubscription<bool>? hasInternetConnectionStream;
 
@@ -32,5 +33,13 @@ class InternetConnectionCubit extends Cubit<InternetConnectionState> {
   Future<void> close() async {
     await hasInternetConnectionStream?.cancel();
     await super.close();
+  }
+
+  void pause() {
+    hasInternetConnectionStream?.pause();
+  }
+
+  void resume() {
+    hasInternetConnectionStream?.resume();
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced lifecycle management for the navigation bar, enhancing responsiveness to app state changes.
	- Added functionality to monitor internet connection status with the ability to pause and resume monitoring.

- **Bug Fixes**
	- Improved resource management by ensuring proper cancellation of stream subscriptions when the cubit is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->