### PR TITLE
Bug: Save game before navigating to bedtime flow

### DIFF
--- a/lib/features/family/features/reflect/bloc/guess_secret_word_cubit.dart
+++ b/lib/features/family/features/reflect/bloc/guess_secret_word_cubit.dart
@@ -90,6 +90,10 @@ class GuessSecretWordCubit
     );
   }
 
+  void saveSummary() {
+    _reflectAndShareRepository.saveSummaryStats();
+  }
+
   void _emitData() {
     emitData(
       GuessTheWordUIModel(

--- a/lib/features/family/features/reflect/bloc/leave_game_cubit.dart
+++ b/lib/features/family/features/reflect/bloc/leave_game_cubit.dart
@@ -10,6 +10,10 @@ class LeaveGameCubit extends CommonCubit<dynamic, LeaveGameCustom> {
 
   final ReflectAndShareRepository _reflectAndShareRepository;
 
+  void saveSummary() {
+    _reflectAndShareRepository.saveSummaryStats();
+  }
+
   Future<void> onConfirmLeaveGameClicked() async {
     var kidsWithoutBedtimeSetup = <Profile>[];
     try {

--- a/lib/features/family/features/reflect/presentation/pages/guess_secret_word_screen.dart
+++ b/lib/features/family/features/reflect/presentation/pages/guess_secret_word_screen.dart
@@ -58,6 +58,7 @@ class _GuessSecretWordScreenState extends State<GuessSecretWordScreen> {
                 const GratefulScreen().toRoute(context),
               );
             case RedirectToBedtimeSelection():
+              _cubit.saveSummary();
               Navigator.of(context).push(IntroBedtimeScreen(
                 arguments: BedtimeArguments(
                   BedtimeConfig.defaultBedtimeHour,

--- a/lib/features/family/features/reflect/presentation/widgets/leave_game_button.dart
+++ b/lib/features/family/features/reflect/presentation/widgets/leave_game_button.dart
@@ -67,6 +67,7 @@ class _LeaveGameButtonState extends State<LeaveGameButton> {
           FamilyPages.profileSelection.name,
         );
       case final LeaveGameCustomIntroBedtime event:
+        _cubit.saveSummary();
         Navigator.of(context).push(
           IntroBedtimeScreen(
             arguments: BedtimeArguments(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `saveSummary` method to both the Guess Secret Word and Leave Game functionalities, allowing for the saving of game summary statistics.
	- Updated navigation logic in the Guess Secret Word and Leave Game screens to include summary saving before transitioning to the next screen.

- **Bug Fixes**
	- Enhanced the handling of custom leave game events to ensure summary data is saved appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->