### PR TITLE
Implement password reset page with app parameter

### DIFF
--- a/lib/app/routes/app_router.dart
+++ b/lib/app/routes/app_router.dart
@@ -11,6 +11,7 @@ import 'package:givt_app/features/account_details/pages/personal_info_edit_page.
 import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/features/donation_overview/donation_overview.dart';
 import 'package:givt_app/features/email_signup/presentation/pages/email_signup_page.dart';
+import 'package:givt_app/features/family/features/reset_password/presentation/pages/change_password_page.dart';
 import 'package:givt_app/features/family/app/family_pages.dart';
 import 'package:givt_app/features/family/app/family_routes.dart';
 import 'package:givt_app/features/give/bloc/bloc.dart';
@@ -498,6 +499,26 @@ class AppRouter {
               _checkAndRedirectAuth(state, context, routerState),
           child: const EmailSignupPage(),
         ),
+      ),
+      GoRoute(
+        path: '/changepassword',
+        name: 'changepassword',
+        builder: (context, state) {
+          final code = state.uri.queryParameters['code'] ?? '';
+          final email = state.uri.queryParameters['email'] ?? '';
+          final app = state.uri.queryParameters['app'] == 'true';
+          
+          if (code.isEmpty || email.isEmpty) {
+            // Redirect to welcome page if required parameters are missing
+            return const EmailSignupPage();
+          }
+          
+          return ChangePasswordPage(
+            code: code,
+            email: email,
+            isApp: app,
+          );
+        },
       ),
       // Family features
       ...FamilyAppRoutes.routes,

--- a/lib/features/family/app/injection.dart
+++ b/lib/features/family/app/injection.dart
@@ -60,7 +60,9 @@ import 'package:givt_app/features/family/features/reflect/domain/reflect_and_sha
 import 'package:givt_app/features/family/features/registration/cubit/us_signup_cubit.dart';
 import 'package:givt_app/features/family/features/remote_config/domain/remote_config_repository.dart';
 import 'package:givt_app/features/family/features/reset_password/cubit/reset_password_cubit.dart';
+import 'package:givt_app/features/family/features/reset_password/cubit/change_password_cubit.dart';
 import 'package:givt_app/features/family/features/reset_password/repositories/reset_password_repository.dart';
+import 'package:givt_app/features/family/features/reset_password/repositories/change_password_repository.dart';
 import 'package:givt_app/features/family/features/tutorial/domain/tutorial_repository.dart';
 import 'package:givt_app/features/family/features/unlocked_badge/cubit/unlocked_badge_cubit.dart';
 import 'package:givt_app/features/family/features/unlocked_badge/repository/unlocked_badge_repository.dart';
@@ -174,6 +176,11 @@ void initCubits() {
     )
     ..registerLazySingleton<ResetPasswordCubit>(
       () => ResetPasswordCubit(
+        getIt(),
+      ),
+    )
+    ..registerLazySingleton<ChangePasswordCubit>(
+      () => ChangePasswordCubit(
         getIt(),
       ),
     )
@@ -334,6 +341,11 @@ void initRepositories() {
     )
     ..registerLazySingleton<ResetPasswordRepository>(
       () => ResetPasswordRepositoryImpl(
+        getIt(),
+      ),
+    )
+    ..registerLazySingleton<ChangePasswordRepository>(
+      () => ChangePasswordRepositoryImpl(
         getIt(),
       ),
     )

--- a/lib/features/family/features/reset_password/cubit/change_password_cubit.dart
+++ b/lib/features/family/features/reset_password/cubit/change_password_cubit.dart
@@ -1,0 +1,40 @@
+import 'package:givt_app/core/logging/logging.dart';
+import 'package:givt_app/features/family/features/reset_password/repositories/change_password_repository.dart';
+import 'package:givt_app/shared/bloc/base_state.dart';
+import 'package:givt_app/shared/bloc/common_cubit.dart';
+
+class ChangePasswordCubit extends CommonCubit<bool, dynamic> {
+  ChangePasswordCubit(
+    this._changePasswordRepository,
+  ) : super(const BaseState.initial());
+
+  final ChangePasswordRepository _changePasswordRepository;
+
+  void init() {
+    emitInitial();
+  }
+
+  Future<void> changePassword({
+    required String userID,
+    required String passwordToken,
+    required String newPassword,
+  }) async {
+    emitLoading();
+
+    try {
+      await _changePasswordRepository.changePassword(
+        userID: userID,
+        passwordToken: passwordToken,
+        newPassword: newPassword,
+      );
+      emitData(true);
+    } catch (e, stackTrace) {
+      LoggingInfo.instance.error(
+        e.toString(),
+        methodName: stackTrace.toString(),
+      );
+
+      emitError(null);
+    }
+  }
+}

--- a/lib/features/family/features/reset_password/presentation/pages/change_password_page.dart
+++ b/lib/features/family/features/reset_password/presentation/pages/change_password_page.dart
@@ -1,0 +1,268 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:givt_app/core/enums/amplitude_events.dart';
+import 'package:givt_app/features/family/app/injection.dart';
+import 'package:givt_app/features/family/features/reset_password/cubit/change_password_cubit.dart';
+import 'package:givt_app/features/family/shared/design/components/components.dart';
+import 'package:givt_app/features/family/shared/widgets/loading/custom_progress_indicator.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/body_medium_text.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/title_medium_text.dart';
+import 'package:givt_app/l10n/l10n.dart';
+import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
+import 'package:givt_app/shared/widgets/common_icons.dart';
+import 'package:givt_app/shared/widgets/outlined_text_form_field.dart';
+import 'package:givt_app/utils/util.dart';
+import 'package:go_router/go_router.dart';
+
+class ChangePasswordPage extends StatefulWidget {
+  const ChangePasswordPage({
+    required this.code,
+    required this.email,
+    required this.isApp,
+    super.key,
+  });
+
+  final String code;
+  final String email;
+  final bool isApp;
+
+  @override
+  State<ChangePasswordPage> createState() => _ChangePasswordPageState();
+}
+
+class _ChangePasswordPageState extends State<ChangePasswordPage> {
+  final formKey = GlobalKey<FormState>();
+  late TextEditingController newPasswordController;
+  late TextEditingController confirmPasswordController;
+  bool _obscureNewPassword = true;
+  bool _obscureConfirmPassword = true;
+
+  final ChangePasswordCubit _cubit = getIt<ChangePasswordCubit>();
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _cubit.init();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    newPasswordController = TextEditingController();
+    confirmPasswordController = TextEditingController();
+    formKey.currentState?.validate();
+  }
+
+  @override
+  void dispose() {
+    newPasswordController.dispose();
+    confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: FunTopAppBar(
+        title: context.l10n.passwordResetTitle,
+        showBackButton: true,
+        onBackPressed: () => context.pop(),
+      ),
+      body: BaseStateConsumer(
+        cubit: _cubit,
+        onInitial: (context) {
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Form(
+              key: formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SizedBox(height: 24),
+                  TitleMediumText(
+                    context.l10n.passwordResetTitle,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  BodyMediumText(
+                    context.l10n.passwordResetDescription,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 32),
+                  OutlinedTextFormField(
+                    controller: newPasswordController,
+                    obscureText: _obscureNewPassword,
+                    onChanged: (value) {
+                      setState(() {
+                        formKey.currentState!.validate();
+                      });
+                    },
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return context.l10n.passwordRequired;
+                      }
+                      if (value.length < 6) {
+                        return context.l10n.passwordTooShort;
+                      }
+                      return null;
+                    },
+                    hintText: context.l10n.newPassword,
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        _obscureNewPassword
+                            ? FontAwesomeIcons.eye
+                            : FontAwesomeIcons.eyeSlash,
+                      ),
+                      onPressed: () {
+                        setState(() {
+                          _obscureNewPassword = !_obscureNewPassword;
+                        });
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  OutlinedTextFormField(
+                    controller: confirmPasswordController,
+                    obscureText: _obscureConfirmPassword,
+                    onChanged: (value) {
+                      setState(() {
+                        formKey.currentState!.validate();
+                      });
+                    },
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return context.l10n.passwordRequired;
+                      }
+                      if (value != newPasswordController.text) {
+                        return context.l10n.passwordsDoNotMatch;
+                      }
+                      return null;
+                    },
+                    hintText: context.l10n.confirmNewPassword,
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        _obscureConfirmPassword
+                            ? FontAwesomeIcons.eye
+                            : FontAwesomeIcons.eyeSlash,
+                      ),
+                      onPressed: () {
+                        setState(() {
+                          _obscureConfirmPassword = !_obscureConfirmPassword;
+                        });
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+                  FunButton(
+                    onTap: () {
+                      if (formKey.currentState!.validate()) {
+                        _cubit.changePassword(
+                          userID: widget.email,
+                          passwordToken: widget.code,
+                          newPassword: newPasswordController.text,
+                        );
+                      }
+                    },
+                    text: context.l10n.changePassword,
+                    analyticsEvent: AmplitudeEvents.changePasswordClicked.toEvent(),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+        onLoading: (context) {
+          return const Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                CustomCircularProgressIndicator(),
+                SizedBox(height: 16),
+                BodyMediumText(
+                  "We're processing your password change",
+                ),
+              ],
+            ),
+          );
+        },
+        onData: (context, data) {
+          return Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  primaryCircleWithIcon(
+                    circleSize: 140,
+                    iconData: FontAwesomeIcons.check,
+                    iconSize: 48,
+                  ),
+                  const SizedBox(height: 24),
+                  BodyMediumText(
+                    context.l10n.passwordChangedSuccessfully,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 32),
+                  if (!widget.isApp) ...[
+                    FunButton(
+                      text: context.l10n.goToDashboard,
+                      analyticsEvent: AmplitudeEvents.okClicked.toEvent(),
+                      onTap: () {
+                        // Navigate to dashboard
+                        context.go('/');
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                  ],
+                  FunButton(
+                    text: context.l10n.buttonDone,
+                    analyticsEvent: AmplitudeEvents.okClicked.toEvent(),
+                    onTap: () {
+                      if (widget.isApp) {
+                        // For app users, just close the page
+                        context.pop();
+                      } else {
+                        // For web users, go to dashboard
+                        context.go('/');
+                      }
+                    },
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+        onError: (context, message) {
+          return Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  errorCircleWithIcon(
+                    circleSize: 140,
+                    iconData: FontAwesomeIcons.triangleExclamation,
+                    iconSize: 48,
+                  ),
+                  const SizedBox(height: 24),
+                  BodyMediumText(
+                    context.l10n.somethingWentWrong,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 32),
+                  FunButton(
+                    text: 'Ok',
+                    analyticsEvent: AmplitudeEvents.okClicked.toEvent(),
+                    onTap: () {
+                      context.pop();
+                    },
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/family/features/reset_password/repositories/change_password_repository.dart
+++ b/lib/features/family/features/reset_password/repositories/change_password_repository.dart
@@ -1,0 +1,30 @@
+import 'package:givt_app/features/family/network/family_api_service.dart';
+
+mixin ChangePasswordRepository {
+  Future<bool> changePassword({
+    required String userID,
+    required String passwordToken,
+    required String newPassword,
+  });
+}
+
+class ChangePasswordRepositoryImpl with ChangePasswordRepository {
+  ChangePasswordRepositoryImpl(
+    this._apiService,
+  );
+
+  final FamilyAPIService _apiService;
+
+  @override
+  Future<bool> changePassword({
+    required String userID,
+    required String passwordToken,
+    required String newPassword,
+  }) {
+    return _apiService.changePassword(
+      userID: userID,
+      passwordToken: passwordToken,
+      newPassword: newPassword,
+    );
+  }
+}

--- a/lib/features/family/network/family_api_service.dart
+++ b/lib/features/family/network/family_api_service.dart
@@ -473,6 +473,30 @@ class FamilyAPIService {
     return response.statusCode == 200;
   }
 
+  Future<bool> changePassword({
+    required String userID,
+    required String passwordToken,
+    required String newPassword,
+  }) async {
+    final url = Uri.https(_apiURL, '/api/Users/ResetPassword');
+    final response = await client.post(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({
+        'userID': userID,
+        'passwordToken': passwordToken,
+        'newPassword': newPassword,
+      }),
+    );
+
+    if (response.statusCode >= 400) {
+      throw Exception(response.statusCode);
+    }
+    return response.statusCode == 200;
+  }
+
   Future<Map<String, dynamic>> updateGame(
       String gameGuid, Map<String, dynamic> body) async {
     final url = Uri.https(_apiURL, '/givtservice/v1/game/$gameGuid');

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -193,6 +193,41 @@
     "description": "Titeltekst op de vergeet wachtwoord pagina",
     "type": "text"
   },
+  "newPassword": "Neues Passwort",
+  "@newPassword": {
+    "description": "Label für neues Passwort Eingabefeld",
+    "type": "text"
+  },
+  "confirmNewPassword": "Neues Passwort bestätigen",
+  "@confirmNewPassword": {
+    "description": "Label für neues Passwort bestätigen Eingabefeld",
+    "type": "text"
+  },
+  "passwordChangedSuccessfully": "Dein Passwort wurde erfolgreich geändert!",
+  "@passwordChangedSuccessfully": {
+    "description": "Erfolgsmeldung wenn Passwort geändert wurde",
+    "type": "text"
+  },
+  "goToDashboard": "Zum Dashboard gehen",
+  "@goToDashboard": {
+    "description": "Button Text um zum Dashboard zu gehen",
+    "type": "text"
+  },
+  "passwordResetTitle": "Passwort Zurücksetzen",
+  "@passwordResetTitle": {
+    "description": "Titel für Passwort Reset Seite",
+    "type": "text"
+  },
+  "passwordResetDescription": "Gib unten dein neues Passwort ein, um den Passwort-Reset-Prozess abzuschließen.",
+  "@passwordResetDescription": {
+    "description": "Beschreibungstext für Passwort Reset Seite",
+    "type": "text"
+  },
+  "passwordsDoNotMatch": "Passwörter stimmen nicht überein",
+  "@passwordsDoNotMatch": {
+    "description": "Fehlermeldung wenn Passwörter nicht übereinstimmen",
+    "type": "text"
+  },
   "give": "Spende",
   "@give": {
     "description": "\"Geven\" op de Geef pagina waar je je bedrag kiest",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -193,6 +193,41 @@
     "description": "Titeltekst op de vergeet wachtwoord pagina",
     "type": "text"
   },
+  "newPassword": "New password",
+  "@newPassword": {
+    "description": "Label for new password input field",
+    "type": "text"
+  },
+  "confirmNewPassword": "Confirm new password",
+  "@confirmNewPassword": {
+    "description": "Label for confirm new password input field",
+    "type": "text"
+  },
+  "passwordChangedSuccessfully": "Your password has been changed successfully!",
+  "@passwordChangedSuccessfully": {
+    "description": "Success message when password is changed",
+    "type": "text"
+  },
+  "goToDashboard": "Go to Dashboard",
+  "@goToDashboard": {
+    "description": "Button text to go to dashboard",
+    "type": "text"
+  },
+  "passwordResetTitle": "Reset Password",
+  "@passwordResetTitle": {
+    "description": "Title for password reset page",
+    "type": "text"
+  },
+  "passwordResetDescription": "Enter your new password below to complete the password reset process.",
+  "@passwordResetDescription": {
+    "description": "Description text for password reset page",
+    "type": "text"
+  },
+  "passwordsDoNotMatch": "Passwords do not match",
+  "@passwordsDoNotMatch": {
+    "description": "Error message when passwords don't match",
+    "type": "text"
+  },
   "give": "Give",
   "@give": {
     "description": "\"Geven\" op de Geef pagina waar je je bedrag kiest",

--- a/lib/l10n/arb/app_en_US.arb
+++ b/lib/l10n/arb/app_en_US.arb
@@ -193,6 +193,41 @@
     "description": "Titeltekst op de vergeet wachtwoord pagina",
     "type": "text"
   },
+  "newPassword": "New password",
+  "@newPassword": {
+    "description": "Label for new password input field",
+    "type": "text"
+  },
+  "confirmNewPassword": "Confirm new password",
+  "@confirmNewPassword": {
+    "description": "Label for confirm new password input field",
+    "type": "text"
+  },
+  "passwordChangedSuccessfully": "Your password has been changed successfully!",
+  "@passwordChangedSuccessfully": {
+    "description": "Success message when password is changed",
+    "type": "text"
+  },
+  "goToDashboard": "Go to Dashboard",
+  "@goToDashboard": {
+    "description": "Button text to go to dashboard",
+    "type": "text"
+  },
+  "passwordResetTitle": "Reset Password",
+  "@passwordResetTitle": {
+    "description": "Title for password reset page",
+    "type": "text"
+  },
+  "passwordResetDescription": "Enter your new password below to complete the password reset process.",
+  "@passwordResetDescription": {
+    "description": "Description text for password reset page",
+    "type": "text"
+  },
+  "passwordsDoNotMatch": "Passwords do not match",
+  "@passwordsDoNotMatch": {
+    "description": "Error message when passwords don't match",
+    "type": "text"
+  },
   "give": "Give",
   "@give": {
     "description": "\"Geven\" op de Geef pagina waar je je bedrag kiest",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -193,6 +193,41 @@
     "description": "Titeltekst op de vergeet wachtwoord pagina",
     "type": "text"
   },
+  "newPassword": "Nueva contraseña",
+  "@newPassword": {
+    "description": "Etiqueta para campo de nueva contraseña",
+    "type": "text"
+  },
+  "confirmNewPassword": "Confirmar nueva contraseña",
+  "@confirmNewPassword": {
+    "description": "Etiqueta para campo de confirmar nueva contraseña",
+    "type": "text"
+  },
+  "passwordChangedSuccessfully": "¡Tu contraseña ha sido cambiada exitosamente!",
+  "@passwordChangedSuccessfully": {
+    "description": "Mensaje de éxito cuando la contraseña es cambiada",
+    "type": "text"
+  },
+  "goToDashboard": "Ir al Dashboard",
+  "@goToDashboard": {
+    "description": "Texto del botón para ir al dashboard",
+    "type": "text"
+  },
+  "passwordResetTitle": "Restablecer Contraseña",
+  "@passwordResetTitle": {
+    "description": "Título para página de restablecimiento de contraseña",
+    "type": "text"
+  },
+  "passwordResetDescription": "Ingresa tu nueva contraseña a continuación para completar el proceso de restablecimiento de contraseña.",
+  "@passwordResetDescription": {
+    "description": "Texto de descripción para página de restablecimiento de contraseña",
+    "type": "text"
+  },
+  "passwordsDoNotMatch": "Las contraseñas no coinciden",
+  "@passwordsDoNotMatch": {
+    "description": "Mensaje de error cuando las contraseñas no coinciden",
+    "type": "text"
+  },
   "give": "Give",
   "@give": {
     "description": "\"Geven\" op de Geef pagina waar je je bedrag kiest",

--- a/lib/l10n/arb/app_es_419.arb
+++ b/lib/l10n/arb/app_es_419.arb
@@ -193,6 +193,41 @@
     "description": "Titeltekst op de vergeet wachtwoord pagina",
     "type": "text"
   },
+  "newPassword": "Nueva contraseña",
+  "@newPassword": {
+    "description": "Etiqueta para campo de nueva contraseña",
+    "type": "text"
+  },
+  "confirmNewPassword": "Confirmar nueva contraseña",
+  "@confirmNewPassword": {
+    "description": "Etiqueta para campo de confirmar nueva contraseña",
+    "type": "text"
+  },
+  "passwordChangedSuccessfully": "¡Tu contraseña ha sido cambiada exitosamente!",
+  "@passwordChangedSuccessfully": {
+    "description": "Mensaje de éxito cuando la contraseña es cambiada",
+    "type": "text"
+  },
+  "goToDashboard": "Ir al Dashboard",
+  "@goToDashboard": {
+    "description": "Texto del botón para ir al dashboard",
+    "type": "text"
+  },
+  "passwordResetTitle": "Restablecer Contraseña",
+  "@passwordResetTitle": {
+    "description": "Título para página de restablecimiento de contraseña",
+    "type": "text"
+  },
+  "passwordResetDescription": "Ingresa tu nueva contraseña a continuación para completar el proceso de restablecimiento de contraseña.",
+  "@passwordResetDescription": {
+    "description": "Texto de descripción para página de restablecimiento de contraseña",
+    "type": "text"
+  },
+  "passwordsDoNotMatch": "Las contraseñas no coinciden",
+  "@passwordsDoNotMatch": {
+    "description": "Mensaje de error cuando las contraseñas no coinciden",
+    "type": "text"
+  },
   "give": "Donar",
   "@give": {
     "description": "\"Geven\" op de Geef pagina waar je je bedrag kiest",

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -193,6 +193,41 @@
     "description": "Titeltekst op de vergeet wachtwoord pagina",
     "type": "text"
   },
+  "newPassword": "Nieuw wachtwoord",
+  "@newPassword": {
+    "description": "Label voor nieuw wachtwoord invoerveld",
+    "type": "text"
+  },
+  "confirmNewPassword": "Bevestig nieuw wachtwoord",
+  "@confirmNewPassword": {
+    "description": "Label voor bevestig nieuw wachtwoord invoerveld",
+    "type": "text"
+  },
+  "passwordChangedSuccessfully": "Je wachtwoord is succesvol gewijzigd!",
+  "@passwordChangedSuccessfully": {
+    "description": "Succesbericht wanneer wachtwoord is gewijzigd",
+    "type": "text"
+  },
+  "goToDashboard": "Ga naar Dashboard",
+  "@goToDashboard": {
+    "description": "Knop tekst om naar dashboard te gaan",
+    "type": "text"
+  },
+  "passwordResetTitle": "Wachtwoord Resetten",
+  "@passwordResetTitle": {
+    "description": "Titel voor wachtwoord reset pagina",
+    "type": "text"
+  },
+  "passwordResetDescription": "Voer hieronder je nieuwe wachtwoord in om het wachtwoord reset proces te voltooien.",
+  "@passwordResetDescription": {
+    "description": "Beschrijving tekst voor wachtwoord reset pagina",
+    "type": "text"
+  },
+  "passwordsDoNotMatch": "Wachtwoorden komen niet overeen",
+  "@passwordsDoNotMatch": {
+    "description": "Foutmelding wanneer wachtwoorden niet overeenkomen",
+    "type": "text"
+  },
   "give": "Geven",
   "@give": {
     "description": "\"Geven\" op de Geef pagina waar je je bedrag kiest",


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement a dedicated `/changepassword` page to allow app users to reset their password, addressing a bug introduced by a dashboard update.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous password reset flow redirected users to the new dashboard, which lacked the password reset option for app users. This PR introduces a standalone page, accessible via a URL with `code`, `email`, and `app` parameters, to facilitate password changes directly. It ensures app users are not redirected to the dashboard after a successful change, while web users have the option.

---
Linear Issue: [COR-981](https://linear.app/givt/issue/COR-981/users-cant-reset-password-anymore)

<a href="https://cursor.com/background-agent?bcId=bc-12253d67-772f-4fea-bba4-7c4d6e909604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-12253d67-772f-4fea-bba4-7c4d6e909604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

