### PR TITLE
Disable swipe back and add close button

### DIFF
--- a/lib/features/family/features/generosity_hunt/presentation/pages/generosity_level_scan_page.dart
+++ b/lib/features/family/features/generosity_hunt/presentation/pages/generosity_level_scan_page.dart
@@ -2,13 +2,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:givt_app/core/enums/amplitude_events.dart';
 import 'package:givt_app/features/family/app/injection.dart';
 import 'package:givt_app/features/family/features/generosity_hunt/cubit/scan_cubit.dart';
 import 'package:givt_app/features/family/features/profiles/cubit/profiles_cubit.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/features/family/shared/design/illustrations/fun_icon.dart';
-import 'package:givt_app/features/family/shared/widgets/buttons/givt_back_button_flat.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/shared_texts.dart';
 import 'package:givt_app/features/family/utils/family_app_theme.dart';
 import 'package:givt_app/shared/models/analytics_event.dart';
@@ -81,10 +81,19 @@ class _BarcodeLevelScanPageState extends State<BarcodeLevelScanPage> {
       onCustom: _onCustom,
       onData: (context, state) {
         return FunScaffold(
+          canPop: false,
           minimumPadding: EdgeInsets.zero,
           appBar: FunTopAppBar(
             title: 'Level ${state.level?.level}',
-            leading: const GivtBackButtonFlat(),
+            actions: [
+              IconButton(
+                icon: const FaIcon(
+                  FontAwesomeIcons.xmark,
+                  semanticLabel: 'Close',
+                ),
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+            ],
           ),
           body: Column(
             children: [


### PR DESCRIPTION
Disable swipe back and add a close button on the BarcodeLevelScanPage to prevent unintended re-scans and ensure proper navigation.

This change addresses an issue where users could swipe back after scanning, re-scan the same item, and potentially exploit an "unlimited XP easter egg" or encounter recognition issues. Disabling swipe back and providing a clear close button enforces a single-pass scan flow.

---
[Slack Thread](https://nfcollect.slack.com/archives/C08BXP1DEG0/p1753981331233819?thread_ts=1753981331.233819&cid=C08BXP1DEG0)

<a href="https://cursor.com/background-agent?bcId=bc-5595485a-57e4-420c-b603-eba486eb6c48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5595485a-57e4-420c-b603-eba486eb6c48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the back button in the app bar with a close ("xmark") icon button for easier closing of the page.

* **Style**
  * Updated the app bar to use a FontAwesome icon for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->