### PR TITLE
send seconds played to backend instead of rounded number (KIDS-1779)

### DIFF
--- a/lib/features/family/features/reflect/domain/reflect_and_share_repository.dart
+++ b/lib/features/family/features/reflect/domain/reflect_and_share_repository.dart
@@ -63,9 +63,8 @@ class ReflectAndShareRepository {
     try {
       _endTime = DateTime.now();
       totalTimeSpentInSeconds = _endTime!.difference(_startTime!).inSeconds;
-      final totalMinutesPlayed = (totalTimeSpentInSeconds / 60).ceil();
       await _familyApiService.saveGratitudeStats(
-        totalMinutesPlayed * 60,
+        totalTimeSpentInSeconds,
         _gameId,
       );
       await _fetchGameStats();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified time calculation in the summary statistics saving process.
  
- **Refactor**
	- Updated method logic for `saveSummaryStats`, `shareAudio`, and `saveGenerousPowerForCurrentSuperhero` to enhance clarity and efficiency while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->