### PR TITLE
ENG-471 Other category for organisation list and For You

### DIFF
--- a/lib/core/enums/collect_group_type.dart
+++ b/lib/core/enums/collect_group_type.dart
@@ -14,7 +14,7 @@ enum CollectGroupType {
     color: AppTheme.givtOrange,
   ),
   artists(
-    iconData: FontAwesomeIcons.guitar,
+    iconData: FontAwesomeIcons.layerGroup,
     color: AppTheme.givtDarkGreen,
   ),
   charities(
@@ -65,7 +65,7 @@ enum CollectGroupType {
   }
 
   /// Order for organisation search filter chips: Church, Charity, Campaign,
-  /// Others ([artists]). Types outside this list are sorted after, by index.
+  /// Other (enum value artists, UI label "Other"). Non-core types collapse here.
   static int compareForOrganisationFilterBar(
     CollectGroupType a,
     CollectGroupType b,
@@ -114,7 +114,7 @@ enum CollectGroupType {
       case CollectGroupType.campaign:
         return FontAwesomeIcons.bullhorn;
       case CollectGroupType.artists:
-        return FontAwesomeIcons.guitar;
+        return FontAwesomeIcons.layerGroup;
       case CollectGroupType.unknown:
       case CollectGroupType.demo:
       case CollectGroupType.debug:
@@ -140,7 +140,8 @@ enum CollectGroupType {
           iconColor: ColorCombo.highlight.textColor,
         );
       case CollectGroupType.artists:
-        return FunIcon.guitar(
+        return FunIcon(
+          iconData: FontAwesomeIcons.layerGroup,
           circleColor: ColorCombo.secondary.backgroundColor,
           iconColor: ColorCombo.secondary.textColor,
         );

--- a/lib/features/family/shared/design/components/content/fun_organisation_filter_tile_bar.dart
+++ b/lib/features/family/shared/design/components/content/fun_organisation_filter_tile_bar.dart
@@ -23,8 +23,17 @@ class FunOrganisationFilterTilesBar extends StatelessWidget {
     return BlocBuilder<OrganisationBloc, OrganisationState>(
       bloc: effectiveBloc,
       builder: (context, state) {
-        final types = state.organisations.map((e) => e.type).toSet().toList()
-          ..removeWhere((item) => removedTypes.contains(item.name))
+        final rawTypes = state.organisations.map((e) => e.type).toSet().toList()
+          ..removeWhere((item) => removedTypes.contains(item.name));
+        final collapsed = <CollectGroupType>{};
+        for (final t in rawTypes) {
+          if (_isCoreOrganisationFilterChipType(t)) {
+            collapsed.add(t);
+          } else {
+            collapsed.add(CollectGroupType.artists);
+          }
+        }
+        final types = collapsed.toList()
           ..sort(CollectGroupType.compareForOrganisationFilterBar);
         if (state.status == OrganisationStatus.loading) {
           return const Center(child: CircularProgressIndicator());
@@ -58,4 +67,10 @@ class FunOrganisationFilterTilesBar extends StatelessWidget {
       },
     );
   }
+}
+
+bool _isCoreOrganisationFilterChipType(CollectGroupType type) {
+  return type == CollectGroupType.church ||
+      type == CollectGroupType.charities ||
+      type == CollectGroupType.campaign;
 }

--- a/lib/features/family/shared/widgets/buttons/tiles/filter_tile.dart
+++ b/lib/features/family/shared/widgets/buttons/tiles/filter_tile.dart
@@ -55,6 +55,7 @@ String _localizedFilterTitle(BuildContext context, CollectGroupType type) {
     case CollectGroupType.unknown:
     case CollectGroupType.demo:
     case CollectGroupType.debug:
+      return locals.other;
     case CollectGroupType.none:
       return type.name[0].toUpperCase() + type.name.substring(1);
   }

--- a/lib/features/give/pages/for_you_giving_page.dart
+++ b/lib/features/give/pages/for_you_giving_page.dart
@@ -704,7 +704,7 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
       case CollectGroupType.artists:
         return 1;
       default:
-        return 3;
+        return 1;
     }
   }
 

--- a/lib/features/give/pages/for_you_list_page.dart
+++ b/lib/features/give/pages/for_you_list_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app/app/routes/routes.dart';
 import 'package:givt_app/core/enums/analytics_event_name.dart';
-import 'package:givt_app/core/enums/collect_group_type.dart';
 import 'package:givt_app/features/family/features/parent_giving_flow/presentation/widgets/organisation_list_family_content.dart';
 import 'package:givt_app/features/family/shared/design/components/components.dart';
 import 'package:givt_app/features/family/shared/widgets/buttons/givt_back_button_flat.dart';
@@ -50,7 +49,7 @@ class _ForYouListPageState extends State<ForYouListPage> {
                     _selectedOrganisation = collectGroup;
                   });
                 },
-                removedCollectGroupTypes: const [CollectGroupType.artists],
+                removedCollectGroupTypes: const [],
                 showFavorites: true,
                 autoFocusSearch: true,
                 allowSelection: !_isFavoritesOnlyMode,

--- a/lib/features/give/pages/organization_list_page.dart
+++ b/lib/features/give/pages/organization_list_page.dart
@@ -312,7 +312,7 @@ class _OrganizationListPageState extends State<OrganizationListPage> {
       case CollectGroupType.campaign:
         title = locals.campaign;
       case CollectGroupType.artists:
-        title = locals.artist;
+        title = locals.other;
       default:
         break;
     }
@@ -416,9 +416,8 @@ class _OrganizationListPageState extends State<OrganizationListPage> {
         ),
       ),
       FilterSuggestionCard(
-        visible: Platform.isIOS,
         isFocused: bloc.state.selectedType == CollectGroupType.artists.index,
-        title: locals.artist,
+        title: locals.other,
         iconData: CollectGroupType.artists.iconData,
         color: CollectGroupType.artists.color,
         onTap: () => bloc.add(

--- a/lib/features/give/widgets/for_you.dart
+++ b/lib/features/give/widgets/for_you.dart
@@ -366,9 +366,9 @@ class _ForYouState extends State<ForYou>
     if (allocationsCount == 0) {
       if (organisation.type == CollectGroupType.church) {
         allocationsCount = 3;
-      } else if (organisation.type == CollectGroupType.charities ||
-          organisation.type == CollectGroupType.campaign ||
-          organisation.type == CollectGroupType.artists) {
+      } else {
+        // Charity, campaign, and all other organisation types (incl. legacy
+        // "artists" and uncategorized).
         allocationsCount = 1;
       }
     }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -714,6 +714,7 @@
   "faqAntwoordDdi": "NO! You sign a direct debit so we can deduct the donations you have made using the Givt app. The deductions we make are incidental, user-driven deductions.\n \n\n We will not debit your account unless you make a donation using the Givt app.",
   "charity": "Charity",
   "artist": "Künstler",
+  "other": "Sonstiges",
   "church": "Kirche",
   "campaign": "Kampagne",
   "giveToNearestBeacon": "Spende an: {value0}",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -714,6 +714,7 @@
   "faqAntwoordDdi": "NO! You sign a direct debit so we can deduct the donations you have made using the Givt app. The deductions we make are incidental, user-driven deductions.\n \n\n We will not debit your account unless you make a donation using the Givt app.",
   "charity": "Charity",
   "artist": "Artist",
+  "other": "Other",
   "church": "Church",
   "campaign": "Campaign",
   "giveToNearestBeacon": "Give to: {value0}",

--- a/lib/l10n/arb/app_en_US.arb
+++ b/lib/l10n/arb/app_en_US.arb
@@ -714,6 +714,7 @@
   "faqAntwoordDdi": "NO! You sign a direct debit so we can deduct the donations you have made using the Givt app. The deductions we make are incidental, user-driven deductions.\n \n\n We will not debit your account unless you make a donation using the Givt app.",
   "charity": "Non-profit",
   "artist": "Artist",
+  "other": "Other",
   "church": "Church",
   "campaign": "Campaign",
   "giveToNearestBeacon": "Give to: {value0}",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -714,6 +714,7 @@
   "faqAntwoordDdi": "NO! You sign a direct debit so we can deduct the donations you have made using the Givt app. The deductions we make are incidental, user-driven deductions.\n \n\n We will not debit your account unless you make a donation using the Givt app.",
   "charity": "Charity",
   "artist": "Artist",
+  "other": "Otros",
   "church": "Church",
   "campaign": "Campaign",
   "giveToNearestBeacon": "Give to: {value0}",

--- a/lib/l10n/arb/app_es_419.arb
+++ b/lib/l10n/arb/app_es_419.arb
@@ -714,6 +714,7 @@
   "faqAntwoordDdi": "NO! You sign a direct debit so we can deduct the donations you have made using the Givt app. The deductions we make are incidental, user-driven deductions.\n \n\n We will not debit your account unless you make a donation using the Givt app.",
   "charity": "Organización benéfica",
   "artist": "Artista",
+  "other": "Otros",
   "church": "Iglesia",
   "campaign": "Campaña",
   "giveToNearestBeacon": "Donar a: {value0}",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -1799,6 +1799,12 @@ abstract class AppLocalizations {
   /// **'Artist'**
   String get artist;
 
+  /// No description provided for @other.
+  ///
+  /// In en, this message translates to:
+  /// **'Other'**
+  String get other;
+
   /// No description provided for @church.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -984,6 +984,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get artist => 'Künstler';
 
   @override
+  String get other => 'Sonstiges';
+
+  @override
   String get church => 'Kirche';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -976,6 +976,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get artist => 'Artist';
 
   @override
+  String get other => 'Other';
+
+  @override
   String get church => 'Church';
 
   @override
@@ -3763,6 +3766,9 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
 
   @override
   String get artist => 'Artist';
+
+  @override
+  String get other => 'Other';
 
   @override
   String get church => 'Church';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -976,6 +976,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get artist => 'Artist';
 
   @override
+  String get other => 'Otros';
+
+  @override
   String get church => 'Church';
 
   @override
@@ -3776,6 +3779,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get artist => 'Artista';
+
+  @override
+  String get other => 'Otros';
 
   @override
   String get church => 'Iglesia';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -980,6 +980,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get artist => 'Artiest';
 
   @override
+  String get other => 'Overig';
+
+  @override
   String get church => 'Kerk';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -714,6 +714,7 @@
   "faqAntwoordDdi": "NO! You sign a direct debit so we can deduct the donations you have made using the Givt app. The deductions we make are incidental, user-driven deductions.\n \n\n We will not debit your account unless you make a donation using the Givt app.",
   "charity": "Goed doel",
   "artist": "Artiest",
+  "other": "Overig",
   "church": "Kerk",
   "campaign": "Actie",
   "giveToNearestBeacon": "Geef aan: {value0}",

--- a/lib/shared/bloc/organisation/organisation_bloc.dart
+++ b/lib/shared/bloc/organisation/organisation_bloc.dart
@@ -320,9 +320,10 @@ class OrganisationBloc extends Bloc<OrganisationEvent, OrganisationState> {
       // Filter organizations by type first if there's a selected type
       final typeFilteredOrgs = state.organisations
           .where(
-            (org) =>
-                state.selectedType == CollectGroupType.none.index ||
-                org.type.index == state.selectedType,
+            (org) => _collectGroupMatchesSelectedFilter(
+              org,
+              state.selectedType,
+            ),
           )
           .toList();
 
@@ -592,7 +593,9 @@ class OrganisationBloc extends Bloc<OrganisationEvent, OrganisationState> {
     var orgs = state.organisations;
     if (newSelectedType != CollectGroupType.none.index) {
       orgs = state.organisations
-          .where((org) => org.type.index == newSelectedType)
+          .where(
+            (org) => _collectGroupMatchesSelectedFilter(org, newSelectedType),
+          )
           .toList();
     }
 
@@ -705,4 +708,22 @@ class OrganisationBloc extends Bloc<OrganisationEvent, OrganisationState> {
     await _favoritesChangedSubscription.cancel();
     return super.close();
   }
+}
+
+/// Church, charity, and campaign use their own filter chips. The artists enum
+/// index is the UI "Other" bucket for every other collect group type.
+bool _isCoreOrganisationFilterType(CollectGroupType type) {
+  return type == CollectGroupType.church ||
+      type == CollectGroupType.charities ||
+      type == CollectGroupType.campaign;
+}
+
+bool _collectGroupMatchesSelectedFilter(CollectGroup group, int selectedType) {
+  if (selectedType == CollectGroupType.none.index) {
+    return true;
+  }
+  if (selectedType == CollectGroupType.artists.index) {
+    return !_isCoreOrganisationFilterType(group.type);
+  }
+  return group.type.index == selectedType;
 }


### PR DESCRIPTION
## Summary
Implements frontend-only **Other** category (replacing user-visible **Artist**): enum value `CollectGroupType.artists` remains for API/index compatibility, but UI copy uses `other` l10n, generic icon, and filtering treats **Other** as every organisation that is not Church, Charity, or Campaign.

## Linear
- https://linear.app/givt/issue/ENG-471/make-other-category-available-in-list-selection

## Changes
- **OrganisationBloc**: When filter type is `artists` index, include all non-core types in the list/search.
- **FunOrganisationFilterTilesBar**: Collapse unknown/demo/etc. into one **Other** chip.
- **Filter tile / legacy org list**: Label **Other**; fourth filter visible on Android.
- **For You list**: Stop hiding former artists bucket so those orgs appear in the FUN list flow.
- **l10n**: New `other` string (all ARB locales).

## Verification (automated)
```bash
flutter gen-l10n
flutter analyze   # repo has existing info-level findings
flutter test --test-randomize-ordering-seed random
```

## Reviewer checklist
- Confirm **Other** chip and legacy filter show on Android and match iOS.
- Spot-check that selecting **Other** lists non–church/charity/campaign orgs (e.g. music/legacy artist types).
- Church / Charity / Campaign filters unchanged for core types.


Made with [Cursor](https://cursor.com)