### PR TITLE
COR-80 Fix amount presets first-time enable save

### DIFF
--- a/lib/features/amount_presets/pages/change_amount_presets_bottom_sheet.dart
+++ b/lib/features/amount_presets/pages/change_amount_presets_bottom_sheet.dart
@@ -335,6 +335,7 @@ class _ChangeAmountPresetsBottomSheetState
     final presets = auth.state.presets;
     auth.updatePresets(
       presets: presets.copyWith(
+        isEnabled: _useAmountPresets,
         presets: presets.presets.map((preset) {
           switch (preset.id) {
             case 1:

--- a/lib/features/give/pages/for_you_organisation_confirm_page.dart
+++ b/lib/features/give/pages/for_you_organisation_confirm_page.dart
@@ -6,7 +6,6 @@ import 'package:givt_app/core/enums/analytics_event_name.dart';
 import 'package:givt_app/core/enums/collect_group_type.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/features/family/shared/design/illustrations/fun_icon_givy.dart';
-import 'package:givt_app/features/family/shared/design/theme/fun_theme.dart';
 import 'package:givt_app/features/family/shared/widgets/buttons/givt_back_button_flat.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/texts.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/title_large_text.dart';


### PR DESCRIPTION
## Summary
- Fixes first-time amount preset setup where saving updated preset values did not persist the newly-toggled enabled state.

## Test plan
- `flutter analyze --no-fatal-infos`
- `flutter test`

Linear: COR-80

Made with [Cursor](https://cursor.com)