### PR TITLE
Bug: Switching accounts does not reset missions (KIDS-1891)

### DIFF
--- a/lib/features/family/app/injection.dart
+++ b/lib/features/family/app/injection.dart
@@ -285,6 +285,7 @@ void initRepositories() {
     ..registerLazySingleton<MissionRepository>(
       () => MissionRepositoryImpl(
         getIt(),
+        getIt(),
       ),
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced mission repository with authentication state tracking
	- Automatically refreshes missions upon user authentication

- **Improvements**
	- Added dynamic mission data management based on user authentication status
	- Improved mission data clearing and reloading mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->