### PR TITLE
fix(external-donations): correct delete modal button styles (ENG-653)

### DIFF
--- a/lib/features/external_donations/detail/widgets/external_donation_delete_modal.dart
+++ b/lib/features/external_donations/detail/widgets/external_donation_delete_modal.dart
@@ -20,20 +20,21 @@ class ExternalDonationDeleteModal {
       closeAction: () => context.pop(),
       buttons: [
         FunButton(
+          onTap: () => context.pop(),
+          text: locals.externalDonationsDeleteModalCancel,
+          analyticsEvent:
+              AnalyticsEventName.externalDonationsDeleteCancelClicked.toEvent(),
+        ),
+        FunButton(
           onTap: () async {
             context.pop();
             await cubit.confirmDeleteDonation();
           },
           text: locals.externalDonationsDeleteModalConfirm,
+          variant: FunButtonVariant.destructiveSecondary,
+          fullBorder: true,
           analyticsEvent:
               AnalyticsEventName.externalDonationsDeleteConfirmClicked.toEvent(),
-        ),
-        FunButton(
-          onTap: () => context.pop(),
-          text: locals.externalDonationsDeleteModalCancel,
-          variant: FunButtonVariant.secondary,
-          analyticsEvent:
-              AnalyticsEventName.externalDonationsDeleteCancelClicked.toEvent(),
         ),
       ],
     ).show(context, isDismissible: true);
@@ -56,21 +57,22 @@ class ExternalDonationBulkDeleteModal {
       closeAction: () => context.pop(),
       buttons: [
         FunButton(
+          onTap: () => context.pop(),
+          text: locals.externalDonationsBulkDeleteModalCancel,
+          analyticsEvent: AnalyticsEventName
+              .externalDonationsBulkDeleteCancelClicked
+              .toEvent(),
+        ),
+        FunButton(
           onTap: () async {
             context.pop();
             await cubit.confirmBulkDelete();
           },
           text: locals.externalDonationsBulkDeleteModalConfirm,
+          variant: FunButtonVariant.destructiveSecondary,
+          fullBorder: true,
           analyticsEvent: AnalyticsEventName
               .externalDonationsBulkDeleteConfirmClicked
-              .toEvent(),
-        ),
-        FunButton(
-          onTap: () => context.pop(),
-          text: locals.externalDonationsBulkDeleteModalCancel,
-          variant: FunButtonVariant.secondary,
-          analyticsEvent: AnalyticsEventName
-              .externalDonationsBulkDeleteCancelClicked
               .toEvent(),
         ),
       ],

--- a/lib/features/external_donations/detail/widgets/stop_recording_modal.dart
+++ b/lib/features/external_donations/detail/widgets/stop_recording_modal.dart
@@ -19,20 +19,21 @@ class StopRecordingModal {
       closeAction: () => context.pop(),
       buttons: [
         FunButton(
+          onTap: () => context.pop(),
+          text: locals.externalDonationsStopModalCancel,
+          analyticsEvent:
+              AnalyticsEventName.externalDonationsStopCancelClicked.toEvent(),
+        ),
+        FunButton(
           onTap: () async {
             context.pop();
             await onConfirm();
           },
           text: locals.externalDonationsStopModalConfirm,
+          variant: FunButtonVariant.destructiveSecondary,
+          fullBorder: true,
           analyticsEvent:
               AnalyticsEventName.externalDonationsStopConfirmClicked.toEvent(),
-        ),
-        FunButton(
-          onTap: () => context.pop(),
-          text: locals.externalDonationsStopModalCancel,
-          variant: FunButtonVariant.secondary,
-          analyticsEvent:
-              AnalyticsEventName.externalDonationsStopCancelClicked.toEvent(),
         ),
       ],
     ).show(context, isDismissible: true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates confirmation modals in the external donations detail flow so button styles match the design spec:

- **No / keep / dismiss** → primary (green)
- **Yes / confirm destructive action** → `destructiveSecondary` (error secondary)

## Changes

- `ExternalDonationDeleteModal` — delete whole donation
- `ExternalDonationBulkDeleteModal` — bulk delete selected records
- `StopRecordingModal` — stop recording confirmation

The safe dismiss action is shown first (matching the gift aid deactivate dialog pattern), with the destructive confirm action below.

## Linear

Closes ENG-653 (comment feedback on button styling)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-653](https://linear.app/givt/issue/ENG-653/implement-manage-an-external-donation)

<div><a href="https://cursor.com/agents/bc-04d77526-4777-42e4-9a70-c26af67fb593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04d77526-4777-42e4-9a70-c26af67fb593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

