### PR TITLE
Remove Givy from the Change Password Screen in the US (KIDS-2027)

### DIFF
--- a/lib/features/family/features/reset_password/presentation/pages/reset_password_sheet.dart
+++ b/lib/features/family/features/reset_password/presentation/pages/reset_password_sheet.dart
@@ -99,11 +99,6 @@ class _ResetPasswordSheetState extends State<ResetPasswordSheet> {
                     context.l10n.forgotPasswordText,
                     textAlign: TextAlign.center,
                   ),
-                  const SizedBox(height: 24),
-                  Image.asset(
-                    'assets/images/givy_question_big.png',
-                    width: 120,
-                  ),
                 ],
               ),
             ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Refined the reset password screen by streamlining spacing and removing excess imagery for a cleaner, more focused interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->