### PR TITLE
Update donation overview to show all ids

### DIFF
--- a/lib/features/donation_overview/pages/donation_detail_page.dart
+++ b/lib/features/donation_overview/pages/donation_detail_page.dart
@@ -88,7 +88,7 @@ class _DonationDetailPageState extends State<DonationDetailPage> {
             IconButton(
               onPressed: () => _showContactForm(
                 context,
-                firstDonation.id.toString(),
+                _formatTransactionIds(sortedDonations),
                 _getStatusText(context, status.type),
               ),
               icon: const FaIcon(FontAwesomeIcons.circleQuestion),
@@ -174,12 +174,20 @@ class _DonationDetailPageState extends State<DonationDetailPage> {
                     showDivider: true,
                   ),
 
-                // Transaction ID
-                _buildDetailRow(
-                  label: 'Transaction ID',
-                  value: '#${firstDonation.id}',
-                  showDivider: false,
-                ),
+                // Transaction IDs
+                ...sortedDonations.asMap().entries.map((entry) {
+                  final index = entry.key;
+                  final donation = entry.value;
+                  final isLast = index == sortedDonations.length - 1;
+                  
+                  return _buildDetailRow(
+                    label: sortedDonations.length > 1 
+                        ? 'Transaction ID ${index + 1}'
+                        : 'Transaction ID',
+                    value: '#${donation.id}',
+                    showDivider: !isLast,
+                  );
+                }).toList(),
               ],
             ),
 
@@ -446,9 +454,17 @@ class _DonationDetailPageState extends State<DonationDetailPage> {
     }
   }
 
+  String _formatTransactionIds(List<DonationItem> donations) {
+    if (donations.length == 1) {
+      return donations.first.id.toString();
+    }
+    
+    return donations.map((d) => '#${d.id}').join(', ');
+  }
+
   void _showContactForm(
     BuildContext context,
-    String transactionId,
+    String transactionIds,
     String status,
   ) {
     AboutGivtBottomSheet.show(
@@ -456,7 +472,7 @@ class _DonationDetailPageState extends State<DonationDetailPage> {
       initialMessage: context.l10n
           .donationOverviewContactMessage(
             status,
-            transactionId,
+            transactionIds,
           )
           .replaceAll(r'\n', '\n'),
     );


### PR DESCRIPTION
Display all transaction IDs on the donation detail page and include them in the contact form to resolve COR-855.

---
Linear Issue: [COR-855](https://linear.app/givt/issue/COR-855/change-donation-overview-so-it-shows-all-donation-ids)

<a href="https://cursor.com/background-agent?bcId=bc-215fa7d5-1c1d-4dd4-b971-9f558c5842d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-215fa7d5-1c1d-4dd4-b971-9f558c5842d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

