### PR TITLE
ENG-537 Certificate pinning auto-refresh and retry

### DIFF
--- a/lib/core/network/certificate_check_interceptor.dart
+++ b/lib/core/network/certificate_check_interceptor.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:givt_app/app/injection/injection.dart';
 import 'package:givt_app/core/failures/failures.dart';
 import 'package:givt_app/core/logging/logging_service.dart';
@@ -22,22 +23,39 @@ class CertificateCheckInterceptor extends InterceptorContract {
       return request;
     }
 
+    final host = request.url.host;
     final storedSHAFigerprint =
         getIt<SharedPreferences>().getString(apiURL) ?? '';
 
-    final secure = await HttpCertificatePinning.check(
-      serverURL: request.url.toString(),
-      sha: SHA.SHA256,
-      allowedSHAFingerprints: [storedSHAFigerprint],
-      timeout: 50,
-    );
-    if (!secure.contains('CONNECTION_SECURE')) {
-      LoggingInfo.instance.error(
-        request.url.toString(),
-        methodName: StackTrace.current.toString(),
+    try {
+      final secure = await HttpCertificatePinning.check(
+        serverURL: request.url.toString(),
+        sha: SHA.SHA256,
+        allowedSHAFingerprints: [storedSHAFigerprint],
+        timeout: 50,
       );
+      if (!secure.contains('CONNECTION_SECURE')) {
+        LoggingInfo.instance.error(
+          'Certificate pinning check failed: host=$host '
+          'requestUrl=${request.url} pluginResult=$secure '
+          'storedFingerprintLength=${storedSHAFigerprint.length} '
+          'sharedPrefsKeyHost=$apiURL',
+          methodName: StackTrace.current.toString(),
+        );
 
-      throw const CertificatesException(message: 'CONNECTION_NOT_SECURE');
+        throw const CertificatesException(message: 'CONNECTION_NOT_SECURE');
+      }
+    } on PlatformException catch (e, s) {
+      LoggingInfo.instance.error(
+        'Certificate pinning PlatformException: host=$host '
+        'code=${e.code} message=${e.message} '
+        'storedFingerprintLength=${storedSHAFigerprint.length}',
+        methodName: s.toString(),
+      );
+      if (e.code == 'CONNECTION_NOT_SECURE') {
+        throw const CertificatesException(message: 'CONNECTION_NOT_SECURE');
+      }
+      rethrow;
     }
     return request;
   }
@@ -45,6 +63,5 @@ class CertificateCheckInterceptor extends InterceptorContract {
   @override
   Future<BaseResponse> interceptResponse({
     required BaseResponse response,
-  }) async =>
-      response;
+  }) async => response;
 }

--- a/lib/core/network/certificate_retry_policy.dart
+++ b/lib/core/network/certificate_retry_policy.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/services.dart';
+import 'package:givt_app/core/failures/certificate_exception.dart';
+import 'package:http/http.dart';
+import 'package:http_certificate_pinning/http_certificate_pinning.dart';
+import 'package:http_interceptor/models/retry_policy.dart';
+
+/// On certificate pinning failure, invokes the refresh callback once per failed
+/// request, then delegates HTTP response retries (for example token refresh)
+/// to the wrapped token retry policy.
+class CompositeRetryCertificateWithTokenPolicy extends RetryPolicy {
+  CompositeRetryCertificateWithTokenPolicy({
+    required RetryPolicy tokenRetryPolicy,
+    required Future<void> Function() onRefreshFingerprints,
+  }) : _token = tokenRetryPolicy,
+       _onRefreshFingerprints = onRefreshFingerprints;
+
+  final RetryPolicy _token;
+  final Future<void> Function() _onRefreshFingerprints;
+
+  BaseRequest? _lastRefreshedRequest;
+
+  @override
+  int get maxRetryAttempts => _token.maxRetryAttempts + 1;
+
+  static bool isCertificateFailure(Exception reason) {
+    if (reason is CertificatesException) return true;
+    if (reason is CertificateNotVerifiedException) return true;
+    if (reason is PlatformException && reason.code == 'CONNECTION_NOT_SECURE') {
+      return true;
+    }
+    final message = reason.toString();
+    return message.contains('CONNECTION_NOT_SECURE') ||
+        message.contains('CertificateNotVerifiedException');
+  }
+
+  @override
+  Future<bool> shouldAttemptRetryOnException(
+    Exception reason,
+    BaseRequest request,
+  ) async {
+    if (!isCertificateFailure(reason)) {
+      return false;
+    }
+    if (identical(_lastRefreshedRequest, request)) {
+      return false;
+    }
+    _lastRefreshedRequest = request;
+    await _onRefreshFingerprints();
+    return true;
+  }
+
+  @override
+  Future<bool> shouldAttemptRetryOnResponse(BaseResponse response) async {
+    _lastRefreshedRequest = null;
+    return _token.shouldAttemptRetryOnResponse(response);
+  }
+
+  @override
+  Duration delayRetryAttemptOnException({required int retryAttempt}) =>
+      _token.delayRetryAttemptOnException(retryAttempt: retryAttempt);
+
+  @override
+  Duration delayRetryAttemptOnResponse({required int retryAttempt}) =>
+      _token.delayRetryAttemptOnResponse(retryAttempt: retryAttempt);
+}

--- a/lib/core/network/request_helper.dart
+++ b/lib/core/network/request_helper.dart
@@ -9,6 +9,7 @@ import 'package:givt_app/core/failures/certificate_exception.dart';
 import 'package:givt_app/core/failures/failure.dart';
 import 'package:givt_app/core/logging/logging_service.dart';
 import 'package:givt_app/core/network/certificate_check_interceptor.dart';
+import 'package:givt_app/core/network/certificate_retry_policy.dart';
 import 'package:givt_app/core/network/expired_token_retry_policy.dart';
 import 'package:givt_app/core/network/family_expired_token_retry_policy.dart';
 import 'package:givt_app/core/network/network.dart';
@@ -30,7 +31,7 @@ class RequestHelper {
     this._networkInfo,
     this._sharedPreferences, {
     required String apiURL,
-  })  : _apiURL = apiURL;
+  }) : _apiURL = apiURL;
 
   final NetworkInfo _networkInfo;
   final SharedPreferences _sharedPreferences;
@@ -44,6 +45,10 @@ class RequestHelper {
   late String euBaseUrl;
   late String usBaseUrl;
   late String country;
+
+  /// When true, [euClient] / [usClient] wrap pinned [SecureHttpClient]s whose
+  /// fingerprint lists can be updated in place via [refreshFingerprints].
+  bool _secureHttpClientsReady = false;
 
   Client get client => country == Country.us.countryCode ? usClient : euClient;
 
@@ -74,7 +79,9 @@ class RequestHelper {
       _secureUsClient = _getSecureClient(allowedUSFingerprints);
       euClient = createEUClient(client: _secureEuClient);
       usClient = createUSClient(client: _secureUsClient);
+      _secureHttpClientsReady = true;
     } catch (e, s) {
+      _secureHttpClientsReady = false;
       if (_failedDueToInternetConnectionButWeHaveInternetNow(e)) {
         LoggingInfo.instance.info(
           '''
@@ -84,15 +91,16 @@ Error while setting up secure http clients (while having an internet connection)
       } else {
         euClient = createEUClient();
         usClient = createUSClient();
-        _internetSubscription =
-            _networkInfo.hasInternetConnectionStream().listen(
-          (hasConnection) async {
-            if (hasConnection) {
-              await _createClients();
-              _internetSubscription?.cancel();
-            }
-          },
-        );
+        _internetSubscription = _networkInfo
+            .hasInternetConnectionStream()
+            .listen(
+              (hasConnection) async {
+                if (hasConnection) {
+                  await _createClients();
+                  _internetSubscription?.cancel();
+                }
+              },
+            );
       }
     }
   }
@@ -106,8 +114,9 @@ Error while setting up secure http clients (while having an internet connection)
   Future<void> _checkForAndroidTrustedCertificate() async {
     try {
       if (Platform.isAndroid) {
-        final data =
-            await PlatformAssetBundle().load('assets/ca/isrgrootx1.pem');
+        final data = await PlatformAssetBundle().load(
+          'assets/ca/isrgrootx1.pem',
+        );
         SecurityContext.defaultContext.setTrustedCertificatesBytes(
           data.buffer.asUint8List(),
         );
@@ -128,8 +137,9 @@ Error while setting up secure http clients (while having an internet connection)
     if (prefs.containsKey(UserExt.tag)) {
       final userExtString = prefs.getString(UserExt.tag);
       if (userExtString != null) {
-        final user =
-            UserExt.fromJson(jsonDecode(userExtString) as Map<String, dynamic>);
+        final user = UserExt.fromJson(
+          jsonDecode(userExtString) as Map<String, dynamic>,
+        );
         return user.country;
       }
     }
@@ -145,7 +155,10 @@ Error while setting up secure http clients (while having an internet connection)
         if (client == null) CertificateCheckInterceptor(),
         TokenInterceptor(),
       ],
-      retryPolicy: ExpiredTokenRetryPolicy(),
+      retryPolicy: CompositeRetryCertificateWithTokenPolicy(
+        tokenRetryPolicy: ExpiredTokenRetryPolicy(),
+        onRefreshFingerprints: refreshFingerprints,
+      ),
     );
   }
 
@@ -157,8 +170,28 @@ Error while setting up secure http clients (while having an internet connection)
         if (client == null) CertificateCheckInterceptor(),
         TokenInterceptor(),
       ],
-      retryPolicy: FamilyExpiredTokenRetryPolicy(),
+      retryPolicy: CompositeRetryCertificateWithTokenPolicy(
+        tokenRetryPolicy: FamilyExpiredTokenRetryPolicy(),
+        onRefreshFingerprints: refreshFingerprints,
+      ),
     );
+  }
+
+  /// Re-fetches JWT-backed fingerprints for EU and US, updates [SharedPreferences],
+  /// and refreshes in-memory pins on active [SecureHttpClient]s when available.
+  Future<void> refreshFingerprints() async {
+    await _checkForAndroidTrustedCertificate();
+    final allowedEUFingerprints = await _getAllowedFingerprints(euBaseUrl);
+    final allowedUSFingerprints = await _getAllowedFingerprints(usBaseUrl);
+
+    if (_secureHttpClientsReady) {
+      _secureEuClient.allowedSHAFingerprints
+        ..clear()
+        ..addAll(allowedEUFingerprints);
+      _secureUsClient.allowedSHAFingerprints
+        ..clear()
+        ..addAll(allowedUSFingerprints);
+    }
   }
 
   Future<List<String>> _getAllowedFingerprints(
@@ -167,8 +200,9 @@ Error while setting up secure http clients (while having an internet connection)
     try {
       final response = await _requestCerts(apiUrl);
 
-      final publicKey =
-          await rootBundle.loadString('assets/ca/certificatekey.txt');
+      final publicKey = await rootBundle.loadString(
+        'assets/ca/certificatekey.txt',
+      );
       final jwtVerified = JWT.verify(response.token, RSAPublicKey(publicKey));
 
       final allowedFingerprints = [

--- a/lib/features/auth/cubit/auth_cubit.dart
+++ b/lib/features/auth/cubit/auth_cubit.dart
@@ -6,6 +6,7 @@ import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:givt_app/core/enums/enums.dart';
 import 'package:givt_app/core/failures/failures.dart';
@@ -15,13 +16,15 @@ import 'package:givt_app/features/auth/models/models.dart';
 import 'package:givt_app/features/auth/repositories/auth_repository.dart';
 import 'package:givt_app/shared/models/models.dart';
 import 'package:givt_app/utils/utils.dart';
+import 'package:http_certificate_pinning/http_certificate_pinning.dart';
 import 'package:permission_handler/permission_handler.dart';
 part 'auth_state.dart';
 
 class AuthCubit extends Cubit<AuthState> {
   AuthCubit(this._authRepositoy) : super(const AuthState()) {
-    _sessionSubscription =
-        _authRepositoy.hasSessionStream().listen((hasSession) {
+    _sessionSubscription = _authRepositoy.hasSessionStream().listen((
+      hasSession,
+    ) {
       checkAuth(hasSession: hasSession);
     });
   }
@@ -78,7 +81,8 @@ class AuthCubit extends Cubit<AuthState> {
 
       final biometricSetting = await BiometricsHelper.getBiometricSetting();
 
-      final showBiometricCheck = biometricSetting == BiometricSetting.unknown &&
+      final showBiometricCheck =
+          biometricSetting == BiometricSetting.unknown &&
           userExt.tempUser == false;
 
       emit(
@@ -129,6 +133,17 @@ class AuthCubit extends Cubit<AuthState> {
           ),
         );
         return;
+      } else if (_isCertificateAuthFailure(e)) {
+        emit(
+          state.copyWith(
+            status: AuthStatus.certificateException,
+          ),
+        );
+        LoggingInfo.instance.error(
+          e.toString(),
+          methodName: stackTrace.toString(),
+        );
+        return;
       } else {
         LoggingInfo.instance.error(
           e.toString(),
@@ -145,15 +160,26 @@ class AuthCubit extends Cubit<AuthState> {
     }
   }
 
+  bool _isCertificateAuthFailure(Object e) {
+    if (e is CertificatesException) return true;
+    if (e is CertificateNotVerifiedException) return true;
+    if (e is PlatformException && e.code == 'CONNECTION_NOT_SECURE') {
+      return true;
+    }
+    final message = e.toString();
+    return message.contains('CONNECTION_NOT_SECURE') ||
+        message.contains('CertificateNotVerifiedException');
+  }
+
   void completeBiometricsCheck() =>
       emit(state.copyWith(status: AuthStatus.authenticated));
 
   void clearNavigation() => emit(
-        state.copyWith(
-          status: state.status,
-          navigate: AuthState._emptyNavigate,
-        ),
-      );
+    state.copyWith(
+      status: state.status,
+      navigate: AuthState._emptyNavigate,
+    ),
+  );
 
   Future<void> checkAuth({
     bool isAppStartupCheck = false,
@@ -315,8 +341,7 @@ class AuthCubit extends Cubit<AuthState> {
         );
         return;
       }
-      if (e is CertificatesException ||
-          e.toString().contains('CONNECTION_NOT_SECURE')) {
+      if (_isCertificateAuthFailure(e)) {
         emit(
           state.copyWith(
             status: AuthStatus.certificateException,
@@ -477,8 +502,10 @@ class AuthCubit extends Cubit<AuthState> {
       final notificationPermissionStatus =
           await Permission.notification.status.isGranted;
 
-      LoggingInfo.instance.info('New FCM token: $notificationId; '
-          'Notification permission status: $notificationPermissionStatus');
+      LoggingInfo.instance.info(
+        'New FCM token: $notificationId; '
+        'Notification permission status: $notificationPermissionStatus',
+      );
 
       if (userExt.notificationId == notificationId &&
           userExt.pushNotificationsEnabled == notificationPermissionStatus) {

--- a/test/core/network/certificate_retry_policy_test.dart
+++ b/test/core/network/certificate_retry_policy_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/core/failures/certificate_exception.dart';
+import 'package:givt_app/core/network/certificate_retry_policy.dart';
+import 'package:http/http.dart';
+import 'package:http_certificate_pinning/http_certificate_pinning.dart';
+import 'package:http_interceptor/models/retry_policy.dart';
+
+class _FixedTokenPolicy extends RetryPolicy {
+  @override
+  int get maxRetryAttempts => 2;
+
+  @override
+  Future<bool> shouldAttemptRetryOnResponse(BaseResponse response) async =>
+      false;
+}
+
+void main() {
+  group('CompositeRetryCertificateWithTokenPolicy', () {
+    test(
+      'refreshes fingerprints once then refuses same request instance',
+      () async {
+        var refreshCount = 0;
+        final policy = CompositeRetryCertificateWithTokenPolicy(
+          tokenRetryPolicy: _FixedTokenPolicy(),
+          onRefreshFingerprints: () async {
+            refreshCount++;
+          },
+        );
+
+        expect(policy.maxRetryAttempts, 3);
+
+        final req = Request('GET', Uri.parse('https://api.example.com/path'));
+
+        expect(
+          await policy.shouldAttemptRetryOnException(
+            const CertificatesException(message: 'CONNECTION_NOT_SECURE'),
+            req,
+          ),
+          true,
+        );
+        expect(refreshCount, 1);
+
+        expect(
+          await policy.shouldAttemptRetryOnException(
+            const CertificatesException(message: 'CONNECTION_NOT_SECURE'),
+            req,
+          ),
+          false,
+        );
+        expect(refreshCount, 1);
+      },
+    );
+
+    test('shouldAttemptRetryOnResponse resets same-request guard', () async {
+      var refreshCount = 0;
+      final policy = CompositeRetryCertificateWithTokenPolicy(
+        tokenRetryPolicy: _FixedTokenPolicy(),
+        onRefreshFingerprints: () async {
+          refreshCount++;
+        },
+      );
+      final req = Request('GET', Uri.parse('https://api.example.com/path'));
+
+      expect(
+        await policy.shouldAttemptRetryOnException(
+          const CertificatesException(message: 'CONNECTION_NOT_SECURE'),
+          req,
+        ),
+        true,
+      );
+
+      await policy.shouldAttemptRetryOnResponse(
+        Response('ok', 200, request: req),
+      );
+
+      expect(
+        await policy.shouldAttemptRetryOnException(
+          const CertificatesException(message: 'CONNECTION_NOT_SECURE'),
+          req,
+        ),
+        true,
+      );
+      expect(refreshCount, 2);
+    });
+
+    test('isCertificateFailure', () {
+      expect(
+        CompositeRetryCertificateWithTokenPolicy.isCertificateFailure(
+          const CertificatesException(message: 'CONNECTION_NOT_SECURE'),
+        ),
+        true,
+      );
+      expect(
+        CompositeRetryCertificateWithTokenPolicy.isCertificateFailure(
+          const CertificateNotVerifiedException(),
+        ),
+        true,
+      );
+      expect(
+        CompositeRetryCertificateWithTokenPolicy.isCertificateFailure(
+          const FormatException('unrelated'),
+        ),
+        false,
+      );
+    });
+
+    test('delegates token retry on response', () async {
+      var tokenChecked = false;
+      final tokenPolicy = _TokenPolicyThatAlwaysRetries(
+        onCalled: () => tokenChecked = true,
+      );
+      final policy = CompositeRetryCertificateWithTokenPolicy(
+        tokenRetryPolicy: tokenPolicy,
+        onRefreshFingerprints: () async {},
+      );
+
+      final req = Request('GET', Uri.parse('https://api.example.com/path'));
+      expect(
+        await policy.shouldAttemptRetryOnResponse(
+          Response('unauth', 401, request: req),
+        ),
+        true,
+      );
+      expect(tokenChecked, true);
+    });
+  });
+}
+
+class _TokenPolicyThatAlwaysRetries extends RetryPolicy {
+  _TokenPolicyThatAlwaysRetries({required this.onCalled});
+
+  final void Function() onCalled;
+
+  @override
+  int get maxRetryAttempts => 1;
+
+  @override
+  Future<bool> shouldAttemptRetryOnResponse(BaseResponse response) async {
+    onCalled();
+    return response.statusCode == 401;
+  }
+}


### PR DESCRIPTION
## Summary
Implements ENG-537 / COR-2360: when TLS pinning fails (stale fingerprint, `CONNECTION_NOT_SECURE`, or `CertificateNotVerifiedException`), the app refreshes JWT-backed fingerprints from the certs endpoint, updates SharedPreferences and in-memory pins on active `SecureHttpClient`s, then retries the HTTP request once. EU and US clients keep existing token refresh retry behavior via a composite retry policy. Login and registration now surface the same `AuthStatus.certificateException` path for certificate failures. Certificate check failures log host, plugin result, and stored fingerprint length; `PlatformException(CONNECTION_NOT_SECURE)` is normalized to `CertificatesException`.

Linear: https://linear.app/givt/issue/ENG-537/error-report-platformexception

## Test plan (automated)
Commands run:
- `dart format` on touched files
- `flutter analyze` (project reports many pre-existing infos; no new errors in changed code)
- `flutter test --coverage --test-randomize-ordering-seed random` (all tests passed)

**Reviewer checks:** stale-pin scenario recovers without restart where the certs endpoint is reachable; permanent MITM still fails after one refresh; EU login shows certificate error UI when pinning fails irrecoverably.

Made with [Cursor](https://cursor.com)