### PR TITLE
Feature: Show different message when feature is unlocked (KIDS-2195)

### DIFF
--- a/lib/features/family/features/edit_avatar/presentation/pages/edit_avatar_screen.dart
+++ b/lib/features/family/features/edit_avatar/presentation/pages/edit_avatar_screen.dart
@@ -230,7 +230,10 @@ class _EditAvatarScreenState extends State<EditAvatarScreen>
                 uiModel.customAvatarUIModel,
                 fit: BoxFit.contain,
               ),
-            if (uiModel.lockMessageEnabled) const LockedCaptainMessageWidget(),
+            if (uiModel.lockMessageEnabled)
+              LockedCaptainMessageWidget(
+                isCustomizationUnlocked: uiModel.isFeatureUnlocked,
+              ),
           ],
         ),
       ),

--- a/lib/features/family/features/edit_avatar/presentation/widgets/locked_captain_message_widget.dart
+++ b/lib/features/family/features/edit_avatar/presentation/widgets/locked_captain_message_widget.dart
@@ -2,15 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:givt_app/features/family/shared/design/components/content/fun_bubble.dart';
 
 class LockedCaptainMessageWidget extends StatelessWidget {
-  const LockedCaptainMessageWidget({super.key});
+  const LockedCaptainMessageWidget({
+    this.isCustomizationUnlocked = false,
+    super.key,
+  });
+
+  final bool isCustomizationUnlocked;
 
   @override
   Widget build(BuildContext context) {
+    final message = isCustomizationUnlocked
+        ? 'Play more Gratitude Games to unlock this!'
+        : "Heroes don't save the world in towels. Play Gratitude Game to unlock this!";
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24),
       child: FunBubble.captainGenerosity(
-        text:
-            "Heroes don't save the world in towels. Play Gratitude Game to unlock this!",
+        text: message,
       ),
     );
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The message displayed when avatar customization is locked now adapts based on feature unlock status, providing more relevant feedback to users.

- **Bug Fixes**
  - Improved messaging logic for locked customization to ensure users receive accurate information about unlocking options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->