### PR TITLE
Refresh missions in background when going to missions page

### DIFF
--- a/lib/features/family/features/missions/bloc/missions_cubit.dart
+++ b/lib/features/family/features/missions/bloc/missions_cubit.dart
@@ -12,7 +12,12 @@ class MissionsCubit extends CommonCubit<MissionsUIModel, dynamic> {
   List<Mission>? _mission;
 
   Future<void> init() async {
+    // Show known data
     _mission = await repository.getMissions();
+    _emitData();
+    
+    // At the same time also fetch new data
+    _mission = await repository.getMissions(force: true);
     _emitData();
   }
 

--- a/lib/features/family/features/missions/domain/repositories/mission_repository.dart
+++ b/lib/features/family/features/missions/domain/repositories/mission_repository.dart
@@ -1,7 +1,7 @@
 import 'package:givt_app/features/family/features/missions/domain/entities/mission.dart';
 
 mixin MissionRepository {
-  Future<List<Mission>> getMissions();
+  Future<List<Mission>> getMissions({bool force = false});
   Future<void> missionAchieved(String missionKey);
 
   Stream<Mission> onMissionAchieved();

--- a/lib/features/family/features/missions/presentation/pages/missions_screen.dart
+++ b/lib/features/family/features/missions/presentation/pages/missions_screen.dart
@@ -49,7 +49,8 @@ class _MissionsScreenState extends State<MissionsScreen> {
                 options: options,
                 selectedIndex: _selectedIndex,
                 onPressed: (set) => setState(
-                    () => _selectedIndex = set.first == options[0] ? 0 : 1),
+                  () => _selectedIndex = set.first == options[0] ? 0 : 1,
+                ),
                 analyticsEvent: AnalyticsEvent(
                   AmplitudeEvents.missionTabsChanged,
                 ),
@@ -57,14 +58,12 @@ class _MissionsScreenState extends State<MissionsScreen> {
               const SizedBox(height: 24),
               if (_missions(uiModel).isEmpty)
                 FunCard(
-                  title: null,
                   content: BodyMediumText.opacityBlack50(
                     _selectedIndex == 0
                         ? "You don't have any missions currently"
                         : "You haven't completed any missions yet",
                     textAlign: TextAlign.center,
                   ),
-                  button: null,
                   icon: FunGoal.neutral95(),
                 ),
               ...List.generate(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced mission data fetching with a new `force` parameter to retrieve the latest data
	- Improved mission screen rendering for scenarios with no available missions

- **Bug Fixes**
	- Fixed code structure and widget parameter handling in missions screen

<!-- end of auto-generated comment: release notes by coderabbit.ai -->