### PR TITLE
ENG-657 Add max-value validation to donation amount input

### DIFF
--- a/lib/core/constants/donation_amount_constants.dart
+++ b/lib/core/constants/donation_amount_constants.dart
@@ -1,0 +1,15 @@
+/// Shared limits for manual donation amount entry in the Givt app.
+///
+/// Matches the numeric keyboard restrictions in the main giving flow.
+class DonationAmountConstants {
+  DonationAmountConstants._();
+
+  /// Maximum digits before a decimal separator (comma or dot).
+  static const int maxIntegerDigitsWithDecimal = 6;
+
+  /// Maximum digits when no decimal separator is used.
+  static const int maxIntegerDigits = 7;
+
+  /// Highest supported donation amount for manual input.
+  static const double maxInputAmount = 9999999;
+}

--- a/lib/features/give/pages/for_you_giving_page.dart
+++ b/lib/features/give/pages/for_you_giving_page.dart
@@ -237,7 +237,7 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
                         child: FunButton(
                           text: context.l10n.forYouGivingCompleteMyGiving,
                           variant: FunButtonVariant.secondary,
-                          isDisabled: !_hasAnyAmount || isLoading,
+                          isDisabled: !_hasValidAmounts || isLoading,
                           analyticsEvent: AnalyticsEventName
                               .forYouGivingContinueTapped
                               .toEvent(),
@@ -260,7 +260,7 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
                       Expanded(
                         child: FunButton(
                           text: context.l10n.forYouGivingCompleteMyGiving,
-                          isDisabled: !_hasAnyAmount || isLoading,
+                          isDisabled: !_hasValidAmounts || isLoading,
                           isLoading: isLoading,
                           analyticsEvent: AnalyticsEventName
                               .forYouGivingContinueTapped
@@ -444,6 +444,9 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
   }
 
   void _submit(BuildContext context, String namespace) {
+    if (!_hasValidAmounts) {
+      return;
+    }
     final userGuid = context.read<AuthCubit>().state.user.guid;
     final amounts = _controllers.map((c) => _parseAmount(c.text)).toList();
     final donations = buildForYouDonationTransactions(
@@ -504,6 +507,13 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
   bool get _hasAnyAmount =>
       _controllers.any((controller) => _parseAmount(controller.text) > 0);
 
+  bool get _hasValidAmounts =>
+      _hasAnyAmount &&
+      _controllers.every(
+        (controller) =>
+            !DonationAmountValidation.exceedsMaxInputAmount(controller.text),
+      );
+
   bool get _isLastAccordion => _expandedIndex >= _goalLines.length - 1;
 
   void onBackspaceTapped() {
@@ -524,22 +534,22 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
 
   void onCommaTapped() {
     final controller = _controllers[_selectedField];
-    if (controller.text.contains(_decimalSeparator)) {
-      return;
-    }
     setState(() {
-      controller.text = '${controller.text}$_decimalSeparator';
+      controller.text = DonationAmountValidation.appendDecimalSeparator(
+        currentText: controller.text,
+        decimalSeparator: _decimalSeparator,
+      );
     });
   }
 
   void onNumberTapped(String value) {
     final controller = _controllers[_selectedField];
     setState(() {
-      if (controller.text == '0') {
-        controller.text = value;
-      } else {
-        controller.text = '${controller.text}$value';
-      }
+      controller.text = DonationAmountValidation.appendDigit(
+        currentText: controller.text,
+        digit: value,
+        decimalSeparator: _decimalSeparator,
+      );
     });
   }
 

--- a/lib/features/give/widgets/choose_amount.dart
+++ b/lib/features/give/widgets/choose_amount.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:givt_app/core/constants/donation_amount_constants.dart';
 import 'package:givt_app/core/enums/analytics_event_name.dart';
 import 'package:givt_app/core/enums/country.dart';
 import 'package:givt_app/features/amount_presets/models/preset.dart';
@@ -399,6 +400,22 @@ class _ChooseAmountState extends State<ChooseAmount> {
             content: context.l10n.givtNotEnough(
               '$currency ${Util.formatNumberComma(
                 lowerLimit,
+                widget.country,
+              )}',
+            ),
+            onConfirm: () => context.pop(),
+          ),
+        );
+        return false;
+      }
+      if (amount > DonationAmountConstants.maxInputAmount) {
+        await showDialog<void>(
+          context: context,
+          builder: (_) => WarningDialog(
+            title: context.l10n.amountTooHigh,
+            content: context.l10n.donationAmountExceedsMaximum(
+              '$currency ${Util.formatNumberComma(
+                DonationAmountConstants.maxInputAmount,
                 widget.country,
               )}',
             ),

--- a/lib/features/give/widgets/collection_form_field.dart
+++ b/lib/features/give/widgets/collection_form_field.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:givt_app/core/constants/donation_amount_constants.dart';
 import 'package:givt_app/features/family/utils/utils.dart';
 import 'package:givt_app/utils/app_theme.dart';
 
@@ -56,6 +57,9 @@ String? _validateCollectionValue(
   );
   if (currentValue == 0) {
     return null;
+  }
+  if (currentValue > DonationAmountConstants.maxInputAmount) {
+    return '';
   }
   if (currentValue > double.parse(amountLimit.toString())) {
     return '';

--- a/lib/features/recurring_donations/create/presentation/models/set_amount_ui_model.dart
+++ b/lib/features/recurring_donations/create/presentation/models/set_amount_ui_model.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:givt_app/features/recurring_donations/overview/models/recurring_donation.dart' as overview;
+import 'package:givt_app/utils/donation_amount_validation.dart';
 
 class SetAmountUIModel extends Equatable {
   const SetAmountUIModel({
@@ -19,7 +20,8 @@ class SetAmountUIModel extends Equatable {
     return selectedFrequency != null &&
         amount.isNotEmpty &&
         double.tryParse(normalizedAmount) != null &&
-        double.parse(normalizedAmount) > 0;
+        double.parse(normalizedAmount) > 0 &&
+        !DonationAmountValidation.exceedsMaxInputAmount(amount);
   }
 
   SetAmountUIModel copyWith({
@@ -38,4 +40,4 @@ class SetAmountUIModel extends Equatable {
 
   @override
   List<Object?> get props => [selectedFrequency, amount, isLoading, error];
-} 
+}

--- a/lib/features/recurring_donations/create/presentation/pages/step2_set_amount_page.dart
+++ b/lib/features/recurring_donations/create/presentation/pages/step2_set_amount_page.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app/app/injection/injection.dart';
+import 'package:givt_app/core/constants/donation_amount_constants.dart';
 import 'package:givt_app/core/enums/analytics_event_name.dart';
+import 'package:givt_app/core/enums/country.dart';
 import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/shared/design_system/design_system.dart';
 import 'package:givt_app/features/family/shared/widgets/buttons/givt_back_button_flat.dart';
@@ -125,7 +127,11 @@ class _Step2SetAmountPageState extends State<Step2SetAmountPage> {
                   FilteringTextInputFormatter.allow(
                     Util.numberInputFieldRegExp(),
                   ),
+                  LengthLimitingTextInputFormatter(
+                    DonationAmountConstants.maxIntegerDigits + 3,
+                  ),
                 ],
+                errorText: _amountErrorText(context, uiModel.amount),
                 prefixText: Util.getCurrencySymbol(
                   countryCode: context.read<AuthCubit>().state.user.country,
                 ),
@@ -163,5 +169,21 @@ class _Step2SetAmountPageState extends State<Step2SetAmountPage> {
         );
       },
     );
+  }
+
+  String? _amountErrorText(BuildContext context, String amount) {
+    if (!DonationAmountValidation.exceedsMaxInputAmount(amount)) {
+      return null;
+    }
+
+    final country = Country.fromCode(
+      context.read<AuthCubit>().state.user.country,
+    );
+    final formattedMax = Util.formatNumberComma(
+      DonationAmountConstants.maxInputAmount,
+      country,
+    );
+
+    return context.l10n.donationAmountExceedsMaximum(formattedMax);
   }
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -137,6 +137,14 @@
   "fingerprintUsage": "Hier änderst du die Verwendung des Fingerabdrucks, um dich bei der Givt App anzumelden.",
   "offlineGiftsTitle": "Offline Spenden",
   "amountTooHigh": "Betrag zu hoch",
+  "donationAmountExceedsMaximum": "Der Betrag überschreitet den maximal zulässigen Spendenbetrag von {maxAmount}",
+  "@donationAmountExceedsMaximum": {
+    "placeholders": {
+      "maxAmount": {
+        "type": "String"
+      }
+    }
+  },
   "loginFailure": "Login Fehler",
   "requestFailed": "Anfrage fehlgeschlagen",
   "resetPasswordSent": "Du solltest eine E-Mail mit einem Link erhalten haben, um dein Passwort zurück setzen zu können. Falls du diese E-Mail nicht sofort findest, überprüf bitte auch den Spam-Ordner.",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -137,6 +137,14 @@
   "fingerprintUsage": "This is where you change the use of your fingerprint to login into the Givt app.",
   "offlineGiftsTitle": "Offline donations",
   "amountTooHigh": "Amount too high",
+  "donationAmountExceedsMaximum": "Amount exceeds the maximum allowed donation of {maxAmount}",
+  "@donationAmountExceedsMaximum": {
+    "placeholders": {
+      "maxAmount": {
+        "type": "String"
+      }
+    }
+  },
   "loginFailure": "Login error",
   "requestFailed": "Request failed",
   "resetPasswordSent": "You should have received an e-mail with a link to reset your password. In case you do not see the e-mail right away, check your spam.",

--- a/lib/l10n/arb/app_en_US.arb
+++ b/lib/l10n/arb/app_en_US.arb
@@ -137,6 +137,14 @@
   "fingerprintUsage": "This is where you change the use of your fingerprint to login into the Givt app.",
   "offlineGiftsTitle": "Offline donations",
   "amountTooHigh": "Amount too high",
+  "donationAmountExceedsMaximum": "Amount exceeds the maximum allowed donation of {maxAmount}",
+  "@donationAmountExceedsMaximum": {
+    "placeholders": {
+      "maxAmount": {
+        "type": "String"
+      }
+    }
+  },
   "loginFailure": "Login error",
   "requestFailed": "Request failed",
   "resetPasswordSent": "You should have received an e-mail with a link to reset your password. In case you do not see the e-mail right away, check your spam.",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -137,6 +137,14 @@
   "fingerprintUsage": "This is where you change the use of your fingerprint to login into the Givt app.",
   "offlineGiftsTitle": "Offline donations",
   "amountTooHigh": "Amount too high",
+  "donationAmountExceedsMaximum": "El monto supera la donación máxima permitida de {maxAmount}",
+  "@donationAmountExceedsMaximum": {
+    "placeholders": {
+      "maxAmount": {
+        "type": "String"
+      }
+    }
+  },
   "loginFailure": "Login error",
   "requestFailed": "Request failed",
   "resetPasswordSent": "You should have received an e-mail with a link to reset your password. In case you do not see the e-mail right away, check your spam.",

--- a/lib/l10n/arb/app_es_419.arb
+++ b/lib/l10n/arb/app_es_419.arb
@@ -137,6 +137,14 @@
   "fingerprintUsage": "Aquí puedes cambiar el uso de tu huella dactilar para iniciar sesión en la aplicación Givt.",
   "offlineGiftsTitle": "Donaciones sin conexión",
   "amountTooHigh": "Monto demasiado alto",
+  "donationAmountExceedsMaximum": "El monto supera la donación máxima permitida de {maxAmount}",
+  "@donationAmountExceedsMaximum": {
+    "placeholders": {
+      "maxAmount": {
+        "type": "String"
+      }
+    }
+  },
   "loginFailure": "Error de inicio de sesión",
   "requestFailed": "Solicitud fallida",
   "resetPasswordSent": "Debería haber recibido un correo electrónico con un enlace para restablecer tu contraseña. En caso de que no veas el correo electrónico de inmediato, revisa tu correo no deseado.",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -818,6 +818,12 @@ abstract class AppLocalizations {
   /// **'Amount too high'**
   String get amountTooHigh;
 
+  /// No description provided for @donationAmountExceedsMaximum.
+  ///
+  /// In en, this message translates to:
+  /// **'Amount exceeds the maximum allowed donation of {maxAmount}'**
+  String donationAmountExceedsMaximum(String maxAmount);
+
   /// No description provided for @loginFailure.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -431,6 +431,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get amountTooHigh => 'Betrag zu hoch';
 
   @override
+  String donationAmountExceedsMaximum(String maxAmount) {
+    return 'Der Betrag überschreitet den maximal zulässigen Spendenbetrag von $maxAmount';
+  }
+
+  @override
   String get loginFailure => 'Login Fehler';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -426,6 +426,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get amountTooHigh => 'Amount too high';
 
   @override
+  String donationAmountExceedsMaximum(String maxAmount) {
+    return 'Amount exceeds the maximum allowed donation of $maxAmount';
+  }
+
+  @override
   String get loginFailure => 'Login error';
 
   @override
@@ -3361,6 +3366,11 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
 
   @override
   String get amountTooHigh => 'Amount too high';
+
+  @override
+  String donationAmountExceedsMaximum(String maxAmount) {
+    return 'Amount exceeds the maximum allowed donation of $maxAmount';
+  }
 
   @override
   String get loginFailure => 'Login error';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -426,6 +426,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get amountTooHigh => 'Amount too high';
 
   @override
+  String donationAmountExceedsMaximum(String maxAmount) {
+    return 'El monto supera la donación máxima permitida de $maxAmount';
+  }
+
+  @override
   String get loginFailure => 'Login error';
 
   @override
@@ -3373,6 +3378,11 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get amountTooHigh => 'Monto demasiado alto';
+
+  @override
+  String donationAmountExceedsMaximum(String maxAmount) {
+    return 'El monto supera la donación máxima permitida de $maxAmount';
+  }
 
   @override
   String get loginFailure => 'Error de inicio de sesión';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -429,6 +429,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get amountTooHigh => 'Bedrag te hoog';
 
   @override
+  String donationAmountExceedsMaximum(String maxAmount) {
+    return 'Dit bedrag is hoger dan het maximaal toegestane geefbedrag van $maxAmount';
+  }
+
+  @override
   String get loginFailure => 'Fout bij inloggen';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -137,6 +137,14 @@
   "fingerprintUsage": "Hier beheer je het gebruik van je vingerafdruk om in de Givt-app in te loggen.",
   "offlineGiftsTitle": "Offline giften",
   "amountTooHigh": "Bedrag te hoog",
+  "donationAmountExceedsMaximum": "Dit bedrag is hoger dan het maximaal toegestane geefbedrag van {maxAmount}",
+  "@donationAmountExceedsMaximum": {
+    "placeholders": {
+      "maxAmount": {
+        "type": "String"
+      }
+    }
+  },
   "loginFailure": "Fout bij inloggen",
   "requestFailed": "Aanvraag mislukt",
   "resetPasswordSent": "Je krijgt een e-mail met daarin een link om je wachtwoord opnieuw in te stellen. Heb je na 5 minuten nog steeds de e-mail niet ontvangen? Kijk dan even in je spam.",

--- a/lib/utils/donation_amount_validation.dart
+++ b/lib/utils/donation_amount_validation.dart
@@ -1,0 +1,78 @@
+import 'package:givt_app/core/constants/donation_amount_constants.dart';
+
+/// Validation and input helpers for donation amount fields.
+class DonationAmountValidation {
+  DonationAmountValidation._();
+
+  static double? parseAmount(String value) {
+    final normalized = value.trim();
+    if (normalized.isEmpty) {
+      return null;
+    }
+    return double.tryParse(normalized.replaceAll(',', '.'));
+  }
+
+  static bool exceedsMaxInputAmount(String value) {
+    final amount = parseAmount(value);
+    if (amount == null) {
+      return false;
+    }
+    return amount > DonationAmountConstants.maxInputAmount;
+  }
+
+  static bool isPositiveWithinInputLimit(String value) {
+    final amount = parseAmount(value);
+    if (amount == null || amount <= 0) {
+      return false;
+    }
+    return amount <= DonationAmountConstants.maxInputAmount;
+  }
+
+  /// Applies the same digit restrictions as the main giving numeric keyboard.
+  static String appendDigit({
+    required String currentText,
+    required String digit,
+    required String decimalSeparator,
+    String zeroChar = '0',
+  }) {
+    if (currentText.contains(decimalSeparator)) {
+      final parts = currentText.split(decimalSeparator);
+      if (parts.length > 1 && parts[1].length >= 2) {
+        return currentText;
+      }
+      return currentText + digit;
+    }
+
+    if (currentText == zeroChar) {
+      return digit;
+    }
+
+    if (currentText.length >= DonationAmountConstants.maxIntegerDigits) {
+      return currentText;
+    }
+
+    return currentText + digit;
+  }
+
+  /// Applies the same decimal-separator restrictions as the main giving flow.
+  static String appendDecimalSeparator({
+    required String currentText,
+    required String decimalSeparator,
+    String zeroChar = '0',
+  }) {
+    if (currentText.contains(decimalSeparator)) {
+      return currentText;
+    }
+
+    if (currentText.length >
+        DonationAmountConstants.maxIntegerDigitsWithDecimal) {
+      return currentText;
+    }
+
+    if (currentText == zeroChar) {
+      return '$zeroChar$decimalSeparator';
+    }
+
+    return '$currentText$decimalSeparator';
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -3,6 +3,7 @@ export 'app_theme.dart';
 export 'auth_utils.dart';
 export 'biometrics_helper.dart';
 export 'country_emoji.dart';
+export 'donation_amount_validation.dart';
 export 'json.dart';
 export 'ns_user_defaults_keys.dart';
 export 'shared_preferences_keys.dart';

--- a/test/utils/donation_amount_validation_test.dart
+++ b/test/utils/donation_amount_validation_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/core/constants/donation_amount_constants.dart';
+import 'package:givt_app/utils/donation_amount_validation.dart';
+
+void main() {
+  group('DonationAmountValidation.parseAmount', () {
+    test('parses comma and dot decimal separators', () {
+      expect(DonationAmountValidation.parseAmount('12,50'), 12.5);
+      expect(DonationAmountValidation.parseAmount('12.50'), 12.5);
+    });
+  });
+
+  group('DonationAmountValidation.exceedsMaxInputAmount', () {
+    test('returns false for valid amounts', () {
+      expect(DonationAmountValidation.exceedsMaxInputAmount('5'), isFalse);
+      expect(
+        DonationAmountValidation.exceedsMaxInputAmount(
+          DonationAmountConstants.maxInputAmount.toString(),
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns true for extremely large amounts', () {
+      expect(
+        DonationAmountValidation.exceedsMaxInputAmount('9999999999'),
+        isTrue,
+      );
+    });
+  });
+
+  group('DonationAmountValidation keyboard helpers', () {
+    test('limits integer digits to seven', () {
+      var text = '999999';
+      text = DonationAmountValidation.appendDigit(
+        currentText: text,
+        digit: '9',
+        decimalSeparator: ',',
+      );
+      expect(text, '9999999');
+
+      text = DonationAmountValidation.appendDigit(
+        currentText: text,
+        digit: '9',
+        decimalSeparator: ',',
+      );
+      expect(text, '9999999');
+    });
+
+    test('allows two decimal digits after separator', () {
+      var text = DonationAmountValidation.appendDecimalSeparator(
+        currentText: '999999',
+        decimalSeparator: ',',
+      );
+      expect(text, '999999,');
+
+      text = DonationAmountValidation.appendDigit(
+        currentText: text,
+        digit: '9',
+        decimalSeparator: ',',
+      );
+      text = DonationAmountValidation.appendDigit(
+        currentText: text,
+        digit: '9',
+        decimalSeparator: ',',
+      );
+      expect(text, '999999,99');
+
+      text = DonationAmountValidation.appendDigit(
+        currentText: text,
+        digit: '9',
+        decimalSeparator: ',',
+      );
+      expect(text, '999999,99');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds shared donation amount input limits (`DonationAmountConstants.maxInputAmount = 9,999,999`) matching the main giving flow numeric keyboard restrictions.
- Applies validation and input restrictions to recurring donation amount entry, for-you giving keyboard input, and the standard choose-amount flow.
- Adds localized error copy (`donationAmountExceedsMaximum`) and unit tests for the validation helpers.

Linear: https://linear.app/givt/issue/ENG-657/add-max-value-validation-to-donation-amount-input

## Test plan

Automated checks run locally:
- `flutter gen-l10n`
- `flutter analyze` (changed files)
- `flutter test --coverage --test-randomize-ordering-seed random`

Reviewer validation (expected behavior):
- Recurring donation step 2 rejects amounts above 9,999,999 and shows the localized error below the field; Continue stays disabled.
- For-you giving numeric keyboard stops accepting extra digits once the main-flow limit is reached; Complete my giving stays disabled for over-limit amounts.
- Main choose-amount flow shows a warning dialog when an amount exceeds the supported input maximum before proceeding.


Made with [Cursor](https://cursor.com)