### PR TITLE
Bug: Remove empty summaries (kids-1822)

### DIFF
--- a/lib/features/family/features/game_summary/data/game_summaries_repository.dart
+++ b/lib/features/family/features/game_summary/data/game_summaries_repository.dart
@@ -12,10 +12,14 @@ class GameSummariesRepository {
       List<Profile> profiles) async {
     try {
       final response = await _familyAPIService.fetchGameSummaries();
-      return response
-          .map((e) =>
-              GameSummaryItem.fromMap(e as Map<String, dynamic>, profiles))
-          .toList();
+      final filteredResponse = response
+          .map(
+            (e) => GameSummaryItem.fromMap(e as Map<String, dynamic>, profiles),
+          )
+          .toList()
+        ..removeWhere((e) => e.isEmpty);
+
+      return filteredResponse;
     } on Exception catch (e) {
       LoggingInfo.instance.error('Error fetching game summaries: $e');
       throw Exception('Error fetching game summaries: $e');

--- a/lib/features/family/features/game_summary/data/models/game_summary_item.dart
+++ b/lib/features/family/features/game_summary/data/models/game_summary_item.dart
@@ -16,12 +16,9 @@ class GameSummaryItem {
         (map['profiles'] as List<dynamic>).map((e) => e as String).toList();
     final players =
         profiles.where((element) => playerGuids.contains(element.id)).toList();
-    return GameSummaryItem(
-      id: id,
-      date: date,
-      players: players,
-    );
+    return GameSummaryItem(id: id, date: date, players: players);
   }
+  bool get isEmpty => players.isEmpty;
 
   final String id;
   final DateTime date;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data filtering in game summaries to exclude empty items.
	- Introduced a new `isEmpty` property in the game summary model to check for empty player lists.

- **Bug Fixes**
	- Improved data processing to ensure only relevant game summary items are returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->