### PR TITLE
Update confirm.html for universal platform fees

### DIFF
--- a/lib/features/family/features/parent_giving_flow/presentation/pages/parent_giving_page.dart
+++ b/lib/features/family/features/parent_giving_flow/presentation/pages/parent_giving_page.dart
@@ -108,6 +108,17 @@ class _ParentGivingPageState extends State<ParentGivingPage> {
       yesSuccess: context.l10n.yesSuccess,
       close: context.l10n.close,
       collect: context.l10n.collect,
+      subtotalText: context.l10n.donationSubtotal,
+      totalText: context.l10n.donationTotal,
+      platformFeeNoContributionText: context.l10n.platformFeeNoContribution,
+      platformFeeGoodOptionText: context.l10n.platformFeeGoodOption,
+      platformFeeCommonOptionText: context.l10n.platformFeeCommonOption,
+      platformFeeGenerousOptionText: context.l10n.platformFeeGenerousOption,
+      platformFeeText: context.l10n.platformFeeText,
+      platformFeeTitle: context.l10n.platformFeeTitle,
+      platformFeePlaceholder: context.l10n.platformFeePlaceholder,
+      platformFeeRequired: context.l10n.platformFeeRequired,
+      platformFeeRemember: context.l10n.platformFeeRemember,
       experiencePoints: state.experiencePoints,
     ).toJson();
   }
@@ -134,7 +145,7 @@ class _ParentGivingPageState extends State<ParentGivingPage> {
               url: WebUri.uri(
                 Uri.https(
                   getIt<RequestHelper>().apiURL,
-                  'confirm-G4F.html',
+                  'confirm.html',
                   {'msg': base64.encode(utf8.encode(jsonEncode(givt)))},
                 ),
               ),


### PR DESCRIPTION
Unify platform fee parameters and HTML template in the parent giving flow to apply the bracket-based platform contribution to all users consistently.

---
Linear Issue: [COR-825](https://linear.app/givt/issue/COR-825/apply-the-platform-contribution-to-all-users-in-the-givt)

<a href="https://cursor.com/background-agent?bcId=bc-53130cb9-4fdc-49b6-acef-e3a54936ebce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-53130cb9-4fdc-49b6-acef-e3a54936ebce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

