### PR TITLE
Fix biometric fallback to password login (ENG-675)

### DIFF
--- a/lib/utils/auth_utils.dart
+++ b/lib/utils/auth_utils.dart
@@ -76,6 +76,13 @@ class AuthUtils {
     try {
       final hasAuthenticated = await LocalAuthInfo.instance.authenticate();
       if (!hasAuthenticated) {
+        if (!context.mounted) {
+          return;
+        }
+        await displayLoginBottomSheet(
+          context,
+          checkAuthRequest: checkAuthRequest,
+        );
         return;
       }
       if (!context.mounted) {


### PR DESCRIPTION
## Summary

- When biometric re-auth fails, is cancelled, or the user taps **Enter password**, the EU app now opens the login bottom sheet instead of staying on the same screen with no action.
- Aligns `AuthUtils.checkToken` with the existing `FamilyAuthUtils` pattern.

Linear: [ENG-675](https://linear.app/givt/issue/ENG-675) (formerly COR-2607)

## Test plan

- [x] Manual: expired session + protected action → biometric prompt → **Enter password** → login bottom sheet opens
- [ ] Manual: cancel / fail biometric → login bottom sheet opens
- [ ] Manual: complete password login → original navigation callback runs
- [ ] Optional: verify on Face ID and fingerprint devices


Made with [Cursor](https://cursor.com)