### PR TITLE
Bug: Family Goal tile is always visible even when no goal is setup (KIDS-1833)

### DIFF
--- a/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
@@ -16,6 +16,7 @@ import 'package:givt_app/features/family/features/home_screen/widgets/give_butto
 import 'package:givt_app/features/family/features/home_screen/widgets/gratitude_game_button.dart';
 import 'package:givt_app/features/family/features/home_screen/widgets/missions_container.dart';
 import 'package:givt_app/features/family/features/home_screen/widgets/stats_container.dart';
+import 'package:givt_app/features/family/features/impact_groups/cubit/impact_groups_cubit.dart';
 import 'package:givt_app/features/family/features/profiles/cubit/profiles_cubit.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/features/family/shared/design/components/content/avatar_bar.dart';
@@ -210,6 +211,8 @@ class _FamilyHomeScreenState extends State<FamilyHomeScreen> {
         },
       ),
     );
+
+    context.read<ImpactGroupsCubit>().fetchImpactGroups(profile.id, true);
 
     if (profile.profileType == ProfileType.Parent) {
       final authstate = context.read<FamilyAuthCubit>().state;

--- a/lib/features/family/features/impact_groups/models/goal.dart
+++ b/lib/features/family/features/impact_groups/models/goal.dart
@@ -39,7 +39,7 @@ class Goal extends Equatable {
       orgName: map['collectGroupName'] as String? ?? '',
     );
   }
-  bool get isActive => status == FamilyGoalStatus.inProgress;
+  bool get isActive => status == FamilyGoalStatus.inProgress && orgName.isNotEmpty;
 
   final String id;
   final int goalAmount;

--- a/lib/features/family/features/overview/widgets/family_available_page.dart
+++ b/lib/features/family/features/overview/widgets/family_available_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app/features/family/features/family_goal/pages/family_goal_tracker.dart';
 import 'package:givt_app/features/family/features/family_history/family_history.dart';
 import 'package:givt_app/features/family/features/family_history/family_history_cubit/family_history_cubit.dart';
+import 'package:givt_app/features/family/features/impact_groups/cubit/impact_groups_cubit.dart';
 import 'package:givt_app/features/family/features/overview/cubit/family_overview_cubit.dart';
 import 'package:givt_app/features/family/features/overview/widgets/profiles_overview_widget.dart';
 import 'package:givt_app/features/family/features/auth/bloc/family_auth_cubit.dart';
@@ -17,6 +18,9 @@ class FamilyAvailablePage extends StatefulWidget {
 }
 
 class _FamilyAvailablePageState extends State<FamilyAvailablePage> {
+
+
+
   @override
   Widget build(BuildContext context) {
     final state = context.watch<FamilyOverviewCubit>().state
@@ -63,5 +67,12 @@ class _FamilyAvailablePageState extends State<FamilyAvailablePage> {
         ),
       ),
     );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final currentUserId = context.read<FamilyAuthCubit>().user!.guid;
+    context.read<ImpactGroupsCubit>().fetchImpactGroups(currentUserId, true);
   }
 }


### PR DESCRIPTION
Original problem: several places where dependent on the ImpactGroupsCubit but it wasn't actually updated anywhere anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced impact groups fetching functionality when user avatar is tapped
  - Improved goal activation criteria by adding additional validation

- **Refactor**
  - Updated lifecycle method to fetch impact groups when widget dependencies change

The changes improve data retrieval and validation mechanisms within the family-related features of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->