### PR TITLE
Bug: Add a safeguard for profiles call failing (KIDS-1959)

### DIFF
--- a/lib/features/splash/cubit/splash_cubit.dart
+++ b/lib/features/splash/cubit/splash_cubit.dart
@@ -43,6 +43,11 @@ class SplashCubit extends CommonCubit<void, SplashCustom> {
     emitLoading();
   }
 
+  void _showExperiencingIssuesMessage() {
+    emitCustom(const SplashCustom.experiencingIssues());
+    emitLoading();
+  }
+
   Future<void> _checkForRedirect() async {
     try {
       await _authRepository.initAuth();
@@ -68,7 +73,15 @@ class SplashCubit extends CommonCubit<void, SplashCustom> {
         return;
       }
 
-      if (profiles.length <= 1) {
+      if (profiles.isEmpty) {
+        _showExperiencingIssuesMessage();
+        // we probably have a BE issue
+        LoggingInfo.instance.error(
+          'No profiles found for user ${user.guid}, do we have a failing BE call?',
+          methodName: 'SplashCubit._checkForRedirect',
+        );
+        return;
+      } else if (profiles.length <= 1) {
         _authRepository.onRegistrationStarted();
         emitCustom(const SplashCustom.redirectToAddMembers());
         return;

--- a/lib/features/splash/cubit/splash_custom.dart
+++ b/lib/features/splash/cubit/splash_custom.dart
@@ -8,6 +8,7 @@ sealed class SplashCustom {
   const factory SplashCustom.redirectToAddMembers() =
       SplashRedirectToAddMembers;
   const factory SplashCustom.noInternet() = NoInternet;
+  const factory SplashCustom.experiencingIssues() = ExperiencingIssues;
 }
 
 class SplashRedirectToWelcome extends SplashCustom {
@@ -29,4 +30,8 @@ class SplashRedirectToAddMembers extends SplashCustom {
 
 class NoInternet extends SplashCustom {
   const NoInternet();
+}
+
+class ExperiencingIssues extends SplashCustom {
+  const ExperiencingIssues();
 }

--- a/lib/features/splash/pages/splash_page.dart
+++ b/lib/features/splash/pages/splash_page.dart
@@ -25,6 +25,7 @@ class _SplashPageState extends State<SplashPage> {
   final _cubit = getIt<SplashCubit>();
 
   bool _showNoInternetMessage = false;
+  bool _showCurrentlyExperiencingIssues = false;
 
   @override
   void initState() {
@@ -53,12 +54,21 @@ class _SplashPageState extends State<SplashPage> {
               width: 100,
             ),
             const SizedBox(height: 20),
-            const CustomCircularProgressIndicator(),
+            if (!_showCurrentlyExperiencingIssues)
+              const CustomCircularProgressIndicator(),
             if (_showNoInternetMessage)
               Padding(
                 padding: const EdgeInsets.all(20),
                 child: BodyMediumText(
                   context.l10n.noInternet,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            if (_showCurrentlyExperiencingIssues)
+              const Padding(
+                padding: EdgeInsets.all(20),
+                child: BodyMediumText(
+                  'We are currently experiencing issues. Please close the app and try again later.',
                   textAlign: TextAlign.center,
                 ),
               ),
@@ -90,6 +100,10 @@ class _SplashPageState extends State<SplashPage> {
       case NoInternet():
         setState(() {
           _showNoInternetMessage = true;
+        });
+      case ExperiencingIssues():
+        setState(() {
+          _showCurrentlyExperiencingIssues = true;
         });
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The splash screen now provides clear, dedicated messaging when issues are detected during startup, ensuring users are promptly informed about connectivity or data retrieval problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->