### PR TITLE
Feature: Allow skip when an error has occured in heard about givt KIDS-2020

### DIFF
--- a/lib/core/enums/amplitude_events.dart
+++ b/lib/core/enums/amplitude_events.dart
@@ -23,6 +23,7 @@ enum AmplitudeEvents {
   continueClicked('continue_clicked'),
   readyClicked('ready_clicked'),
   retryClicked('retry_clicked'),
+  skipClicked('skip_clicked'),
   createChildProfileClicked('create_child_profile_clicked'),
   directNoticeClicked('direct_notice_clicked'),
   enterCardDetailsClicked('enter_card_details_clicked'),

--- a/lib/features/family/features/box_origin/presentation/box_origin_selection_page.dart
+++ b/lib/features/family/features/box_origin/presentation/box_origin_selection_page.dart
@@ -66,9 +66,13 @@ class _BoxOriginSelectionPageState extends State<BoxOriginSelectionPage> {
     } else {
       await showBoxOriginErrorDialog(
         context,
-        onTap: () {
+        onTapRetry: () {
           Navigator.of(context).pop();
           _onTapConfirm(context);
+        },
+        onTapSkip: () {
+          Navigator.of(context).pop();
+          context.goNamed(FamilyPages.profileSelection.name);
         },
       );
     }

--- a/lib/features/family/features/impact_groups/widgets/dialogs/box_origin_outcome_dialog.dart
+++ b/lib/features/family/features/impact_groups/widgets/dialogs/box_origin_outcome_dialog.dart
@@ -27,18 +27,24 @@ Future<void> showBoxOriginSuccessDialog(
 
 Future<void> showBoxOriginErrorDialog(
   BuildContext context, {
-      void Function()? onTap,
+  void Function()? onTapRetry,
+  void Function()? onTapSkip,
 }) async {
   await FunModal(
     title: 'Oops, something went wrong...',
     buttons: [
       FunButton(
         text: 'Retry',
-        onTap: onTap ?? () => context.pop(),
+        onTap: onTapRetry ?? () => context.pop(),
         leftIcon: Icons.refresh_rounded,
         analyticsEvent: AnalyticsEvent(
           AmplitudeEvents.retryClicked,
         ),
+      ),
+      FunButton.secondary(
+        onTap: onTapSkip,
+        text: 'Skip',
+        analyticsEvent: AnalyticsEvent(AmplitudeEvents.skipClicked),
       ),
     ],
   ).show(context);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new event for tracking skip actions.
  - Enhanced error dialogs to now offer a distinct "Skip" option alongside the existing retry action, giving users the flexibility to bypass resetting and proceed directly to profile selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->