### PR TITLE
ENG-710 Fix overlapping Add button on external donations list

### DIFF
--- a/lib/features/external_donations/overview/widgets/external_donations_list.dart
+++ b/lib/features/external_donations/overview/widgets/external_donations_list.dart
@@ -26,6 +26,7 @@ class ExternalDonationsList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView.separated(
+      padding: const EdgeInsets.only(bottom: 98), // inset + button size
       itemCount: donations.length,
       separatorBuilder: (context, index) => const SizedBox(height: 16),
       itemBuilder: (context, index) {


### PR DESCRIPTION
## Summary

- Add `bottom: 98` padding to `ExternalDonationsList` so the last donation card is not obscured by the docked "Add external donation" button when scrolled to the bottom.
- Matches the existing pattern in `RecurringDonationsList`.

Linear: https://linear.app/givt/issue/ENG-710/fix-overlapping-add-button-on-external-donation-page

## Test plan

**Commands run:**
- `flutter analyze lib/features/external_donations/overview/widgets/external_donations_list.dart`
- `flutter test --coverage --test-randomize-ordering-seed random`

**Reviewer validation:**
- On External donations overview (Current and Past tabs), scroll a long list to the bottom and confirm the last `FunMissionCard` is fully visible above the Add button.
- Spot-check on a smaller screen size that bottom clearance still looks correct.


Made with [Cursor](https://cursor.com)