### PR TITLE
ENG-656 Enforce max donation limit in for-you flow

### DIFF
--- a/lib/features/give/pages/for_you_giving_page.dart
+++ b/lib/features/give/pages/for_you_giving_page.dart
@@ -105,10 +105,17 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
     final currencySymbol = Util.getCurrencySymbol(
       countryCode: country.countryCode,
     );
+    final amountLimit = auth.user.amountLimit;
     if (country.countryCode == Country.us.countryCode ||
         Country.unitedKingdomCodes().contains(country.countryCode)) {
       _decimalSeparator = '.';
     }
+    final hasAmountLimitViolation = DonationAmountValidation.anyExceedsUserAmountLimit(
+      values: _controllers.map((controller) => controller.text),
+      amountLimit: amountLimit,
+      decimalSeparator: _decimalSeparator,
+    );
+    final hasValidAmounts = _hasAnyAmount && !hasAmountLimitViolation;
 
     if (organisation == null) {
       return FunScaffold(
@@ -193,6 +200,7 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
                               line: _goalLines[index],
                               index: index,
                               currencySymbol: currencySymbol,
+                              amountLimit: amountLimit,
                               accordionKey: _accordionKeys[index],
                             ),
                           );
@@ -201,6 +209,14 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
                     ),
                   ),
                 ),
+                if (hasAmountLimitViolation)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: BodySmallText(
+                      context.l10n.amountLimitExceeded,
+                      color: FunTheme.of(context).error50,
+                    ),
+                  ),
                 if (_showMoreGoalsLink)
                   FunTextButton(
                     text: context.l10n.forYouGivingMoreGoals,
@@ -237,18 +253,22 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
                         child: FunButton(
                           text: context.l10n.forYouGivingCompleteMyGiving,
                           variant: FunButtonVariant.secondary,
-                          isDisabled: !_hasAnyAmount || isLoading,
+                          isDisabled: !hasValidAmounts || isLoading,
                           analyticsEvent: AnalyticsEventName
                               .forYouGivingContinueTapped
                               .toEvent(),
-                          onTap: () => _submit(context, organisation.nameSpace),
+                          onTap: () => _submit(
+                            context,
+                            organisation.nameSpace,
+                            amountLimit: amountLimit,
+                          ),
                         ),
                       ),
                       const SizedBox(width: 8),
                       Expanded(
                         child: FunButton(
                           text: context.l10n.next,
-                          isDisabled: isLoading,
+                          isDisabled: isLoading || hasAmountLimitViolation,
                           isLoading: false,
                           analyticsEvent: AnalyticsEventName
                               .forYouGivingContinueTapped
@@ -260,12 +280,16 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
                       Expanded(
                         child: FunButton(
                           text: context.l10n.forYouGivingCompleteMyGiving,
-                          isDisabled: !_hasAnyAmount || isLoading,
+                          isDisabled: !hasValidAmounts || isLoading,
                           isLoading: isLoading,
                           analyticsEvent: AnalyticsEventName
                               .forYouGivingContinueTapped
                               .toEvent(),
-                          onTap: () => _submit(context, organisation.nameSpace),
+                          onTap: () => _submit(
+                            context,
+                            organisation.nameSpace,
+                            amountLimit: amountLimit,
+                          ),
                         ),
                       ),
                   ],
@@ -283,6 +307,7 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
     required ForYouGoalLineKind line,
     required int index,
     required String currencySymbol,
+    required int amountLimit,
     required GlobalKey accordionKey,
   }) {
     final title = switch (line) {
@@ -318,6 +343,7 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
           controller: _controllers[index],
           isExpanded: _expandedIndex == index,
           amount: _parseAmount(_controllers[index].text),
+          amountLimit: amountLimit,
           onClear: () {
             setState(() {
               _controllers[index].text = '0';
@@ -366,15 +392,22 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
     required TextEditingController controller,
     required bool isExpanded,
     required double amount,
+    required int amountLimit,
     required VoidCallback onClear,
   }) {
     final theme = FunTheme.of(context);
     final isComplete = amount > 0;
-    final borderColor = isComplete
-        ? theme.primary30
-        : isExpanded
-            ? theme.primary70
-            : theme.neutralVariant90;
+    final exceedsLimit = DonationAmountValidation.exceedsUserAmountLimit(
+      amount: amount,
+      amountLimit: amountLimit,
+    );
+    final borderColor = exceedsLimit
+        ? theme.error50
+        : isComplete
+            ? theme.primary30
+            : isExpanded
+                ? theme.primary70
+                : theme.neutralVariant90;
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
@@ -443,7 +476,19 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
     });
   }
 
-  void _submit(BuildContext context, String namespace) {
+  void _submit(
+    BuildContext context,
+    String namespace, {
+    required int amountLimit,
+  }) {
+    if (!(_hasAnyAmount &&
+        !DonationAmountValidation.anyExceedsUserAmountLimit(
+          values: _controllers.map((controller) => controller.text),
+          amountLimit: amountLimit,
+          decimalSeparator: _decimalSeparator,
+        ))) {
+      return;
+    }
     final userGuid = context.read<AuthCubit>().state.user.guid;
     final amounts = _controllers.map((c) => _parseAmount(c.text)).toList();
     final donations = buildForYouDonationTransactions(

--- a/lib/utils/donation_amount_validation.dart
+++ b/lib/utils/donation_amount_validation.dart
@@ -1,0 +1,36 @@
+/// Validation helpers for donation amount fields.
+class DonationAmountValidation {
+  DonationAmountValidation._();
+
+  static double parseLocalizedAmount(
+    String value, {
+    String decimalSeparator = ',',
+  }) {
+    return double.tryParse(value.replaceAll(decimalSeparator, '.')) ?? 0;
+  }
+
+  /// Whether [amount] exceeds the user's configured per-donation maximum.
+  static bool exceedsUserAmountLimit({
+    required double amount,
+    required int amountLimit,
+  }) {
+    return amount > 0 && amount > amountLimit;
+  }
+
+  /// Whether any parsed amount in [values] exceeds [amountLimit].
+  static bool anyExceedsUserAmountLimit({
+    required Iterable<String> values,
+    required int amountLimit,
+    String decimalSeparator = ',',
+  }) {
+    return values.any(
+      (value) => exceedsUserAmountLimit(
+        amount: parseLocalizedAmount(
+          value,
+          decimalSeparator: decimalSeparator,
+        ),
+        amountLimit: amountLimit,
+      ),
+    );
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -3,6 +3,7 @@ export 'app_theme.dart';
 export 'auth_utils.dart';
 export 'biometrics_helper.dart';
 export 'country_emoji.dart';
+export 'donation_amount_validation.dart';
 export 'json.dart';
 export 'ns_user_defaults_keys.dart';
 export 'shared_preferences_keys.dart';

--- a/test/utils/donation_amount_validation_test.dart
+++ b/test/utils/donation_amount_validation_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/utils/donation_amount_validation.dart';
+
+void main() {
+  group('DonationAmountValidation', () {
+    group('parseLocalizedAmount', () {
+      test('parses comma decimal separator', () {
+        expect(
+          DonationAmountValidation.parseLocalizedAmount('12,50'),
+          12.5,
+        );
+      });
+
+      test('parses dot decimal separator', () {
+        expect(
+          DonationAmountValidation.parseLocalizedAmount(
+            '12.50',
+            decimalSeparator: '.',
+          ),
+          12.5,
+        );
+      });
+
+      test('returns zero for invalid input', () {
+        expect(DonationAmountValidation.parseLocalizedAmount(''), 0);
+      });
+    });
+
+    group('exceedsUserAmountLimit', () {
+      test('returns false for zero amount', () {
+        expect(
+          DonationAmountValidation.exceedsUserAmountLimit(
+            amount: 0,
+            amountLimit: 100,
+          ),
+          isFalse,
+        );
+      });
+
+      test('returns false when amount equals limit', () {
+        expect(
+          DonationAmountValidation.exceedsUserAmountLimit(
+            amount: 100,
+            amountLimit: 100,
+          ),
+          isFalse,
+        );
+      });
+
+      test('returns true when amount exceeds limit', () {
+        expect(
+          DonationAmountValidation.exceedsUserAmountLimit(
+            amount: 101,
+            amountLimit: 100,
+          ),
+          isTrue,
+        );
+      });
+    });
+
+    group('anyExceedsUserAmountLimit', () {
+      test('returns false when all amounts are within limit', () {
+        expect(
+          DonationAmountValidation.anyExceedsUserAmountLimit(
+            values: const ['0', '50', '100'],
+            amountLimit: 100,
+          ),
+          isFalse,
+        );
+      });
+
+      test('returns true when any amount exceeds limit', () {
+        expect(
+          DonationAmountValidation.anyExceedsUserAmountLimit(
+            values: const ['0', '50,01'],
+            amountLimit: 50,
+          ),
+          isTrue,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Enforces the user's configured `amountLimit` in the for-you (suggestion) giving flow, matching manual donation validation.
- Disables Give/Next actions when any entered amount exceeds the limit, shows `amountLimitExceeded` feedback, and highlights offending amount fields with an error border.
- Adds shared `DonationAmountValidation` helper with unit tests.

Linear: https://linear.app/givt/issue/ENG-656/enforce-max-donation-limit-in-for-you-flow

## Test plan
Commands run:
- `flutter test test/utils/donation_amount_validation_test.dart --test-randomize-ordering-seed random`
- `flutter test --coverage --test-randomize-ordering-seed random`
- `flutter analyze lib/features/give/pages/for_you_giving_page.dart lib/utils/donation_amount_validation.dart lib/utils/utils.dart`

Reviewer validation:
- [ ] In for-you giving, entering an amount above the user's max donation limit shows the error message and disables Give now.
- [ ] Amount fields over the limit show a red error border.
- [ ] Amounts at or below the limit allow proceeding as before.
- [ ] Next is disabled while any goal amount exceeds the limit.


Made with [Cursor](https://cursor.com)