### PR TITLE
fix(COR-582): Change League welcome screen based on game type

### DIFF
--- a/lib/features/family/app/injection.dart
+++ b/lib/features/family/app/injection.dart
@@ -114,7 +114,7 @@ void initCubits() {
       CameraCubit.new,
     )
     ..registerLazySingleton<MediumCubit>(MediumCubit.new)
-    ..registerLazySingleton(() => LeagueCubit(getIt(), getIt(), getIt()))
+    ..registerLazySingleton(() => LeagueCubit(getIt(), getIt(), getIt(), getIt()))
     ..registerFactory(
         () => InGameLeagueCubit(getIt(), getIt(), getIt(), getIt()))
     ..registerLazySingleton<GiveCubit>(

--- a/lib/features/family/features/league/bloc/league_cubit.dart
+++ b/lib/features/family/features/league/bloc/league_cubit.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:givt_app/features/impact_groups_legacy_logic/repo/impact_groups_repository.dart';
+import 'package:givt_app/features/family/features/impact_groups/models/impact_group.dart';
 import 'package:givt_app/features/family/features/league/domain/league_repository.dart';
 import 'package:givt_app/features/family/features/league/domain/models/league_item.dart';
 import 'package:givt_app/features/family/features/league/presentation/pages/models/league_screen_uimodel.dart';
@@ -16,17 +18,20 @@ class LeagueCubit extends CommonCubit<LeagueScreenUIModel, dynamic> {
     this._profilesRepository,
     this._leagueRepository,
     this._prefs,
+    this._impactGroupsRepository,
   ) : super(const BaseState.loading());
 
   final ProfilesRepository _profilesRepository;
   final LeagueRepository _leagueRepository;
   final SharedPreferences _prefs;
+  final ImpactGroupsRepository _impactGroupsRepository;
 
   static const String _leagueExplanationKey = 'leagueExplanation';
 
   List<Profile> _profiles = [];
   List<LeagueItem> _league = [];
   late bool _hasSeenLeagueExplanation;
+  ImpactGroup? _familyGroup;
 
   StreamSubscription<List<Profile>>? _profilesSubscription;
   StreamSubscription<List<LeagueItem>>? _leagueSubscription;
@@ -47,6 +52,8 @@ class LeagueCubit extends CommonCubit<LeagueScreenUIModel, dynamic> {
       emitLoading();
       _profiles = await _profilesRepository.getProfiles();
       _league = await _leagueRepository.fetchLeague();
+      _familyGroup = await _impactGroupsRepository.getImpactGroups(fetchWhenEmpty: true)
+          .then((groups) => groups.where((element) => element.isFamilyGroup).firstOrNull);
     } catch (e, s) {
       // do nothing
     }
@@ -78,7 +85,9 @@ class LeagueCubit extends CommonCubit<LeagueScreenUIModel, dynamic> {
   }
 
   void _emitEmptyLeague() {
-    emitData(const LeagueScreenUIModel.showEmptyLeague());
+    final showGenerosityHunt = _familyGroup?.boxOrigin?.mediumId?.toLowerCase() ==
+        'FF8EC1E5-8D2F-4238-519C-08DC57CE1CE7'.toLowerCase();
+    emitData(LeagueScreenUIModel.showEmptyLeague(showGenerosityHunt: showGenerosityHunt));
   }
 
   void onExplanationContinuePressed() {

--- a/lib/features/family/features/league/presentation/pages/league_screen.dart
+++ b/lib/features/family/features/league/presentation/pages/league_screen.dart
@@ -98,7 +98,7 @@ class _LeagueScreenState extends State<LeagueScreen> {
                 onContinuePressed: _leagueCubit.onExplanationContinuePressed,
               );
             case ShowEmptyLeague():
-              return const EmptyLeague();
+              return EmptyLeague(showGenerosityHunt: uiModel.showGenerosityHunt);
           }
         },
       ),

--- a/lib/features/family/features/league/presentation/pages/models/league_screen_uimodel.dart
+++ b/lib/features/family/features/league/presentation/pages/models/league_screen_uimodel.dart
@@ -9,7 +9,7 @@ sealed class LeagueScreenUIModel {
 
   const factory LeagueScreenUIModel.showLeagueExplanation() = ShowLeagueExplanation;
 
-  const factory LeagueScreenUIModel.showEmptyLeague() = ShowEmptyLeague;
+  const factory LeagueScreenUIModel.showEmptyLeague({bool showGenerosityHunt}) = ShowEmptyLeague;
 }
 
 class ShowLeagueOverview extends LeagueScreenUIModel {
@@ -23,5 +23,7 @@ class ShowLeagueExplanation extends LeagueScreenUIModel {
 }
 
 class ShowEmptyLeague extends LeagueScreenUIModel {
-  const ShowEmptyLeague();
+  const ShowEmptyLeague({this.showGenerosityHunt = false});
+
+  final bool showGenerosityHunt;
 }

--- a/lib/features/family/features/league/presentation/widgets/empty_league.dart
+++ b/lib/features/family/features/league/presentation/widgets/empty_league.dart
@@ -8,10 +8,20 @@ import 'package:givt_app/shared/models/analytics_event.dart';
 import 'package:go_router/go_router.dart';
 
 class EmptyLeague extends StatelessWidget {
-  const EmptyLeague({super.key});
+  const EmptyLeague({required this.showGenerosityHunt, super.key});
+
+  final bool showGenerosityHunt;
 
   @override
   Widget build(BuildContext context) {
+    final titleText = showGenerosityHunt
+        ? "Play the Generosity Hunt to unlock this week's League!"
+        : "Play the Gratitude Game to unlock this week's League!";
+    
+    final buttonText = showGenerosityHunt
+        ? 'Play Generosity Hunt'
+        : 'Play Gratitude Game';
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24),
       child: Column(
@@ -21,16 +31,18 @@ class EmptyLeague extends StatelessWidget {
             'assets/family/images/league/league_empty_image.svg',
           ),
           const SizedBox(height: 16),
-          const TitleMediumText(
-            "Play the Gratitude Game to unlock this week's League!",
+          TitleMediumText(
+            titleText,
             textAlign: TextAlign.center,
           ),
           const Spacer(),
           FunButton(
             onTap: () => context.goNamed(
-              FamilyPages.reflectIntro.name,
+              showGenerosityHunt
+                  ? FamilyPages.newGame.name
+                  : FamilyPages.reflectIntro.name,
             ),
-            text: 'Play Gratitude Game',
+            text: buttonText,
             analyticsEvent:
             AnalyticsEvent(AmplitudeEvents.leaguePlayGameClicked),
           ),


### PR DESCRIPTION
- Add logic to determine if user should see Generosity Hunt or Gratitude Game
- Modify LeagueCubit to access ImpactGroupsRepository and check church preference
- Update LeagueScreenUIModel to include showGenerosityHunt parameter
- Modify EmptyLeague widget to display different text and navigation based on game type
- Update LeagueScreen to pass game type information to EmptyLeague widget
- Update dependency injection to include ImpactGroupsRepository in LeagueCubit

Users with Redeemer church preference now see 'Generosity Hunt' content instead of 'Gratitude Game' content on the League page.