### PR TITLE
Keep screen active while listening to summary (KIDS-1786)

### DIFF
--- a/lib/features/family/features/game_summary/presentation/widgets/summary_page.dart
+++ b/lib/features/family/features/game_summary/presentation/widgets/summary_page.dart
@@ -10,6 +10,7 @@ import 'package:givt_app/features/family/utils/family_app_theme.dart';
 import 'package:givt_app/shared/models/analytics_event.dart';
 import 'package:givt_app/utils/utils.dart';
 import 'package:go_router/go_router.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 class SummaryPage extends StatefulWidget {
   const SummaryPage({super.key, required this.uiModel});
@@ -20,6 +21,19 @@ class SummaryPage extends StatefulWidget {
 
 class _SummaryPageState extends State<SummaryPage> {
   bool _hasClickedAudio = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WakelockPlus.enable();
+  }
+
+  @override
+  void dispose() {
+    WakelockPlus.disable();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added device wake lock management to prevent screen from sleeping during the summary page
	- Ensures continuous display of summary information without device screen dimming or sleeping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->