### PR TITLE
Fix league countdown not working correctly on monday itself

### DIFF
--- a/lib/features/family/features/giving_flow/create_transaction/models/transaction.dart
+++ b/lib/features/family/features/giving_flow/create_transaction/models/transaction.dart
@@ -1,12 +1,15 @@
+import 'package:intl/intl.dart';
+
 class Transaction {
-  const Transaction({
+  Transaction({
     required this.userId,
     required this.mediumId,
     required this.amount,
     this.goalId,
     this.isActOfService = false,
     this.gameGuid,
-  });
+  }) : timestamp =
+            DateFormat('yyyy-MM-ddTHH:mm:ss').format(DateTime.now().toUtc());
 
   final String userId;
   final String mediumId;
@@ -14,12 +17,15 @@ class Transaction {
   final String? goalId;
   final bool isActOfService;
   final String? gameGuid;
+  final String timestamp;
+
   Map<String, dynamic> toJson() {
     return {
       'userId': userId,
       'mediumId': mediumId,
       'amount': amount,
       'goalId': goalId,
+      'timestamp': timestamp,
       'isActOfService': isActOfService,
       if (gameGuid != null) 'GameId': gameGuid,
     };

--- a/lib/features/family/features/giving_flow/create_transaction/models/transaction.dart
+++ b/lib/features/family/features/giving_flow/create_transaction/models/transaction.dart
@@ -1,15 +1,12 @@
-import 'package:intl/intl.dart';
-
 class Transaction {
-  Transaction({
+  const Transaction({
     required this.userId,
     required this.mediumId,
     required this.amount,
     this.goalId,
     this.isActOfService = false,
     this.gameGuid,
-  }) : timestamp =
-            DateFormat('yyyy-MM-ddTHH:mm:ss').format(DateTime.now().toUtc());
+  });
 
   final String userId;
   final String mediumId;
@@ -17,15 +14,12 @@ class Transaction {
   final String? goalId;
   final bool isActOfService;
   final String? gameGuid;
-  final String timestamp;
-
   Map<String, dynamic> toJson() {
     return {
       'userId': userId,
       'mediumId': mediumId,
       'amount': amount,
       'goalId': goalId,
-      'timestamp': timestamp,
       'isActOfService': isActOfService,
       if (gameGuid != null) 'GameId': gameGuid,
     };

--- a/lib/features/family/features/league/presentation/pages/models/league_screen.dart
+++ b/lib/features/family/features/league/presentation/pages/models/league_screen.dart
@@ -31,16 +31,18 @@ class _LeagueScreenState extends State<LeagueScreen> {
     super.didChangeDependencies();
     _calculateDatesAndTimes();
     _leagueCubit.init();
-    if (_remainingHours <= 24) {
+    if (daysDifference <= 1) {
       _startCountdown();
     }
   }
-  
+
   void _calculateDatesAndTimes() {
     final now = DateTime.now();
     mondayMidnight = DateTime(now.year, now.month, now.day).add(
       Duration(
-        days: (DateTime.monday - now.weekday) % DateTime.daysPerWeek,
+        days: now.weekday == DateTime.monday
+            ? 7
+            : (DateTime.monday - now.weekday) % DateTime.daysPerWeek,
       ),
     );
     _minutesUntilReset = mondayMidnight.difference(now).inMinutes;

--- a/lib/features/give/models/givt_transaction.dart
+++ b/lib/features/give/models/givt_transaction.dart
@@ -1,16 +1,18 @@
 import 'package:equatable/equatable.dart';
 import 'package:givt_app/features/family/features/giving_flow/create_transaction/models/transaction.dart';
+import 'package:intl/intl.dart';
 
 class GivtTransaction extends Equatable {
   GivtTransaction.fromTransaction(Transaction transaction)
       : guid = transaction.userId,
         amount = transaction.amount,
         beaconId = transaction.mediumId,
-        timestamp = transaction.timestamp,
+        timestamp = DateFormat('yyyy-MM-ddTHH:mm:ss').format(
+          DateTime.now().toUtc(),
+        ),
         collectId = '1',
         goalId = transaction.goalId,
         mediumId = transaction.mediumId;
-
   const GivtTransaction({
     required this.guid,
     required this.amount,

--- a/lib/features/give/models/givt_transaction.dart
+++ b/lib/features/give/models/givt_transaction.dart
@@ -1,18 +1,16 @@
 import 'package:equatable/equatable.dart';
 import 'package:givt_app/features/family/features/giving_flow/create_transaction/models/transaction.dart';
-import 'package:intl/intl.dart';
 
 class GivtTransaction extends Equatable {
   GivtTransaction.fromTransaction(Transaction transaction)
       : guid = transaction.userId,
         amount = transaction.amount,
         beaconId = transaction.mediumId,
-        timestamp = DateFormat('yyyy-MM-ddTHH:mm:ss').format(
-          DateTime.now().toUtc(),
-        ),
+        timestamp = transaction.timestamp,
         collectId = '1',
         goalId = transaction.goalId,
         mediumId = transaction.mediumId;
+
   const GivtTransaction({
     required this.guid,
     required this.amount,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved countdown timer functionality for a more precise user experience.
  - The timer now starts when there is one day left until the next event, ensuring that the countdown reflects the correct time remaining.
  - If today is Monday, the countdown resets after a full week rather than immediately, offering a more intuitive timing display.
  - Introduced a new timestamp feature in transactions to capture the current UTC time, enhancing data tracking and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->