### PR TITLE
docs(ENG-597): Draft Linear follow-up for plan renewal API

### DIFF
--- a/.cursor/plans/eng-597-follow-up-renewal-api.issue.md
+++ b/.cursor/plans/eng-597-follow-up-renewal-api.issue.md
@@ -1,0 +1,88 @@
+# Follow-up Linear issue (draft) — Plan renewal / end date API
+
+**Parent:** [ENG-597](https://linear.app/givt/issue/ENG-597) — Implement new Pricing Page layout  
+**Design:** [COR-2444 — New pricing plan layout and manage modal (Figma)](https://www.figma.com/design/dBOnDJTvfqLwJsK5yvXukj/Givt4Kids---Ongoing-Design?node-id=49529-585)  
+**Labels:** `Givt Dashboard`, `Backend` (or `API`), `Blocked` / `Dependency`  
+**Team:** Same as ENG-597 (Givt4Kids dashboard)
+
+---
+
+## Title
+
+**Expose plan renewal semantics for Plans & Billing current-plan card (Renews vs Ends)**
+
+---
+
+## Problem
+
+ENG-597 requires the current-plan card renewal row to show:
+
+- **"Renews [date]"** when the plan **auto-renews**
+- **"Ends [date]"** when the plan **does not** auto-renew
+
+There is **no backend field / contract yet** that reliably distinguishes auto-renew vs end-of-term for the dashboard. Frontend cannot complete this acceptance criterion without API support.
+
+### Interim behaviour (documented on ENG-597)
+
+Until this issue is done, product agreed to show **"Ends [date]"** when a **new contract is scheduled** (scheduled plan change). That is a **workaround**, not the final Renews/Ends rules above.
+
+---
+
+## Proposed scope (backend + contract)
+
+### API / model
+
+Extend the subscription/contract payload used by **Plans & Billing** (organisation or family account context — align with existing billing endpoints) with explicit renewal fields, for example:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `renewalLabel` | enum: `renews` \| `ends` | Which copy prefix the UI should use |
+| `renewalDate` | ISO date (org timezone) | Date shown after "Renews" / "Ends" |
+| `autoRenews` | boolean | Source of truth for `renewalLabel` when no scheduled change |
+| `scheduledContractId` | string? (optional) | Present when a future contract is scheduled |
+| `scheduledContractStartDate` | ISO date? | Optional; supports interim "Ends" when change is scheduled |
+
+**Rules (target behaviour):**
+
+1. If the active plan **auto-renews** at period end → `renewalLabel = renews`, `renewalDate` = next renewal date.
+2. If the active plan **does not** auto-renew → `renewalLabel = ends`, `renewalDate` = contract end date.
+3. If a **scheduled contract/plan change** exists, document whether the row should still use `ends` (interim) or switch to `renews` with the new contract’s date — **confirm with product** and encode in API docs.
+
+### Non-goals
+
+- Manage modal / contracts list UI (separate ENG-597 item / modal work)
+- Available-plans tier filtering (frontend-only on ENG-597)
+
+---
+
+## Frontend follow-up (after API ships)
+
+In the Givt4Kids dashboard Plans & Billing page:
+
+- Map `renewalLabel` + `renewalDate` to localized strings: `Renews {date}` / `Ends {date}`.
+- Remove interim-only logic that infers "Ends" solely from "scheduled contract" once API provides `renewalLabel`.
+- Add tests for: auto-renew active, non-renewing active, scheduled change (per final product rules).
+
+---
+
+## Acceptance criteria
+
+- [ ] Billing/subscription read API returns `renewalLabel` and `renewalDate` for the active plan.
+- [ ] `autoRenews` (or equivalent) is documented and matches production billing behaviour.
+- [ ] Scheduled plan change is represented without ambiguous client-side guessing.
+- [ ] OpenAPI / internal API docs updated; dashboard team notified.
+- [ ] ENG-597 renewal-row checkbox can be marked done after frontend wires to new fields.
+
+---
+
+## Links
+
+- ENG-597 — unchecked AC: *Renewal row shows "Renews [date]" when the plan auto-renews, "Ends [date]" when it doesn't*
+- Figma current-plan details row label: **Renews** ([node `50804:37112`](https://www.figma.com/design/dBOnDJTvfqLwJsK5yvXukj/Givt4Kids---Ongoing-Design?node-id=50804-37112))
+
+---
+
+## Suggested Linear metadata
+
+- **Priority:** Medium (blocks ENG-597 AC, not whole page layout)
+- **Relation:** Blocks ENG-597 (renewal row) or add as sub-issue of ENG-597

--- a/.cursor/plans/eng-597-pricing-page.plan.md
+++ b/.cursor/plans/eng-597-pricing-page.plan.md
@@ -1,0 +1,27 @@
+# ENG-597 — Pricing page layout (Plans & Billing)
+
+**Status:** Partial — layout/items marked done in Linear; **renewal row** and **available plans** AC still open on dashboard codebase (not in `givt-app`).
+
+**Design:** [COR-2444 (Figma)](https://www.figma.com/design/dBOnDJTvfqLwJsK5yvXukj/Givt4Kids---Ongoing-Design?node-id=49529-585)
+
+## Repo note
+
+This issue is labeled **Givt Dashboard** (Angular/web). Implementation is **not** in `givtnl/givt-app` (Flutter). Use the Givt4Kids dashboard repository where Plans & Billing settings live.
+
+## Remaining acceptance criteria (dashboard)
+
+| Area | Item | Notes |
+|------|------|--------|
+| Current plan | Renews vs Ends row | **Blocked** — see follow-up draft [eng-597-follow-up-renewal-api.issue.md](./eng-597-follow-up-renewal-api.issue.md). Interim: show **Ends** when a new contract is scheduled. |
+| Available plans | Current + higher tiers only | e.g. Free → Free, Basic, Plus |
+| Available plans | Hide section on Plus (top tier) | Page: current plan → invoices |
+| Available plans | Current plan: disabled "Current plan" button | |
+| Available plans | Higher tiers: "Upgrade to [Plan]" | Opens plan-change flow |
+
+## Completed (per Linear)
+
+- Page order: current plan → available plans → invoices
+- Subtitle removed; "Get in contact" unchanged
+- Contracts section removed from page (moved to Manage modal)
+- Dynamic feature tiles on current-plan card
+- View invoices anchor scroll; Manage opens modal


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the ENG-597 thread comment: there is **no backend renewal semantics yet** for the Plans & Billing “Renews / Ends” row.

This PR does **not** implement dashboard UI (ENG-597 lives in the Givt4Kids **dashboard** repo, not `givt-app`). It adds copy-ready Linear issue drafts under `.cursor/plans/`.

## What's included

- **`eng-597-follow-up-renewal-api.issue.md`** — Proposed follow-up issue: expose `renewalLabel`, `renewalDate`, `autoRenews`, and scheduled-contract fields on the billing API so the dashboard can show **Renews [date]** vs **Ends [date]** per design.
- **`eng-597-pricing-page.plan.md`** — ENG-597 status tracker (remaining AC: renewal row + available plans section).

## Interim product rule (documented)

Until the API exists: show **Ends [date]** when a **new contract is scheduled** (workaround; not final Renews/Ends logic).

## Next steps for the team

1. Create the Linear issue from `eng-597-follow-up-renewal-api.issue.md` (Linear MCP was not authenticated in the agent environment).
2. Link it as **blocking** ENG-597 renewal-row AC.
3. Continue ENG-597 frontend in the dashboard repo for available-plans tier rules.

Linear: ENG-597
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-597](https://linear.app/givt/issue/ENG-597/implement-new-pricing-page-layout)

<div><a href="https://cursor.com/agents/bc-76fa7fe0-e508-4a64-a850-f9f24b551570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76fa7fe0-e508-4a64-a850-f9f24b551570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

