### PR TITLE
Add amplitude tracking for donation management

### DIFF
--- a/lib/core/enums/amplitude_events.dart
+++ b/lib/core/enums/amplitude_events.dart
@@ -116,6 +116,12 @@ enum AmplitudeEvents {
   recurringDonationsAddRecurringDonation(
     'recurring_donations_add_recurring_donation',
   ),
+  // Recurring donation management actions
+  recurringDonationEditActionClicked('recurring_donation_edit_action_clicked'),
+  recurringDonationPauseActionClicked('recurring_donation_pause_action_clicked'),
+  recurringDonationCancelActionClicked('recurring_donation_cancel_action_clicked'),
+  recurringDonationCancelConfirmed('recurring_donation_cancel_confirmed'),
+  recurringDonationCancelCancelled('recurring_donation_cancel_cancelled'),
   editAvatarPictureClicked('edit_avatar_picture_clicked'),
   familyGoalCreateClicked('family_goal_create_clicked'),
   familyGoalCauseSet('family_goal_cause_set'),

--- a/lib/features/recurring_donations/cancel/widgets/cancel_recurring_donation_confirmation_dialog.dart
+++ b/lib/features/recurring_donations/cancel/widgets/cancel_recurring_donation_confirmation_dialog.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app/app/injection/injection.dart';
+import 'package:givt_app/core/enums/amplitude_events.dart';
 import 'package:givt_app/features/recurring_donations/cancel/cubit/cancel_recurring_donation_cubit.dart';
 import 'package:givt_app/features/recurring_donations/overview/models/recurring_donation.dart';
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/shared/dialogs/dialogs.dart';
+import 'package:givt_app/utils/analytics_helper.dart';
 import 'package:go_router/go_router.dart';
 
 class CancelRecurringDonationConfirmationDialog extends StatelessWidget {
@@ -46,12 +48,20 @@ class CancelRecurringDonationConfirmationDialog extends StatelessWidget {
               content: locals.cancelRecurringDonationAlertMessage,
               confirmText: locals.yes,
               onConfirm: () {
+                AnalyticsHelper.logEvent(
+                  eventName: AmplitudeEvents.recurringDonationCancelConfirmed,
+                );
                 context
                     .read<CancelRecurringDonationCubit>()
                     .cancelRecurringDonations(recurringDonation);
               },
               cancelText: locals.no,
-              onCancel: () => context.pop(false),
+              onCancel: () {
+                AnalyticsHelper.logEvent(
+                  eventName: AmplitudeEvents.recurringDonationCancelCancelled,
+                );
+                context.pop(false);
+              },
             );
           } else {
             return Container();

--- a/lib/features/recurring_donations/detail/pages/recurring_donation_detail_page.dart
+++ b/lib/features/recurring_donations/detail/pages/recurring_donation_detail_page.dart
@@ -19,6 +19,7 @@ import 'package:givt_app/features/recurring_donations/overview/pages/recurring_d
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
 import 'package:givt_app/shared/widgets/fun_scaffold.dart';
+import 'package:givt_app/utils/analytics_helper.dart';
 import 'package:givt_app/utils/util.dart';
 import 'package:go_router/go_router.dart';
 
@@ -449,6 +450,9 @@ class _RecurringDonationDetailPageState
               leading: const Icon(Icons.edit),
               title: Text(context.l10n.recurringDonationsDetailEditDonation),
               onTap: () {
+                AnalyticsHelper.logEvent(
+                  eventName: AmplitudeEvents.recurringDonationEditActionClicked,
+                );
                 Navigator.of(context).pop();
                 // TODO: Navigate to edit page when implemented
                 ScaffoldMessenger.of(context).showSnackBar(
@@ -465,6 +469,9 @@ class _RecurringDonationDetailPageState
               leading: const Icon(Icons.pause),
               title: Text(context.l10n.recurringDonationsDetailPauseDonation),
               onTap: () {
+                AnalyticsHelper.logEvent(
+                  eventName: AmplitudeEvents.recurringDonationPauseActionClicked,
+                );
                 Navigator.of(context).pop();
                 // TODO: Implement pause functionality when available
                 ScaffoldMessenger.of(context).showSnackBar(
@@ -484,6 +491,9 @@ class _RecurringDonationDetailPageState
                 style: const TextStyle(color: Colors.red),
               ),
               onTap: () {
+                AnalyticsHelper.logEvent(
+                  eventName: AmplitudeEvents.recurringDonationCancelActionClicked,
+                );
                 // Show cancel confirmation dialog
                 showDialog<bool>(
                   context: context,


### PR DESCRIPTION
Add Amplitude tracking for recurring donation management actions to capture user interactions with edit, pause, and cancel options.

---
Linear Issue: [COR-870](https://linear.app/givt/issue/COR-870/add-amplitude-tracking-for-recurring-donation-actions)

<a href="https://cursor.com/background-agent?bcId=bc-552f9e08-02d3-41a6-a6d2-7133348f0807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-552f9e08-02d3-41a6-a6d2-7133348f0807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

