### PR TITLE
Fix recurring donation start date bug

### DIFF
--- a/lib/features/recurring_donations/detail/pages/recurring_donation_detail_page.dart
+++ b/lib/features/recurring_donations/detail/pages/recurring_donation_detail_page.dart
@@ -412,13 +412,15 @@ class _RecurringDonationDetailPageState
         // Find the last completed transaction
         final lastTransaction = completedTransactions
             .reduce((a, b) => a.date.isAfter(b.date) ? a : b);
-        final daysHelped = lastTransaction.date.difference(startDate).inDays;
+        // Ensure days helped is never negative - if last transaction is before start date, show 0
+        final daysHelped = lastTransaction.date.difference(startDate).inDays.clamp(0, double.infinity).toInt();
         return context.l10n.recurringDonationsDetailTimeDisplayDays(
           daysHelped.toString(),
         );
       } else {
         // Fallback: no completed transactions, show days from start to end date
-        final daysHelped = uiModel.endDate!.difference(startDate).inDays;
+        // Ensure days helped is never negative - if end date is before start date, show 0
+        final daysHelped = uiModel.endDate!.difference(startDate).inDays.clamp(0, double.infinity).toInt();
         return context.l10n.recurringDonationsDetailTimeDisplayDays(
           daysHelped.toString(),
         );
@@ -426,7 +428,8 @@ class _RecurringDonationDetailPageState
     } else {
       // For active donations, show days from start until now
       final now = DateTime.now();
-      final daysHelped = now.difference(startDate).inDays;
+      // Ensure days helped is never negative - if start date is in the future, show 0
+      final daysHelped = now.difference(startDate).inDays.clamp(0, double.infinity).toInt();
       return context.l10n.recurringDonationsDetailTimeDisplayDays(
         daysHelped.toString(),
       );

--- a/lib/features/recurring_donations/overview/models/recurring_donation.dart
+++ b/lib/features/recurring_donations/overview/models/recurring_donation.dart
@@ -158,19 +158,36 @@ class RecurringDonation extends Equatable {
     final frequency = _evaluateFrequencyFromCronExpression();
     
     // Calculate the date of the next turn based on start date and completed turns
+    // The first donation (completedTurns = 0) should happen on the start date itself
     var nextDate = start;
     
     switch (frequency) {
       case 0: // Weekly
-        nextDate = start.add(Duration(days: 7 * (completedTurns + 1)));
+        nextDate = start.add(Duration(days: 7 * completedTurns));
       case 1: // Monthly
-        nextDate = start.copyWith(month: start.month + completedTurns + 1);
+        nextDate = start.copyWith(month: start.month + completedTurns);
       case 2: // Quarterly
-        nextDate = start.copyWith(month: start.month + (3 * (completedTurns + 1)));
+        nextDate = start.copyWith(month: start.month + (3 * completedTurns));
       case 3: // Semi-annually
-        nextDate = start.copyWith(month: start.month + (6 * (completedTurns + 1)));
+        nextDate = start.copyWith(month: start.month + (6 * completedTurns));
       case 4: // Annually
-        nextDate = start.copyWith(year: start.year + completedTurns + 1);
+        nextDate = start.copyWith(year: start.year + completedTurns);
+    }
+    
+    // If the calculated date is not after now, we need the next occurrence
+    if (!nextDate.isAfter(now)) {
+      switch (frequency) {
+        case 0: // Weekly
+          nextDate = start.add(Duration(days: 7 * (completedTurns + 1)));
+        case 1: // Monthly
+          nextDate = start.copyWith(month: start.month + completedTurns + 1);
+        case 2: // Quarterly
+          nextDate = start.copyWith(month: start.month + (3 * (completedTurns + 1)));
+        case 3: // Semi-annually
+          nextDate = start.copyWith(month: start.month + (6 * (completedTurns + 1)));
+        case 4: // Annually
+          nextDate = start.copyWith(year: start.year + completedTurns + 1);
+      }
     }
     
     return nextDate;


### PR DESCRIPTION
Fixes recurring donation start date calculation and prevents negative "days helped" display.

The recurring donation feature incorrectly scheduled the first donation to occur one frequency period after the chosen start date. This PR adjusts the `getNextDonationDateFromStart` logic to ensure the initial donation happens on the exact start date. Additionally, the "days helped" display on the detail screen could show negative values when the donation had not yet started; this is now clamped to zero for better user experience.

---
Linear Issue: [COR-737](https://linear.app/givt/issue/COR-737/recurring-donation-doesnt-start-on-the-starting-date-but-on-starting)

<a href="https://cursor.com/background-agent?bcId=bc-9629fe9a-f278-4ce6-b636-7976a41fd3f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9629fe9a-f278-4ce6-b636-7976a41fd3f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

