### PR TITLE
Feature: improve error handling for no internet connection scenarios (KIDS-1886)

### DIFF
--- a/lib/core/enums/amplitude_events.dart
+++ b/lib/core/enums/amplitude_events.dart
@@ -349,7 +349,7 @@ enum AmplitudeEvents {
   summaryLeaveMessageClicked(
     'summary_leave_message_clicked',
   ),
-  afterGameSummaryDoneClicked('after_game_usmmary_done_clicked'),
+  afterGameSummaryDoneClicked('after_game_summary_done_clicked'),
   doneRecordingSummaryMessageClicked(
     'done_recording_summary_message_clicked',
   ),

--- a/lib/features/auth/pages/login_page.dart
+++ b/lib/features/auth/pages/login_page.dart
@@ -95,7 +95,7 @@ class _LoginPageState extends State<LoginPage> {
                 context: context,
                 builder: (context) => WarningDialog(
                   title: locals.loginFailure,
-                  content: locals.wrongCredentials,
+                  content: locals.noInternet,
                   onConfirm: () => context.pop(),
                 ),
               );

--- a/lib/features/email_signup/cubit/email_signup_cubit.dart
+++ b/lib/features/email_signup/cubit/email_signup_cubit.dart
@@ -162,7 +162,13 @@ class EmailSignupCubit
     await _authRepository.checkUserExt(email: _currentEmail);
 
     // Get info if this is a registered user
-    final result = await _authRepository.checkEmail(email: _currentEmail);
+    String result;
+    try {
+      result = await _authRepository.checkEmail(email: _currentEmail);
+    } catch (e, s) {
+      emitCustom(const EmailSignupCustom.noInternet());
+      return;
+    }
 
     // When this is a registered user, we show the login page
     if (result.contains('true')) {

--- a/lib/features/email_signup/presentation/pages/email_signup_page.dart
+++ b/lib/features/email_signup/presentation/pages/email_signup_page.dart
@@ -21,9 +21,11 @@ import 'package:givt_app/features/family/shared/widgets/loading/custom_progress_
 import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
 import 'package:givt_app/features/family/utils/family_app_theme.dart';
 import 'package:givt_app/features/family/utils/family_auth_utils.dart';
+import 'package:givt_app/features/internet_connection/internet_connection_cubit.dart';
 import 'package:givt_app/features/permit_biometric/models/permit_biometric_request.dart';
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/shared/dialogs/dialogs.dart';
+import 'package:givt_app/shared/dialogs/internet_connection_lost_dialog.dart';
 import 'package:givt_app/shared/models/analytics_event.dart';
 import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
 import 'package:givt_app/shared/widgets/fun_scaffold.dart';
@@ -53,6 +55,7 @@ class _EmailSignupPageState extends State<EmailSignupPage> {
   bool _isLoading = false;
 
   final _cubit = getIt<EmailSignupCubit>();
+  final _connectionCubit = getIt<InternetConnectionCubit>();
 
   @override
   void didChangeDependencies() {
@@ -84,160 +87,171 @@ class _EmailSignupPageState extends State<EmailSignupPage> {
   Widget build(BuildContext context) {
     final locals = context.l10n;
 
-    return BlocListener<AuthCubit, AuthState>(
-      listenWhen: (previous, current) => previous != current,
+    return BlocListener<InternetConnectionCubit, InternetConnectionState>(
+      bloc: _connectionCubit,
       listener: (context, state) {
-        if (state.status == AuthStatus.loginRedirect) {
-          AuthUtils.checkToken(
-            context,
-            checkAuthRequest: CheckAuthRequest(
-              navigate: (context) async => context.goNamed(Pages.home.name),
-              email: state.email.trim(),
-              forceLogin: true,
-            ),
-          );
+        if (state is InternetConnectionLost) {
+          InternetConnectionLostDialog.show(context);
         }
       },
-      child: BaseStateConsumer(
-        cubit: _cubit,
-        onLoading: (context) => const FunScaffold(
-          body: Center(
-            child: CustomCircularProgressIndicator(),
+      child: BlocListener<AuthCubit, AuthState>(
+        listenWhen: (previous, current) => previous != current,
+        listener: (context, state) {
+          if (state.status == AuthStatus.loginRedirect) {
+            AuthUtils.checkToken(
+              context,
+              checkAuthRequest: CheckAuthRequest(
+                navigate: (context) async => context.goNamed(Pages.home.name),
+                email: state.email.trim(),
+                forceLogin: true,
+              ),
+            );
+          }
+        },
+        child: BaseStateConsumer(
+          cubit: _cubit,
+          onLoading: (context) => const FunScaffold(
+            body: Center(
+              child: CustomCircularProgressIndicator(),
+            ),
           ),
-        ),
-        onCustom: handleCustom,
-        onData: (context, state) => FunScaffold(
-          body: LayoutBuilder(
-            builder: (context, constraint) {
-              return SingleChildScrollView(
-                key: const ValueKey('Email-Signup-Scrollable'),
-                child: ConstrainedBox(
-                  constraints: BoxConstraints(
-                    minHeight: constraint.maxHeight,
-                  ),
-                  child: IntrinsicHeight(
-                    child: Form(
-                      key: _formKey,
-                      child: Column(
-                        children: [
-                          const SizedBox(
-                            height: 24,
-                          ),
-                          TitleLargeText(
-                            locals.welcomeContinue,
-                          ),
-                          const SizedBox(height: 4),
-                          BodyMediumText(
-                            locals.toGiveWeNeedYourEmailAddress,
-                            textAlign: TextAlign.center,
-                          ),
-                          const SizedBox(height: 4),
-                          BodySmallText.primary40(locals.weWontSendAnySpam),
-                          const Spacer(),
-                          OutlinedTextFormField(
-                            key: const ValueKey('Email-Input'),
-                            initialValue: state.email,
-                            hintText: locals.email,
-                            onChanged: _cubit.updateEmail,
-                            validator: (value) {
-                              if (!_cubit.validateEmail(value)) {
-                                return context.l10n.invalidEmail;
-                              }
+          onCustom: handleCustom,
+          onData: (context, state) => FunScaffold(
+            body: LayoutBuilder(
+              builder: (context, constraint) {
+                return SingleChildScrollView(
+                  key: const ValueKey('Email-Signup-Scrollable'),
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      minHeight: constraint.maxHeight,
+                    ),
+                    child: IntrinsicHeight(
+                      child: Form(
+                        key: _formKey,
+                        child: Column(
+                          children: [
+                            const SizedBox(
+                              height: 24,
+                            ),
+                            TitleLargeText(
+                              locals.welcomeContinue,
+                            ),
+                            const SizedBox(height: 4),
+                            BodyMediumText(
+                              locals.toGiveWeNeedYourEmailAddress,
+                              textAlign: TextAlign.center,
+                            ),
+                            const SizedBox(height: 4),
+                            BodySmallText.primary40(locals.weWontSendAnySpam),
+                            const Spacer(),
+                            OutlinedTextFormField(
+                              key: const ValueKey('Email-Input'),
+                              initialValue: state.email,
+                              hintText: locals.email,
+                              onChanged: _cubit.updateEmail,
+                              validator: (value) {
+                                if (!_cubit.validateEmail(value)) {
+                                  return context.l10n.invalidEmail;
+                                }
 
-                              return null;
-                            },
-                            keyboardType: TextInputType.emailAddress,
-                            autofillHints: const [
-                              AutofillHints.username,
-                              AutofillHints.email,
-                            ],
-                          ),
-                          const SizedBox(height: 12),
-                          CountryDropDown(
-                            selectedCountry: state.country,
-                            onChanged: (Country? newValue) {
-                              _cubit.updateCountry(newValue!);
-                            },
-                          ),
-                          const Spacer(),
-                          Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 8),
-                            child: GestureDetector(
-                              onTap: () => showModalBottomSheet<void>(
-                                context: context,
-                                useSafeArea: true,
-                                scrollControlDisabledMaxHeightRatio: 1,
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(20),
-                                ),
-                                builder: (BuildContext context) =>
-                                    TermsAndConditionsDialog(
-                                  content: locals.termsText,
-                                ),
-                              ),
-                              child: Row(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  const Icon(
-                                    FontAwesomeIcons.circleInfo,
-                                    size: 20,
-                                    color: FamilyAppTheme.primary20,
+                                return null;
+                              },
+                              keyboardType: TextInputType.emailAddress,
+                              autofillHints: const [
+                                AutofillHints.username,
+                                AutofillHints.email,
+                              ],
+                            ),
+                            const SizedBox(height: 12),
+                            CountryDropDown(
+                              selectedCountry: state.country,
+                              onChanged: (Country? newValue) {
+                                _cubit.updateCountry(newValue!);
+                              },
+                            ),
+                            const Spacer(),
+                            Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 8),
+                              child: GestureDetector(
+                                onTap: () => showModalBottomSheet<void>(
+                                  context: context,
+                                  useSafeArea: true,
+                                  scrollControlDisabledMaxHeightRatio: 1,
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(20),
                                   ),
-                                  const SizedBox(width: 8),
-                                  Flexible(
-                                    child: BodySmallText.primary40(
-                                      locals.acceptTerms,
+                                  builder: (BuildContext context) =>
+                                      TermsAndConditionsDialog(
+                                    content: locals.termsText,
+                                  ),
+                                ),
+                                child: Row(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    const Icon(
+                                      FontAwesomeIcons.circleInfo,
+                                      size: 20,
+                                      color: FamilyAppTheme.primary20,
                                     ),
-                                  ),
-                                ],
+                                    const SizedBox(width: 8),
+                                    Flexible(
+                                      child: BodySmallText.primary40(
+                                        locals.acceptTerms,
+                                      ),
+                                    ),
+                                  ],
+                                ),
                               ),
                             ),
-                          ),
-                          const SizedBox(height: 12),
-                          FunButton(
-                            key: const ValueKey('Email-Continue-Button'),
-                            isDisabled: !state.continueButtonEnabled,
-                            isLoading: _isLoading,
-                            onTap: state.continueButtonEnabled
-                                ? () async {
-                                    _cubit.updateApi();
-                                    if (state.country.isUS) {
-                                      final fbsdk = FacebookAppEvents();
-                                      await fbsdk
-                                          .setAutoLogAppEventsEnabled(true);
-                                      await fbsdk.logEvent(
-                                        name: 'email_signup_continue_clicked',
-                                      );
+                            const SizedBox(height: 12),
+                            FunButton(
+                              key: const ValueKey('Email-Continue-Button'),
+                              isDisabled: !state.continueButtonEnabled,
+                              isLoading: _isLoading,
+                              onTap: state.continueButtonEnabled
+                                  ? () async {
+                                      _cubit.updateApi();
+                                      if (state.country.isUS) {
+                                        final fbsdk = FacebookAppEvents();
+                                        await fbsdk
+                                            .setAutoLogAppEventsEnabled(true);
+                                        await fbsdk.logEvent(
+                                          name: 'email_signup_continue_clicked',
+                                        );
 
-                                      await _cubit.login();
-                                    } else {
-                                      setLoading();
-                                      AppThemeSwitcher.of(context)
-                                          .switchTheme(isFamilyApp: false);
-                                      await context.read<AuthCubit>().register(
-                                            country: state.country,
-                                            email: state.email,
-                                            locale:
-                                                Localizations.localeOf(context)
-                                                    .languageCode,
-                                          );
-                                      setLoading(state: false);
+                                        await _cubit.login();
+                                      } else {
+                                        setLoading();
+                                        AppThemeSwitcher.of(context)
+                                            .switchTheme(isFamilyApp: false);
+                                        await context
+                                            .read<AuthCubit>()
+                                            .register(
+                                              country: state.country,
+                                              email: state.email,
+                                              locale: Localizations.localeOf(
+                                                      context)
+                                                  .languageCode,
+                                            );
+                                        setLoading(state: false);
+                                      }
                                     }
-                                  }
-                                : null,
-                            text: locals.continueKey,
-                            rightIcon: FontAwesomeIcons.arrowRight,
-                            analyticsEvent: AnalyticsEvent(
-                              AmplitudeEvents.emailSignupContinueClicked,
+                                  : null,
+                              text: locals.continueKey,
+                              rightIcon: FontAwesomeIcons.arrowRight,
+                              analyticsEvent: AnalyticsEvent(
+                                AmplitudeEvents.emailSignupContinueClicked,
+                              ),
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
                   ),
-                ),
-              );
-            },
+                );
+              },
+            ),
           ),
         ),
       ),

--- a/lib/features/family/features/login/presentation/pages/family_login_sheet.dart
+++ b/lib/features/family/features/login/presentation/pages/family_login_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app/core/enums/amplitude_events.dart';
 import 'package:givt_app/features/family/app/injection.dart';
 import 'package:givt_app/features/family/features/login/cubit/family_login_cubit.dart';
@@ -7,8 +8,10 @@ import 'package:givt_app/features/family/features/reset_password/presentation/pa
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/features/family/shared/widgets/loading/custom_progress_indicator.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
+import 'package:givt_app/features/internet_connection/internet_connection_cubit.dart';
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/shared/dialogs/dialogs.dart';
+import 'package:givt_app/shared/dialogs/internet_connection_lost_dialog.dart';
 import 'package:givt_app/shared/models/analytics_event.dart';
 import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
 import 'package:givt_app/shared/widgets/outlined_text_form_field.dart';
@@ -36,6 +39,7 @@ class _FamilyLoginSheetState extends State<FamilyLoginSheet> {
   bool obscureText = true;
 
   final _cubit = getIt<FamilyLoginCubit>();
+  final _connectionCubit = getIt<InternetConnectionCubit>();
 
   @override
   void didChangeDependencies() {
@@ -69,19 +73,27 @@ class _FamilyLoginSheetState extends State<FamilyLoginSheet> {
 
   @override
   Widget build(BuildContext context) {
-    return BaseStateConsumer(
-      cubit: _cubit,
-      onCustom: onCustom,
-      onData: (context, data) => showLoginForm(data),
-      onLoading: (context) {
-        return FunBottomSheet(
-          title: context.l10n.login,
-          icon: const CustomCircularProgressIndicator(),
-          content: const BodyMediumText(
-            "We're logging you in",
-          ),
-        );
+    return BlocListener<InternetConnectionCubit, InternetConnectionState>(
+      bloc: _connectionCubit,
+      listener: (context, state) {
+        if (state is InternetConnectionLost) {
+          InternetConnectionLostDialog.show(context);
+        }
       },
+      child: BaseStateConsumer(
+        cubit: _cubit,
+        onCustom: onCustom,
+        onData: (context, data) => showLoginForm(data),
+        onLoading: (context) {
+          return FunBottomSheet(
+            title: context.l10n.login,
+            icon: const CustomCircularProgressIndicator(),
+            content: const BodyMediumText(
+              "We're logging you in",
+            ),
+          );
+        },
+      ),
     );
   }
 

--- a/lib/features/family/features/login/presentation/pages/family_login_sheet.dart
+++ b/lib/features/family/features/login/presentation/pages/family_login_sheet.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app/core/enums/amplitude_events.dart';
 import 'package:givt_app/features/family/app/injection.dart';
 import 'package:givt_app/features/family/features/login/cubit/family_login_cubit.dart';
@@ -8,10 +7,8 @@ import 'package:givt_app/features/family/features/reset_password/presentation/pa
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/features/family/shared/widgets/loading/custom_progress_indicator.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
-import 'package:givt_app/features/internet_connection/internet_connection_cubit.dart';
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/shared/dialogs/dialogs.dart';
-import 'package:givt_app/shared/dialogs/internet_connection_lost_dialog.dart';
 import 'package:givt_app/shared/models/analytics_event.dart';
 import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
 import 'package:givt_app/shared/widgets/outlined_text_form_field.dart';
@@ -39,7 +36,6 @@ class _FamilyLoginSheetState extends State<FamilyLoginSheet> {
   bool obscureText = true;
 
   final _cubit = getIt<FamilyLoginCubit>();
-  final _connectionCubit = getIt<InternetConnectionCubit>();
 
   @override
   void didChangeDependencies() {
@@ -73,27 +69,19 @@ class _FamilyLoginSheetState extends State<FamilyLoginSheet> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocListener<InternetConnectionCubit, InternetConnectionState>(
-      bloc: _connectionCubit,
-      listener: (context, state) {
-        if (state is InternetConnectionLost) {
-          InternetConnectionLostDialog.show(context);
-        }
+    return BaseStateConsumer(
+      cubit: _cubit,
+      onCustom: onCustom,
+      onData: (context, data) => showLoginForm(data),
+      onLoading: (context) {
+        return FunBottomSheet(
+          title: context.l10n.login,
+          icon: const CustomCircularProgressIndicator(),
+          content: const BodyMediumText(
+            "We're logging you in",
+          ),
+        );
       },
-      child: BaseStateConsumer(
-        cubit: _cubit,
-        onCustom: onCustom,
-        onData: (context, data) => showLoginForm(data),
-        onLoading: (context) {
-          return FunBottomSheet(
-            title: context.l10n.login,
-            icon: const CustomCircularProgressIndicator(),
-            content: const BodyMediumText(
-              "We're logging you in",
-            ),
-          );
-        },
-      ),
     );
   }
 

--- a/lib/features/family/features/login/presentation/pages/family_login_sheet.dart
+++ b/lib/features/family/features/login/presentation/pages/family_login_sheet.dart
@@ -235,7 +235,7 @@ class _FamilyLoginSheetState extends State<FamilyLoginSheet> {
           context: context,
           builder: (context) => WarningDialog(
             title: context.l10n.loginFailure,
-            content: context.l10n.wrongCredentials,
+            content: context.l10n.noInternet,
             onConfirm: () => context.pop(),
           ),
         );


### PR DESCRIPTION
Show no internet connection popup on email signup page (and therefore also the loginsheet on that page).
Do not show wrong credentials message when we have a generic error (much more likely to be internet related).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Bug Fixes**
  - Corrected a typo in an Amplitude event name
  - Updated error handling for login scenarios to display more accurate internet connectivity messages
  - Improved error handling for email signup and authentication processes

- **New Features**
  - Added internet connection status monitoring to signup and login flows
  - Implemented more robust error detection for network-related issues

- **Chores**
  - Enhanced error messaging across multiple authentication-related components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->