### PR TITLE
Make sure it's possible to end the first part of the email with an _ or .

### DIFF
--- a/lib/utils/util.dart
+++ b/lib/utils/util.dart
@@ -33,7 +33,8 @@ class Util {
   static final usPhoneNumberRegEx =
       RegExp(r'^(\([0-9]{3}\) |[0-9]{3}-)[0-9]{3}-[0-9]{4}$');
   static final ukSortCodeRegEx = RegExp(r'^\d{6}$');
-  static final emailRegEx = RegExp(r'^(?!.*\.\.)[a-zA-Z0-9][\w-\.]*[a-zA-Z0-9](\+[\w-\.]+)?@([\w-]+\.)+[\w]+$');
+  static final emailRegEx = RegExp(
+      r'^(?!.*\.\.)[a-zA-Z0-9][\w-\.]*[a-zA-Z0-9_\.](\+[\w-\.]+)?@([\w-]+\.)+[\w]+$');
   static final nameFieldsRegEx =
       RegExp(r'^[^0-9_!,¡?÷?¿/\\+=@#$%ˆ&*(){}|~<>;:[\]]{2,}$');
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced email validation to accept addresses with underscores, ensuring a broader range of valid email formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->