### PR TITLE
ENG-602 Report missing organisation in For You org search

### DIFF
--- a/lib/core/enums/analytics_event_name.dart
+++ b/lib/core/enums/analytics_event_name.dart
@@ -213,6 +213,9 @@ enum AnalyticsEventName {
   ),
   forYouFavoritesDoneTapped('for_you_favorites_done_tapped'),
   forYouOrganisationSelected('for_you_organisation_selected'),
+  forYouReportMissingOrganisationTapped(
+    'for_you_report_missing_organisation_tapped',
+  ),
   forYouOrganisationConfirmGiveTapped(
     'for_you_organisation_confirm_give_tapped',
   ),

--- a/lib/features/family/features/parent_giving_flow/presentation/widgets/organisation_list_family_content.dart
+++ b/lib/features/family/features/parent_giving_flow/presentation/widgets/organisation_list_family_content.dart
@@ -9,6 +9,7 @@ import 'package:givt_app/features/family/shared/widgets/texts/texts.dart';
 import 'package:givt_app/features/give/bloc/bloc.dart';
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/shared/models/collect_group.dart';
+import 'package:givt_app/shared/widgets/about_givt_bottom_sheet.dart';
 import 'package:givt_app/utils/utils.dart';
 
 class OrganisationListFamilyContent extends StatefulWidget {
@@ -80,6 +81,8 @@ class _OrganisationListFamilyContentState
             )
             .toList();
 
+        final showFallbackRow = state.previousSearchQuery.isNotEmpty;
+
         return Column(
           children: [
             FunOrganisationFilterTilesBar(
@@ -115,8 +118,52 @@ class _OrganisationListFamilyContentState
                     color: AppTheme.neutralVariant95,
                   ),
                   shrinkWrap: true,
-                  itemCount: visibleOrganisations.length,
+                  itemCount:
+                      visibleOrganisations.length + (showFallbackRow ? 1 : 0),
                   itemBuilder: (context, index) {
+                    if (showFallbackRow &&
+                        index == visibleOrganisations.length) {
+                      return ListTile(
+                        key: const ValueKey<String>(
+                          'organisation_list_report_missing',
+                        ),
+                        contentPadding: EdgeInsets.zero,
+                        splashColor: FunTheme.of(context).highlight99,
+                        onTap: () {
+                          AnalyticsHelper.logEvent(
+                            eventName: AnalyticsEventName
+                                .forYouReportMissingOrganisationTapped,
+                          );
+                          final metadata =
+                              state.previousSearchQuery.isNotEmpty
+                                  ? {'searchText': state.previousSearchQuery}
+                                  : null;
+                          showModalBottomSheet<void>(
+                            context: context,
+                            isScrollControlled: true,
+                            useSafeArea: true,
+                            builder: (_) => AboutGivtBottomSheet(
+                              initialMessage:
+                                  locals.reportMissingOrganisationPrefilledText,
+                              metadata: metadata,
+                            ),
+                          );
+                        },
+                        leading: Icon(
+                          Icons.report_problem_outlined,
+                          color: FunTheme.of(context).primary20,
+                        ),
+                        title: LabelMediumText(
+                          locals.reportMissingOrganisationListItem,
+                          color: AppTheme.primary20,
+                        ),
+                        trailing: Icon(
+                          Icons.chevron_right,
+                          color: FunTheme.of(context).primary20,
+                        ),
+                      );
+                    }
+
                     final organisation = visibleOrganisations[index];
                     final isFavorited = state.favoritedOrganisations.contains(
                       organisation.nameSpace,

--- a/test/features/family/features/parent_giving_flow/presentation/widgets/organisation_list_family_content_test.dart
+++ b/test/features/family/features/parent_giving_flow/presentation/widgets/organisation_list_family_content_test.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/core/enums/collect_group_type.dart';
+import 'package:givt_app/core/enums/country.dart';
+import 'package:givt_app/features/auth/models/session.dart';
+import 'package:givt_app/features/family/features/parent_giving_flow/presentation/widgets/organisation_list_family_content.dart';
+import 'package:givt_app/features/give/bloc/bloc.dart';
+import 'package:givt_app/features/give/models/organisation.dart';
+import 'package:givt_app/features/give/repositories/campaign_repository.dart';
+import 'package:givt_app/l10n/arb/app_localizations.dart';
+import 'package:givt_app/shared/models/collect_group.dart';
+import 'package:givt_app/shared/repositories/collect_group_repository.dart';
+import 'package:givt_app/utils/util.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeCollectGroupRepository with CollectGroupRepository {
+  _FakeCollectGroupRepository(this._groups);
+
+  final List<CollectGroup> _groups;
+
+  @override
+  Future<List<CollectGroup>> fetchCollectGroupList() async => _groups;
+
+  @override
+  Future<List<CollectGroup>> getCollectGroupList() async => _groups;
+}
+
+class _FakeCampaignRepository with CampaignRepository {
+  @override
+  Future<Organisation> getOrganisation(String mediumId) async =>
+      const Organisation.empty();
+
+  @override
+  Future<bool> saveLastDonation(Organisation organisation) async => true;
+
+  @override
+  Future<Organisation> getLastOrganisationDonated() async =>
+      const Organisation.empty();
+
+  @override
+  Future<Organisation> getCachedOrganisation(String mediumId) async =>
+      const Organisation.empty();
+}
+
+void main() {
+  const userGuid = 'org-list-family-content-test-guid';
+
+  const testCollectGroup = CollectGroup(
+    nameSpace: '0123456789abcd',
+    orgName: 'Test church',
+    hasCelebration: false,
+    type: CollectGroupType.church,
+  );
+
+  Future<OrganisationBloc> createBloc({
+    required SharedPreferences prefs,
+  }) async {
+    const key = '${Util.favoritedOrganisationsKey}$userGuid';
+    await prefs.setStringList(key, const []);
+    final bloc = OrganisationBloc(
+      _FakeCollectGroupRepository([testCollectGroup]),
+      _FakeCampaignRepository(),
+      prefs,
+    )..add(
+        OrganisationFetch(
+          Country.us,
+          showLastDonated: false,
+          type: CollectGroupType.none.index,
+        ),
+      );
+    await bloc.stream.firstWhere(
+      (s) => s.status == OrganisationStatus.filtered,
+    );
+    return bloc;
+  }
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({
+      Session.tag: jsonEncode({
+        'GUID': userGuid,
+        'Email': 'test@example.com',
+        'access_token': 'access',
+        'refresh_token': 'refresh',
+        '.expires': '2099-01-01T00:00:00Z',
+        'isLoggedIn': true,
+      }),
+    });
+  });
+
+  testWidgets('report missing organisation row hidden when search is empty',
+      (tester) async {
+    final prefs = await SharedPreferences.getInstance();
+    final bloc = await createBloc(prefs: prefs);
+    addTearDown(bloc.close);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: OrganisationListFamilyContent(
+            bloc: bloc,
+            onTapListItem: (_) {},
+            removedCollectGroupTypes: const [],
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final context = tester.element(find.byType(OrganisationListFamilyContent));
+    expect(
+      find.text(AppLocalizations.of(context).reportMissingOrganisationListItem),
+      findsNothing,
+    );
+  });
+
+  testWidgets(
+    'report missing organisation row shown after non-empty search',
+    (tester) async {
+      final prefs = await SharedPreferences.getInstance();
+      final bloc = await createBloc(prefs: prefs);
+      addTearDown(bloc.close);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: OrganisationListFamilyContent(
+              bloc: bloc,
+              onTapListItem: (_) {},
+              removedCollectGroupTypes: const [],
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      bloc.add(const OrganisationFilterQueryChanged('nomatch'));
+      await tester.pumpAndSettle();
+
+      final context =
+          tester.element(find.byType(OrganisationListFamilyContent));
+      expect(
+        find.text(
+          AppLocalizations.of(context).reportMissingOrganisationListItem,
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a trailing **Report a missing organisation** row to `OrganisationListFamilyContent` when `previousSearchQuery` is non-empty (new giving / For You flow), matching the legacy EU list behaviour for empty or partial search results.
- Opens `AboutGivtBottomSheet` with `reportMissingOrganisationPrefilledText` and `metadata: {'searchText': previousSearchQuery}` when applicable.
- Logs `forYouReportMissingOrganisationTapped` on tap.
- Widget tests cover visibility with empty vs non-empty search.

Linear: https://linear.app/givt/issue/ENG-602

## Test plan (automated)
Commands run:
- `flutter test test/features/family/features/parent_giving_flow/presentation/widgets/organisation_list_family_content_test.dart --test-randomize-ordering-seed random`
- `flutter test --test-randomize-ordering-seed random`
- `flutter analyze lib/features/family/features/parent_giving_flow/presentation/widgets/organisation_list_family_content.dart lib/core/enums/analytics_event_name.dart`

**Reviewer validation:** In the US For You organisation picker, type any search text; confirm the report row appears at the end of the list (including when there are no matches), opens the About/Contact sheet with prefilled copy, and submits support as before.

Made with [Cursor](https://cursor.com)