### PR TITLE
Small improvements to not show the keyboard anymore when going from login to the next page (KIDS-2060)

### DIFF
--- a/lib/features/email_signup/presentation/pages/email_signup_page.dart
+++ b/lib/features/email_signup/presentation/pages/email_signup_page.dart
@@ -254,6 +254,9 @@ class _EmailSignupPageState extends State<EmailSignupPage> {
                               isLoading: _isLoading,
                               onTap: state.continueButtonEnabled
                                   ? () async {
+                                      // Hide keyboard when continue button is tapped
+                                      FocusScope.of(context).unfocus();
+                                      
                                       _cubit.updateApi();
                                       if (state.country?.isUS == true) {
                                         final fbsdk = FacebookAppEvents();

--- a/lib/features/family/features/login/presentation/pages/family_login_sheet.dart
+++ b/lib/features/family/features/login/presentation/pages/family_login_sheet.dart
@@ -200,9 +200,6 @@ class _FamilyLoginSheetState extends State<FamilyLoginSheet> {
     switch (state) {
       case LoginSuccess():
         if (!context.mounted) return;
-        context.pop();
-
-        if (!context.mounted) return;
         await widget.navigate(context);
       case TwoAttemptsLeftDialog():
         await showDialog<void>(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Email signup now offers an improved experience: when you tap the continue button, the on-screen keyboard automatically dismisses, providing a clearer view for the next steps.
  
- **Refactor**
  - The login flow has been streamlined by removing unnecessary code, ensuring that navigation remains smooth and consistent during the login process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->