### PR TITLE
For You giving: log amounts per collection on continue (ENG-676)

### DIFF
--- a/lib/features/give/pages/for_you_giving_page.dart
+++ b/lib/features/give/pages/for_you_giving_page.dart
@@ -15,6 +15,8 @@ import 'package:givt_app/features/give/bloc/bloc.dart';
 import 'package:givt_app/features/give/dialogs/donation_submission_timeout_dialog.dart';
 import 'package:givt_app/features/give/models/models.dart';
 import 'package:givt_app/features/give/utils/for_you_donation_transactions.dart';
+import 'package:givt_app/features/give/utils/for_you_giving_analytics.dart';
+import 'package:givt_app/shared/models/analytics_event.dart';
 import 'package:givt_app/features/give/widgets/for_you_more_general_goals_sheet.dart';
 import 'package:givt_app/features/give/widgets/numeric_keyboard.dart';
 import 'package:givt_app/l10n/l10n.dart';
@@ -258,9 +260,7 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
                           text: context.l10n.forYouGivingCompleteMyGiving,
                           variant: FunButtonVariant.secondary,
                           isDisabled: !canSubmit || isLoading,
-                          analyticsEvent: AnalyticsEventName
-                              .forYouGivingContinueTapped
-                              .toEvent(),
+                          analyticsEvent: _givingContinueAnalyticsEvent(),
                           onTap: () => _submit(
                             context,
                             organisation.nameSpace,
@@ -274,9 +274,7 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
                           text: context.l10n.next,
                           isDisabled: isLoading || hasAmountLimitViolation,
                           isLoading: false,
-                          analyticsEvent: AnalyticsEventName
-                              .forYouGivingContinueTapped
-                              .toEvent(),
+                          analyticsEvent: _givingContinueAnalyticsEvent(),
                           onTap: _openNextAccordion,
                         ),
                       ),
@@ -286,9 +284,7 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
                           text: context.l10n.forYouGivingCompleteMyGiving,
                           isDisabled: !canSubmit || isLoading,
                           isLoading: isLoading,
-                          analyticsEvent: AnalyticsEventName
-                              .forYouGivingContinueTapped
-                              .toEvent(),
+                          analyticsEvent: _givingContinueAnalyticsEvent(),
                           onTap: () => _submit(
                             context,
                             organisation.nameSpace,
@@ -478,6 +474,16 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
       }
       _scrollAccordionIntoView(_expandedIndex);
     });
+  }
+
+  AnalyticsEvent _givingContinueAnalyticsEvent() {
+    return AnalyticsEvent(
+      AnalyticsEventName.forYouGivingContinueTapped,
+      parameters: buildForYouGivingContinueAnalyticsParameters(
+        lines: _goalLines,
+        amountTexts: _controllers.map((c) => c.text).toList(),
+      ),
+    );
   }
 
   void _submit(

--- a/lib/features/give/utils/for_you_giving_analytics.dart
+++ b/lib/features/give/utils/for_you_giving_analytics.dart
@@ -1,0 +1,35 @@
+import 'package:givt_app/features/give/models/for_you_goal_line.dart';
+
+/// PostHog parameters for `for_you_giving_continue_tapped`.
+///
+/// Collection rows use `Collection {index}` keys (same as legacy `continue_clicked`).
+/// General goals use `General goal: {name}` or `General goal {n}` when unnamed.
+Map<String, dynamic> buildForYouGivingContinueAnalyticsParameters({
+  required List<ForYouGoalLineKind> lines,
+  required List<String> amountTexts,
+}) {
+  assert(
+    lines.length == amountTexts.length,
+    'lines and amountTexts must align',
+  );
+
+  final parameters = <String, dynamic>{};
+  var generalOrdinal = 0;
+
+  for (var i = 0; i < lines.length; i++) {
+    final amount = amountTexts[i];
+    switch (lines[i]) {
+      case ForYouCollectionGoalLine(:final subtitleIndex):
+        parameters['Collection $subtitleIndex'] = amount;
+      case ForYouGeneralGoalLine(:final qr):
+        generalOrdinal++;
+        final name = qr.allocationName.trim();
+        final key = name.isNotEmpty
+            ? 'General goal: $name'
+            : 'General goal $generalOrdinal';
+        parameters[key] = amount;
+    }
+  }
+
+  return parameters;
+}

--- a/test/features/give/utils/for_you_giving_analytics_test.dart
+++ b/test/features/give/utils/for_you_giving_analytics_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/features/give/models/for_you_goal_line.dart';
+import 'package:givt_app/features/give/utils/for_you_giving_analytics.dart';
+import 'package:givt_app/shared/models/organisation_goals.dart';
+
+void main() {
+  group('buildForYouGivingContinueAnalyticsParameters', () {
+    test('maps collection and general goal amounts', () {
+      final lines = <ForYouGoalLineKind>[
+        const ForYouCollectionGoalLine(
+          title: 'Building fund',
+          subtitleIndex: 1,
+        ),
+        const ForYouCollectionGoalLine(
+          title: 'Youth',
+          subtitleIndex: 2,
+        ),
+        ForYouGeneralGoalLine(
+          OrganisationQrCode(
+            mediumId: 'qr.medium',
+            allocationName: 'Mission',
+            collectGroupId: 'g',
+          ),
+        ),
+      ];
+
+      final parameters = buildForYouGivingContinueAnalyticsParameters(
+        lines: lines,
+        amountTexts: ['10', '0', '5,50'],
+      );
+
+      expect(parameters, {
+        'Collection 1': '10',
+        'Collection 2': '0',
+        'General goal: Mission': '5,50',
+      });
+    });
+
+    test('uses ordinal when general goal has no allocation name', () {
+      final lines = <ForYouGoalLineKind>[
+        ForYouGeneralGoalLine(
+          OrganisationQrCode(
+            mediumId: 'qr.medium',
+            allocationName: '   ',
+            collectGroupId: 'g',
+          ),
+        ),
+      ];
+
+      final parameters = buildForYouGivingContinueAnalyticsParameters(
+        lines: lines,
+        amountTexts: ['3'],
+      );
+
+      expect(parameters, {'General goal 1': '3'});
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds PostHog event properties to `for_you_giving_continue_tapped` for each goal line on the For You giving page (Continue / Next / Give now).
- Collection goals use `Collection {index}` keys with the entered amount string, matching the legacy `continue_clicked` convention in `choose_amount.dart`.
- General (QR) goals use `General goal: {name}` or `General goal {n}` when unnamed.

Linear: https://linear.app/givt/issue/ENG-676/for-you-giving-log-amounts-per-collection-on-continue

## Test plan
- [ ] On For You giving, enter amounts for multiple collections and tap **Give now** — verify PostHog event `for_you_giving_continue_tapped` includes `Collection 1`, `Collection 2`, etc.
- [ ] Add a general goal from the sheet, enter an amount, submit — verify a `General goal: …` property is present.
- [ ] Tap **Next** between accordions — properties reflect current amounts on all lines.
- [x] `flutter test test/features/give/utils/for_you_giving_analytics_test.dart`


Made with [Cursor](https://cursor.com)