### PR TITLE
Feature: Only show auth block on parent give (KIDs-2227)

### DIFF
--- a/lib/features/family/app/family_routes.dart
+++ b/lib/features/family/app/family_routes.dart
@@ -210,6 +210,9 @@ class FamilyAppRoutes {
           path: FamilyPages.giveByListFamily.path,
           name: FamilyPages.giveByListFamily.name,
           builder: (context, state) {
+            final map = state.extra as Map<String, dynamic>? ?? {};
+            final shouldAuthenticate =
+                map['shouldAuthenticate'] as bool? ?? false;
             final user = context.read<FamilyAuthCubit>().user!;
             return MultiBlocProvider(
               providers: [
@@ -226,7 +229,9 @@ class FamilyAppRoutes {
                     ),
                 ),
               ],
-              child: const GiveFromListPage(),
+              child: GiveFromListPage(
+                shouldAuthenticate: shouldAuthenticate,
+              ),
             );
           },
         ),

--- a/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/family_home_screen.dart
@@ -328,20 +328,12 @@ class _FamilyHomeScreenState extends State<FamilyHomeScreen> {
         _showSecondParentDialog(context, profile);
         return;
       }
-
-      await FamilyAuthUtils.authenticateUser(
-        context,
-        checkAuthRequest: FamilyCheckAuthRequest(
-          navigate: (context) async {
-            await context.pushNamed(
-              FamilyPages.parentHome.name,
-              extra: profile,
-            );
-            await AnalyticsHelper.setUserProperties(
-              userId: profile.id,
-            );
-          },
-        ),
+      context.pushNamed(
+        FamilyPages.parentHome.name,
+        extra: profile,
+      );
+      await AnalyticsHelper.setUserProperties(
+        userId: profile.id,
       );
     } else {
       context.goNamed(

--- a/lib/features/family/features/home_screen/presentation/pages/parent_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/parent_home_screen.dart
@@ -14,6 +14,7 @@ import 'package:givt_app/features/family/shared/design/components/components.dar
 import 'package:givt_app/features/family/shared/design/illustrations/fun_avatar.dart';
 import 'package:givt_app/features/family/shared/widgets/buttons/givt_back_button_flat.dart';
 import 'package:givt_app/features/family/utils/family_app_theme.dart';
+import 'package:givt_app/features/family/utils/utils.dart';
 import 'package:givt_app/shared/models/analytics_event.dart';
 import 'package:givt_app/shared/models/color_combo.dart';
 import 'package:givt_app/utils/analytics_helper.dart';
@@ -64,17 +65,24 @@ class _ParentHomeScreenState extends State<ParentHomeScreen> {
     }
   }
 
-  void _onProfileSwitchPressed(BuildContext context) {
-    context.pop();
-    AnalyticsHelper.logEvent(
-      eventName: AmplitudeEvents.profileSwitchPressed,
-    );
-  }
-
   Widget _giveTile(BuildContext context) => Padding(
         padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
         child: FunTile(
-          onTap: () => context.pushNamed(FamilyPages.giveByListFamily.name),
+          onTap: () {
+            // Add authentication when clicking the Give button
+            FamilyAuthUtils.authenticateUser(
+              context,
+              checkAuthRequest: FamilyCheckAuthRequest(
+                navigate: (context) =>
+                    context.pushNamed(FamilyPages.giveByListFamily.name),
+              ),
+            );
+
+            // Track analytics event
+            AnalyticsHelper.logEvent(
+              eventName: AmplitudeEvents.parentGiveTileClicked,
+            );
+          },
           borderColor: ColorCombo.secondary.borderColor,
           backgroundColor: ColorCombo.secondary.backgroundColor,
           textColor: ColorCombo.secondary.textColor,

--- a/lib/features/family/features/home_screen/presentation/pages/parent_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/parent_home_screen.dart
@@ -69,13 +69,11 @@ class _ParentHomeScreenState extends State<ParentHomeScreen> {
         padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
         child: FunTile(
           onTap: () {
-            // Add authentication when clicking the Give button
-            FamilyAuthUtils.authenticateUser(
-              context,
-              checkAuthRequest: FamilyCheckAuthRequest(
-                navigate: (context) =>
-                    context.pushNamed(FamilyPages.giveByListFamily.name),
-              ),
+            context.pushNamed(
+              FamilyPages.giveByListFamily.name,
+              extra: {
+                'shouldAuthenticate': true,
+              },
             );
 
             // Track analytics event


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Simplified navigation to the parent's home screen by removing the extra authentication step when selecting a parent profile.
  - Updated the "Give" tile on the parent home screen to require authentication before navigation, improving security and consistency.

- **Other Changes**
  - Analytics events are now logged immediately after relevant actions for improved tracking.
  - Added optional authentication before creating transactions in the giving flow, enhancing security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->