### PR TITLE
Bug: Block rules screen button until audio is over

### DIFF
--- a/lib/features/family/features/reflect/presentation/pages/rule_screen.dart
+++ b/lib/features/family/features/reflect/presentation/pages/rule_screen.dart
@@ -184,7 +184,7 @@ class _RuleScreenState extends State<RuleScreen> {
                 FunBackgroundAudioWidget(
                   isVisible: true,
                   audioPath: widget.audioPath,
-                  onPlay: () {
+                  onPauseOrStop: () {
                     setState(() {
                       _hasPlayedAudio = true;
                     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated audio widget to respond to both pause and stop actions, enhancing audio event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->