### PR TITLE
button should be primary

### DIFF
--- a/lib/features/family/features/reflect/presentation/pages/gather_around_screen.dart
+++ b/lib/features/family/features/reflect/presentation/pages/gather_around_screen.dart
@@ -75,7 +75,7 @@ class _GatherAroundScreenState extends State<GatherAroundScreen> {
           const SizedBox(height: 24),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 24),
-            child: FunButton.secondary(
+            child: FunButton(
               isDisabled: !_hasPlayedAudio && isFirstGame,
               onTap: () {
                 Navigator.of(context)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated a button on one of the screens to use a unified design, delivering a more streamlined appearance while retaining its existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->