### PR TITLE
Bug: Frequent login required when opening the app (KIDS-1785)

### DIFF
--- a/lib/features/family/features/auth/data/family_auth_repository.dart
+++ b/lib/features/family/features/auth/data/family_auth_repository.dart
@@ -393,7 +393,11 @@ class FamilyAuthRepositoryImpl implements FamilyAuthRepository {
       await refreshToken();
       await updateNotificationId();
     } catch (e, s) {
-      // Do nothing
+      LoggingInfo.instance.info('Error in initAuth');
+      LoggingInfo.instance.error(
+        e.toString(),
+        methodName: s.toString(),
+      );
     }
   }
 


### PR DESCRIPTION
Also added some local fcm push notification testing possibilities. The solution now is that when we get an unauthenticated user update we first check if we can refresh, if that still doesn't work then we actually logout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced notification handling with new test notification scheduling methods
  - Improved authentication initialization error logging

- **Improvements**
  - Refactored home screen cubit to better handle user authentication and session management
  - Added more robust error tracking for authentication and notification processes

- **Bug Fixes**
  - Improved error handling in authentication and notification services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->