### PR TITLE
Max amount is crashing with the many zeros (KIDS-2240)

### DIFF
--- a/lib/shared/pages/change_max_amount_bottom_sheet.dart
+++ b/lib/shared/pages/change_max_amount_bottom_sheet.dart
@@ -252,10 +252,24 @@ class _ChangeMaxAmountBottomSheetViewState
               keyboardType: TextInputType.number,
               inputFormatters: [
                 FilteringTextInputFormatter.digitsOnly,
+                LengthLimitingTextInputFormatter(
+                  maxAmountLimit.toString().length + 1,
+                ),
               ],
               onChanged: (value) {
                 if (value.isEmpty) {
                   amountController.text = minAmountLimit.toString();
+                } else {
+                  // Check if value exceeds maximum limit
+                  final numValue = int.tryParse(value) ?? 0;
+                  if (numValue > maxAmountLimit) {
+                    amountController
+                      ..text = maxAmountLimit.toString()
+                      // Set cursor position at the end
+                      ..selection = TextSelection.fromPosition(
+                        TextPosition(offset: amountController.text.length),
+                      );
+                  }
                 }
                 setState(() {});
               },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the amount input field to prevent entering values greater than the allowed maximum. The field now automatically resets to the maximum if exceeded and limits the number of digits you can enter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->