### PR TITLE
ENG-678 Fix overlapping Add button on recurring donations page

### DIFF
--- a/lib/features/recurring_donations/overview/widgets/recurring_donations_list.dart
+++ b/lib/features/recurring_donations/overview/widgets/recurring_donations_list.dart
@@ -32,6 +32,7 @@ class RecurringDonationsList extends StatelessWidget {
     }
 
     return ListView.separated(
+      padding: const EdgeInsets.only(bottom: 100),
       itemCount: donations.length,
       separatorBuilder: (context, index) => const SizedBox(height: 16),
       itemBuilder: (context, index) {

--- a/lib/features/recurring_donations/overview/widgets/recurring_donations_list.dart
+++ b/lib/features/recurring_donations/overview/widgets/recurring_donations_list.dart
@@ -32,7 +32,7 @@ class RecurringDonationsList extends StatelessWidget {
     }
 
     return ListView.separated(
-      padding: const EdgeInsets.only(bottom: 100),
+      padding: const EdgeInsets.only(bottom: 98), // inset + button size
       itemCount: donations.length,
       separatorBuilder: (context, index) => const SizedBox(height: 16),
       itemBuilder: (context, index) {


### PR DESCRIPTION
## Summary

Fixes the recurring donations overview list so the last card is not obscured by the docked "Add recurring donation" button when scrolled to the bottom.

- Added `padding: EdgeInsets.only(bottom: 100)` to `ListView.separated` in `RecurringDonationsList`

Linear: https://linear.app/givt/issue/ENG-678/fix-overlapping-add-button-on-recurring-donation-page

## Test plan

**Commands run:**
- `flutter analyze lib/features/recurring_donations/overview/widgets/recurring_donations_list.dart`
- `flutter test test/features/recurring_donations/ --test-randomize-ordering-seed random`

**Reviewer validation:**
- On the Recurring Donations page with enough items to scroll, scroll to the bottom and confirm the last card is fully visible above the Add button with comfortable spacing.
- Spot-check on a small-screen device/emulator for consistent behavior.


Made with [Cursor](https://cursor.com)