### PR TITLE
Feature: add memories show summaries currently to the menu bar (KIDS-1880)

### DIFF
--- a/lib/features/family/features/game_summary/presentation/pages/game_summaries_screen.dart
+++ b/lib/features/family/features/game_summary/presentation/pages/game_summaries_screen.dart
@@ -46,8 +46,7 @@ class _GameSummariesScreenState extends State<GameSummariesScreen> {
     return FunScaffold(
       minimumPadding: EdgeInsets.zero,
       appBar: const FunTopAppBar(
-        title: 'Game Summaries',
-        leading: GivtBackButtonFlat(),
+        title: 'Memories',
       ),
       body: BaseStateConsumer(
         cubit: _cubit,

--- a/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
@@ -167,15 +167,6 @@ class _FamilyHomeScreenState extends State<FamilyHomeScreen> {
                       GiveButton(
                         onPressed: _cubit.onGiveButtonPressed,
                       ),
-                      const SizedBox(height: 16),
-                      FunButton.secondary(
-                        onTap: () => context.goNamed(
-                          FamilyPages.gameSummaries.name,
-                        ),
-                        text: 'Show Summaries',
-                        analyticsEvent: AnalyticsEvent(AmplitudeEvents
-                            .familyHomeScreenShowSummariesClicked),
-                      ),
                     ],
                   ),
                 ),

--- a/lib/features/family/features/home_screen/presentation/pages/navigation_bar_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/navigation_bar_home_screen.dart
@@ -14,6 +14,7 @@ import 'package:givt_app/features/family/features/account/presentation/pages/us_
 import 'package:givt_app/features/family/features/auth/bloc/family_auth_cubit.dart';
 import 'package:givt_app/features/family/features/auth/presentation/models/family_auth_state.dart';
 import 'package:givt_app/features/family/features/box_origin/box_origin_selection_page.dart';
+import 'package:givt_app/features/family/features/game_summary/presentation/pages/game_summaries_screen.dart';
 import 'package:givt_app/features/family/features/home_screen/cubit/navigation_bar_home_cubit.dart';
 import 'package:givt_app/features/family/features/home_screen/presentation/models/navigation_bar_home_custom.dart';
 import 'package:givt_app/features/family/features/home_screen/presentation/models/navigation_bar_home_screen_uimodel.dart';
@@ -45,11 +46,13 @@ class NavigationBarHomeScreen extends StatefulWidget {
 
   static const int homeIndex = 0;
   static const int familyIndex = 1;
-  static const int profileIndex = 2;
+  static const int memoriesIndex = 2;
+  static const int profileIndex = 3;
 
   static const List<int> validIndexes = [
     homeIndex,
     familyIndex,
+    memoriesIndex,
     profileIndex,
   ];
 
@@ -79,13 +82,18 @@ class _NavigationBarHomeScreenState extends State<NavigationBarHomeScreen> {
     AnalyticsEvent(
       AmplitudeEvents.navigationBarPressed,
       parameters: {
-        'destination': 'My Family',
+        'destination': 'Family',
+      },
+    ),    AnalyticsEvent(
+      AmplitudeEvents.navigationBarPressed,
+      parameters: {
+        'destination': 'Memories',
       },
     ),
     AnalyticsEvent(
       AmplitudeEvents.navigationBarPressed,
       parameters: {
-        'destination': 'My Profile',
+        'destination': 'Profile',
       },
     ),
   ];
@@ -137,7 +145,10 @@ class _NavigationBarHomeScreenState extends State<NavigationBarHomeScreen> {
           ),
           const NavigationDestination(
             icon: FaIcon(FontAwesomeIcons.mask),
-            label: 'My Family',
+            label: 'Family',
+          ),        const NavigationDestination(
+            icon: FaIcon(FontAwesomeIcons.solidCalendar),
+            label: 'Memories',
           ),
           NavigationDestination(
             icon: uiModel?.profilePictureUrl == null
@@ -147,7 +158,7 @@ class _NavigationBarHomeScreenState extends State<NavigationBarHomeScreen> {
                     height: 28,
                     child: SvgPicture.network(uiModel!.profilePictureUrl!),
                   ),
-            label: 'My Profile',
+            label: 'Profile',
           ),
         ],
         analyticsEvent: (int index) => _analyticsEvents[index],
@@ -170,6 +181,7 @@ class _NavigationBarHomeScreenState extends State<NavigationBarHomeScreen> {
           child: <Widget>[
             const FamilyHomeScreen(),
             const FamilyOverviewPage(),
+            const GameSummariesScreen(),
             const USPersonalInfoEditPage(),
           ][_currentIndex],
         ),

--- a/lib/features/family/features/home_screen/presentation/pages/navigation_bar_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/navigation_bar_home_screen.dart
@@ -84,7 +84,8 @@ class _NavigationBarHomeScreenState extends State<NavigationBarHomeScreen> {
       parameters: {
         'destination': 'Family',
       },
-    ),    AnalyticsEvent(
+    ),
+    AnalyticsEvent(
       AmplitudeEvents.navigationBarPressed,
       parameters: {
         'destination': 'Memories',
@@ -146,7 +147,8 @@ class _NavigationBarHomeScreenState extends State<NavigationBarHomeScreen> {
           const NavigationDestination(
             icon: FaIcon(FontAwesomeIcons.mask),
             label: 'Family',
-          ),        const NavigationDestination(
+          ),
+          const NavigationDestination(
             icon: FaIcon(FontAwesomeIcons.solidCalendar),
             label: 'Memories',
           ),
@@ -195,7 +197,8 @@ class _NavigationBarHomeScreenState extends State<NavigationBarHomeScreen> {
   }) async {
     unawaited(SystemSound.play(SystemSoundType.click));
     unawaited(HapticFeedback.selectionClick());
-    if (index == NavigationBarHomeScreen.homeIndex) {
+    if (index == NavigationBarHomeScreen.homeIndex ||
+        index == NavigationBarHomeScreen.memoriesIndex) {
       _setIndex(index);
     } else {
       await FamilyAuthUtils.authenticateUser(
@@ -240,12 +243,14 @@ class _NavigationBarHomeScreenState extends State<NavigationBarHomeScreen> {
       onPause: _connectionCubit.pause,
     );
 
-    _missionAchievedListener = _missionRepo.onMissionAchieved().listen((mission) {
+    _missionAchievedListener =
+        _missionRepo.onMissionAchieved().listen((mission) {
       showDialog<void>(
         context: context,
         barrierDismissible: false,
         barrierColor: Theme.of(context).colorScheme.primary.withOpacity(.25),
-        builder: (context) => MissionCompletedBannerDialog(missionName: mission.title),
+        builder: (context) =>
+            MissionCompletedBannerDialog(missionName: mission.title),
       );
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new 'Memories' section to the navigation bar
	- Updated navigation labels for improved clarity

- **UI Changes**
	- Renamed "Game Summaries" screen title to "Memories"
	- Removed game summaries button from home screen
	- Adjusted navigation destination labels

- **Navigation**
	- Introduced new navigation index for Memories section
	- Modified navigation logic to allow easier access to Memories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->