### PR TITLE
ENG-745 Fix back navigation from account settings sub-pages

### DIFF
--- a/lib/features/account_details/account_settings_actions.dart
+++ b/lib/features/account_details/account_settings_actions.dart
@@ -49,7 +49,7 @@ abstract final class AccountSettingsActions {
       context,
       checkAuthRequest: CheckAuthRequest(
         navigate: (context) async {
-          context.goNamed(Pages.platformContribution.name);
+          context.pushNamed(Pages.platformContribution.name);
           unawaited(
             AnalyticsHelper.logEvent(
               eventName: AnalyticsEventName.platformContributionNavigationClicked,
@@ -83,14 +83,14 @@ abstract final class AccountSettingsActions {
     final user = context.read<AuthCubit>().state.user;
 
     if (user.tempUser) {
-      context.goNamed(Pages.unregister.name);
+      context.pushNamed(Pages.unregister.name);
       return Future.value();
     }
 
     return AuthUtils.checkToken(
       context,
       checkAuthRequest: CheckAuthRequest(
-        navigate: (context) async => context.goNamed(Pages.unregister.name),
+        navigate: (context) async => context.pushNamed(Pages.unregister.name),
       ),
     );
   }


### PR DESCRIPTION
## Summary

Fixes back navigation from **Platform contribution** and **Terminate account** so the user returns to Account settings instead of the navbar/home.

- Changed `context.goNamed` to `context.pushNamed` in `AccountSettingsActions.openPlatformContribution` and `AccountSettingsActions.openUnregister` so the navigation stack is preserved.

Linear: https://linear.app/givt/issue/ENG-745

## Test plan

**Commands run:**
- `flutter analyze lib/features/account_details/account_settings_actions.dart`
- `flutter test --coverage --test-randomize-ordering-seed random` (146 passed; 1 pre-existing flaky failure in `personal_info_edit_bottom_sheets_test.dart` — `MissingPluginException` for `shared_preferences`, unrelated to this change)

**Reviewer validation:**
- From Account settings, open Platform contribution → back returns to Account settings (not navbar).
- From Account settings, open Terminate account → back returns to Account settings (not navbar).
- Manage Gift Aid navigation still works (already uses `pushNamed`).


Made with [Cursor](https://cursor.com)