### PR TITLE
Show empty state when a kid profile doesnt contain donations (KIDS-1900)

### DIFF
--- a/lib/features/family/features/history/history_screen.dart
+++ b/lib/features/family/features/history/history_screen.dart
@@ -14,6 +14,8 @@ import 'package:givt_app/features/family/shared/widgets/content/donation_item_wi
 import 'package:givt_app/features/family/shared/widgets/content/income_item_widget.dart';
 import 'package:givt_app/features/family/shared/widgets/loading/custom_progress_indicator.dart';
 import 'package:givt_app/features/family/shared/widgets/loading/full_screen_loading_widget.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
+import 'package:givt_app/shared/widgets/common_icons.dart';
 import 'package:givt_app/shared/widgets/fun_scaffold.dart';
 
 class HistoryScreen extends StatelessWidget {
@@ -44,6 +46,21 @@ class HistoryScreen extends StatelessWidget {
           // Display loading indicator if no data is available
           if (state.status == HistoryStatus.loading && state.history.isEmpty) {
             return const FullScreenLoadingWidget();
+          }
+
+          if (state.history.isEmpty) {
+            return Column(
+              children: [
+                const SizedBox(height: 20),
+                walletEmptyIcon(),
+                const SizedBox(height: 16),
+                Center(
+                  child: BodyMediumText.opacityBlack50(
+                    'You haven’t made any givts yet!',
+                  ),
+                ),
+              ],
+            );
           }
 
           // Display error message if data is not available

--- a/lib/features/family/features/profiles/widgets/wallet_widget.dart
+++ b/lib/features/family/features/profiles/widgets/wallet_widget.dart
@@ -12,6 +12,7 @@ import 'package:givt_app/features/family/features/history/history_cubit/history_
 import 'package:givt_app/features/family/features/history/history_screen.dart';
 import 'package:givt_app/features/family/features/profiles/cubit/profiles_cubit.dart';
 import 'package:givt_app/features/family/shared/widgets/loading/custom_progress_indicator.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
 import 'package:givt_app/features/family/utils/family_app_theme.dart';
 import 'package:givt_app/shared/widgets/extensions/route_extensions.dart';
 import 'package:givt_app/utils/utils.dart';
@@ -157,10 +158,7 @@ class _WalletWidgetState extends State<WalletWidget> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Text(
-                          'My givts',
-                          style: Theme.of(context).textTheme.labelMedium,
-                        ),
+                        const LabelMediumText('My givts'),
                         Padding(
                           padding: const EdgeInsets.only(left: 4),
                           child: Icon(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced empty state handling in history screen with informative message and icon when no donations are made

- **Style**
  - Updated text styling in wallet widget by using a custom `LabelMediumText` for "My givts"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->