### PR TITLE
Fix profile screen button width bug

### DIFF
--- a/lib/features/family/features/home_screen/presentation/pages/parent_home_screen.dart
+++ b/lib/features/family/features/home_screen/presentation/pages/parent_home_screen.dart
@@ -140,15 +140,17 @@ class _ParentHomeScreenState extends State<ParentHomeScreen> {
                   child: FunAvatar.fromProfile(profile, size: 100),
                 ),
                 const SizedBox(height: 12),
-                FunButton.secondary(
-                  onTap: () => _onEditAvatarClicked(context, false),
-                  text: 'Edit avatar',
-                  analyticsEvent: AmplitudeEvents.editProfilePictureClicked.toEvent(),
-                  size: FunButtonSize.small,
-                  leftIcon: FontAwesomeIcons.userPen,
-                  funButtonBadge: FunButtonBadge(
-                    featureId: Features.profileEditAvatarButton,
-                    profileId: profile.id,
+                Center(
+                  child: FunButton.secondary(
+                    onTap: () => _onEditAvatarClicked(context, false),
+                    text: 'Edit avatar',
+                    analyticsEvent: AmplitudeEvents.editProfilePictureClicked.toEvent(),
+                    size: FunButtonSize.small,
+                    leftIcon: FontAwesomeIcons.userPen,
+                    funButtonBadge: FunButtonBadge(
+                      featureId: Features.profileEditAvatarButton,
+                      profileId: profile.id,
+                    ),
                   ),
                 ),
                 const SizedBox(height: 12),

--- a/lib/features/family/features/profiles/widgets/wallet_widget.dart
+++ b/lib/features/family/features/profiles/widgets/wallet_widget.dart
@@ -83,22 +83,24 @@ class _WalletWidgetState extends State<WalletWidget> {
                     ),
                   ),
                   const SizedBox(height: 12),
-                  FunButton.secondary(
-                    onTap: () {
-                      Navigator.of(context).push(
-                        EditAvatarScreen(userGuid: widget.kidid).toRoute(
-                          context,
-                        ),
-                      );
-                    },
-                    text: 'Edit avatar',
-                    analyticsEvent: AmplitudeEvents.editProfilePictureClicked
-                        .toEvent(),
-                    size: FunButtonSize.small,
-                    leftIcon: FontAwesomeIcons.userPen,
-                    funButtonBadge: FunButtonBadge(
-                      featureId: Features.profileEditAvatarButton,
-                      profileId: widget.kidid,
+                  Center(
+                    child: FunButton.secondary(
+                      onTap: () {
+                        Navigator.of(context).push(
+                          EditAvatarScreen(userGuid: widget.kidid).toRoute(
+                            context,
+                          ),
+                        );
+                      },
+                      text: 'Edit avatar',
+                      analyticsEvent: AmplitudeEvents.editProfilePictureClicked
+                          .toEvent(),
+                      size: FunButtonSize.small,
+                      leftIcon: FontAwesomeIcons.userPen,
+                      funButtonBadge: FunButtonBadge(
+                        featureId: Features.profileEditAvatarButton,
+                        profileId: widget.kidid,
+                      ),
                     ),
                   ),
                   const SizedBox(height: 12),


### PR DESCRIPTION
Wrap small `FunButton` instances in `Center` widgets to ensure they size to content instead of expanding to full width.

---
Linear Issue: [COR-692](https://linear.app/givt/issue/COR-692/button-size-on-profile-screen-isnt-too-width)

<a href="https://cursor.com/background-agent?bcId=bc-446e092c-b8f8-4ff6-8764-d4b8e1d7cba7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-446e092c-b8f8-4ff6-8764-d4b8e1d7cba7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

