### PR TITLE
ENG-744 Fix outlined icons in Account settings Personal details

### DIFF
--- a/lib/features/account_details/pages/personal_info_edit_page.dart
+++ b/lib/features/account_details/pages/personal_info_edit_page.dart
@@ -175,7 +175,11 @@ class _PersonalDetailsSection extends StatelessWidget {
         ),
         AccountSettingsListItem(
           value: '${user.firstName} ${user.lastName}',
-          leading: FaIcon(FontAwesomeIcons.user, size: 20, color: iconColor),
+          leading: FaIcon(
+            FontAwesomeIcons.solidUser,
+            size: 20,
+            color: iconColor,
+          ),
           analyticsEvent: AnalyticsEventName.onInfoRowClicked.toEvent(
             parameters: {'row_type': 'name'},
           ),
@@ -188,7 +192,11 @@ class _PersonalDetailsSection extends StatelessWidget {
         ),
         AccountSettingsListItem(
           value: user.email,
-          leading: FaIcon(FontAwesomeIcons.envelope, size: 20, color: iconColor),
+          leading: FaIcon(
+            FontAwesomeIcons.solidEnvelope,
+            size: 20,
+            color: iconColor,
+          ),
           analyticsEvent: AnalyticsEventName.onInfoRowClicked.toEvent(
             parameters: {'row_type': 'email'},
           ),
@@ -201,7 +209,11 @@ class _PersonalDetailsSection extends StatelessWidget {
               '${user.address}\n${user.postalCode} ${user.city}, '
               '${Country.getCountry(user.country, locals)}',
           maxLines: 3,
-          leading: FaIcon(FontAwesomeIcons.house, size: 20, color: iconColor),
+          leading: FaIcon(
+            FontAwesomeIcons.solidHouse,
+            size: 20,
+            color: iconColor,
+          ),
           analyticsEvent: AnalyticsEventName.onInfoRowClicked.toEvent(
             parameters: {'row_type': 'address'},
           ),


### PR DESCRIPTION
## Summary

- Updated name, email, and address icons in the Personal details section (`_PersonalDetailsSection`) to use filled Font Awesome variants (`solidUser`, `solidEnvelope`, `solidHouse`)
- Phone and bank icons remain unchanged
- Aligns Personal details icons with the filled-icon pattern used elsewhere (e.g. registration mandate flow)

Linear: https://linear.app/givt/issue/ENG-744

## Test plan

**Commands run:**
- `flutter analyze lib/features/account_details/pages/personal_info_edit_page.dart` — no issues
- `flutter test test/features/account_details/` — 12/12 passed (1 flaky parallel-order failure in `resetPersonalInfoEditSheetOnDismiss` when run with full suite; passes in isolation)
- `flutter test` — 146 tests, 1 pre-existing flaky failure in same test when run in parallel

**Reviewer validation:**
- Open Account settings → Personal details and confirm name, email, and address icons are filled/solid
- Confirm phone and bank icons are unchanged and visually consistent with the updated icons


Made with [Cursor](https://cursor.com)