### PR TITLE
ENG-555 Default for_you_new_giving_flow to true when flag cannot be evaluated

### DIFF
--- a/lib/features/give/pages/home_page.dart
+++ b/lib/features/give/pages/home_page.dart
@@ -107,12 +107,17 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
     try {
       isEnabled = await (() async {
         await AnalyticsHelper.ensureInitialized();
-        return AnalyticsHelper.isFeatureEnabled(_forYouStartupFlagKey);
+        return AnalyticsHelper.isFeatureEnabled(
+          _forYouStartupFlagKey,
+          fallback: true,
+        );
       })().timeout(const Duration(seconds: 1));
     } on TimeoutException {
-      return;
-    } catch (_) {
-      return;
+      // Phased rollout: if the flag cannot be evaluated in time, default to
+      // the new giving flow (same as ENG-555 PostHog fallback).
+      isEnabled = true;
+    } on Object {
+      isEnabled = true;
     }
     if (!mounted || !isEnabled) {
       return;

--- a/lib/utils/analytics_helper.dart
+++ b/lib/utils/analytics_helper.dart
@@ -77,15 +77,23 @@ class AnalyticsHelper {
     await _initCompleter?.future;
   }
 
-  static Future<bool> isFeatureEnabled(String key) async {
+  /// Checks whether [key] is enabled in PostHog.
+  ///
+  /// When PostHog is not ready yet or evaluating the flag fails, returns
+  /// [fallback]. Defaults to false so existing call sites keep backward
+  /// compatibility.
+  static Future<bool> isFeatureEnabled(
+    String key, {
+    bool fallback = false,
+  }) async {
     if (!_isInitialized) {
-      return false;
+      return fallback;
     }
     try {
       return await Posthog().isFeatureEnabled(key);
     } catch (_) {
       // Feature flag checks should never crash the app.
-      return false;
+      return fallback;
     }
   }
 


### PR DESCRIPTION
## Summary
- Add optional `fallback` to `AnalyticsHelper.isFeatureEnabled` (defaults to `false`).
- For `for_you_new_giving_flow` on the home tab startup path, pass `fallback: true`, and when the check times out or throws, treat the flag as enabled so the new giving tab is preferred when PostHog cannot be evaluated promptly.

Links: [ENG-555](https://linear.app/givt/issue/ENG-555/set-fallback-to-true-for-for-you-new-giving-flow-feature-flag)

## Verification (automated)
- `dart analyze lib/utils/analytics_helper.dart lib/features/give/pages/home_page.dart`
- `flutter test --coverage --test-randomize-ordering-seed random`

## What to review
- Confirm the home “For you” startup override matches the phased rollout: offline / slow / failed PostHog should behave like rollout default `true`; QR/deep-link entry is still unchanged.


Made with [Cursor](https://cursor.com)