### PR TITLE
Add coming soon text to levels page

### DIFF
--- a/lib/features/family/features/generosity_hunt/presentation/pages/generosity_hunt_levels_page.dart
+++ b/lib/features/family/features/generosity_hunt/presentation/pages/generosity_hunt_levels_page.dart
@@ -62,9 +62,24 @@ class _GenerosityHuntLevelsPageState extends State<GenerosityHuntLevelsPage> {
             }
             return ListView.separated(
               padding: const EdgeInsets.only(top: 24, bottom: 24),
-              itemCount: state.levels.length,
+              itemCount: state.levels.length + 1,
               separatorBuilder: (_, __) => const SizedBox(height: 8),
               itemBuilder: (context, index) {
+                if (index == state.levels.length) {
+                  // Show "More levels coming soon" text after the last level
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    child: Center(
+                      child: Text(
+                        'More levels coming soon',
+                        style: context.bodyMedium.copyWith(
+                          color: context.colorScheme.onSurface.withOpacity(0.6),
+                        ),
+                      ),
+                    ),
+                  );
+                }
+                
                 final level = state.levels[index];
                 return LevelTile(
                   level: level.level,


### PR DESCRIPTION
Add "More levels coming soon" text to GenerosityHuntLevelsPage to inform users about future content.

---
[Slack Thread](https://nfcollect.slack.com/archives/C08BXP1DEG0/p1753981088017169?thread_ts=1753981088.017169&cid=C08BXP1DEG0)

<a href="https://cursor.com/background-agent?bcId=bc-bf36016b-10b2-496e-9e30-7bbcca1efa77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf36016b-10b2-496e-9e30-7bbcca1efa77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>