### PR TITLE
ENG-796 Fix donation frequency hint banner

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -132,15 +132,34 @@ class _AppState extends State<App> {
   }
 }
 
-class _AppView extends StatelessWidget {
+class _AppView extends StatefulWidget {
   const _AppView({required this.themeData});
 
   final ThemeData themeData;
 
   @override
+  State<_AppView> createState() => _AppViewState();
+}
+
+class _AppViewState extends State<_AppView> {
+  Locale? _momentLocale;
+
+  void _syncMomentLocalization(Locale locale) {
+    if (_momentLocale == locale) return;
+    _momentLocale = locale;
+
+    final momentLocalization =
+        MomentLocalizations.byLocale(locale.toLanguageTag()) ??
+        MomentLocalizations.byLanguage(locale.languageCode);
+    if (momentLocalization != null) {
+      Moment.setGlobalLocalization(momentLocalization);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return MaterialApp.router(
-      theme: themeData,
+      theme: widget.themeData,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       localeResolutionCallback: Util.resolveLocale,
@@ -148,13 +167,7 @@ class _AppView extends StatelessWidget {
       routeInformationParser: AppRouter.router.routeInformationParser,
       routerDelegate: AppRouter.router.routerDelegate,
       builder: (context, child) {
-        final locale = Localizations.localeOf(context);
-        final momentLocalization =
-            MomentLocalizations.byLocale(locale.toLanguageTag()) ??
-            MomentLocalizations.byLanguage(locale.languageCode);
-        if (momentLocalization != null) {
-          Moment.setGlobalLocalization(momentLocalization);
-        }
+        _syncMomentLocalization(Localizations.localeOf(context));
 
         final mediaQueryData = MediaQuery.of(context);
         final currentScale = mediaQueryData.textScaler.scale(1.0);

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -17,6 +17,7 @@ import 'package:givt_app/l10n/arb/app_localizations.dart';
 import 'package:givt_app/shared/bloc/infra/infra_cubit.dart';
 import 'package:givt_app/shared/widgets/theme/app_theme_switcher.dart';
 import 'package:givt_app/utils/utils.dart';
+import 'package:moment_dart/moment_dart.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 class App extends StatefulWidget {
@@ -147,6 +148,14 @@ class _AppView extends StatelessWidget {
       routeInformationParser: AppRouter.router.routeInformationParser,
       routerDelegate: AppRouter.router.routerDelegate,
       builder: (context, child) {
+        final locale = Localizations.localeOf(context);
+        final momentLocalization =
+            MomentLocalizations.byLocale(locale.toLanguageTag()) ??
+            MomentLocalizations.byLanguage(locale.languageCode);
+        if (momentLocalization != null) {
+          Moment.setGlobalLocalization(momentLocalization);
+        }
+
         final mediaQueryData = MediaQuery.of(context);
         final currentScale = mediaQueryData.textScaler.scale(1.0);
         final clampedScale = currentScale.clamp(1.0, 1.2);

--- a/lib/features/recurring_donations/create/presentation/widgets/duration_options.dart
+++ b/lib/features/recurring_donations/create/presentation/widgets/duration_options.dart
@@ -9,8 +9,9 @@ import 'package:givt_app/features/recurring_donations/overview/models/recurring_
 import 'package:givt_app/features/recurring_donations/create/presentation/constants/string_keys.dart';
 import 'package:givt_app/features/recurring_donations/create/presentation/models/set_duration_ui_model.dart';
 import 'package:givt_app/l10n/l10n.dart';
+import 'package:givt_app/utils/recurring_donation_date_utils.dart';
+import 'package:givt_app/utils/util.dart';
 import 'package:intl/intl.dart';
-import 'package:moment_dart/moment_dart.dart';
 
 class DurationOptions extends StatefulWidget {
   const DurationOptions({
@@ -167,13 +168,16 @@ class _DurationOptionsState extends State<DurationOptions> {
       
       switch (optionKey) {
         case RecurringDonationStringKeys.whenIDecide:
-          final day = _getDayWithOrdinal(widget.uiModel.startDate!);
+          final message = RecurringDonationDateUtils.buildEndDateHintMessage(
+            l10n: context.l10n,
+            frequency: widget.frequency!,
+            startDate: widget.uiModel.startDate!,
+            locale: Util.getLanguageTageFromLocale(context),
+          );
+          if (message.isEmpty) return;
           _showSnackbarWithKeyboardCheck(
             context,
-            context.l10n.recurringDonationsEndDateHintEveryMonth(
-              day,
-              day,
-            ),
+            message,
             const Icon(
               Icons.calendar_today,
               color: Color(0xFF234B5E),
@@ -435,10 +439,4 @@ DateTime _calculateEndDateFromNumberOfDonations(
     case overview.Frequency.none:
       return startDate;
   }
-}
-
-String _getDayWithOrdinal(DateTime date) {
-  // Use localized ordinal formatting from the current locale
-  final now = date.toMoment();
-  return now.format('Do');
 }

--- a/lib/features/recurring_donations/create/presentation/widgets/duration_options.dart
+++ b/lib/features/recurring_donations/create/presentation/widgets/duration_options.dart
@@ -184,6 +184,7 @@ class _DurationOptionsState extends State<DurationOptions> {
               size: 32,
             ),
           );
+          break;
         case RecurringDonationStringKeys.afterNumberOfDonations:
           final numberOfDonations = int.tryParse(widget.uiModel.numberOfDonations) ?? 1;
           final calculatedEndDate = _calculateEndDateFromNumberOfDonations(
@@ -206,6 +207,7 @@ class _DurationOptionsState extends State<DurationOptions> {
               size: 32,
             ),
           );
+          break;
         case RecurringDonationStringKeys.onSpecificDate:
           final endDate = widget.uiModel.endDate ?? DateTime.now();
           final message = _buildSnackbarMessage(
@@ -223,6 +225,7 @@ class _DurationOptionsState extends State<DurationOptions> {
               size: 32,
             ),
           );
+          break;
       }
     });
   }

--- a/lib/utils/recurring_donation_date_utils.dart
+++ b/lib/utils/recurring_donation_date_utils.dart
@@ -1,0 +1,75 @@
+import 'package:givt_app/features/recurring_donations/overview/models/recurring_donation.dart'
+    as overview;
+import 'package:givt_app/l10n/arb/app_localizations.dart';
+import 'package:intl/intl.dart';
+import 'package:moment_dart/moment_dart.dart';
+
+/// Localized date/day formatting for recurring donation hint banners.
+abstract final class RecurringDonationDateUtils {
+  /// Returns a localized weekday or day-of-month string for hint copy.
+  static String getLocalizedRecurringHintDay(
+    DateTime date,
+    overview.Frequency frequency,
+    String locale,
+  ) {
+    switch (frequency) {
+      case overview.Frequency.weekly:
+        return DateFormat('EEEE', locale).format(date);
+      case overview.Frequency.monthly:
+      case overview.Frequency.quarterly:
+      case overview.Frequency.halfYearly:
+      case overview.Frequency.yearly:
+        return _localizedDayOfMonth(date, locale);
+      case overview.Frequency.daily:
+      case overview.Frequency.none:
+        return '';
+    }
+  }
+
+  static String buildEndDateHintMessage({
+    required AppLocalizations l10n,
+    required overview.Frequency frequency,
+    required DateTime startDate,
+    required String locale,
+  }) {
+    final localizedDay =
+        getLocalizedRecurringHintDay(startDate, frequency, locale);
+
+    switch (frequency) {
+      case overview.Frequency.weekly:
+        return l10n.recurringDonationsEndDateHintEveryWeek(localizedDay);
+      case overview.Frequency.monthly:
+        return l10n.recurringDonationsEndDateHintEveryMonth(
+          localizedDay,
+          localizedDay,
+        );
+      case overview.Frequency.quarterly:
+        return l10n.recurringDonationsEndDateHintEveryXMonth(localizedDay, '3');
+      case overview.Frequency.halfYearly:
+        return l10n.recurringDonationsEndDateHintEveryXMonth(localizedDay, '6');
+      case overview.Frequency.yearly:
+        final month = DateFormat('MMMM', locale).format(startDate);
+        return l10n.recurringDonationsEndDateHintEveryYear(localizedDay, month);
+      case overview.Frequency.daily:
+      case overview.Frequency.none:
+        return '';
+    }
+  }
+
+  static String _localizedDayOfMonth(DateTime date, String locale) {
+    final languageCode = locale.split(RegExp('[-_]')).first;
+    if (languageCode == 'nl') {
+      return '${date.day}e';
+    }
+
+    final momentLocalization =
+        MomentLocalizations.byLocale(locale) ??
+        MomentLocalizations.byLanguage(languageCode);
+
+    if (momentLocalization != null) {
+      return date.toMoment(localization: momentLocalization).format('Do');
+    }
+
+    return date.toMoment().format('Do');
+  }
+}

--- a/test/utils/recurring_donation_date_utils_test.dart
+++ b/test/utils/recurring_donation_date_utils_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/features/recurring_donations/overview/models/recurring_donation.dart'
+    as overview;
+import 'package:givt_app/l10n/arb/app_localizations_en.dart';
+import 'package:givt_app/l10n/arb/app_localizations_nl.dart';
+import 'package:givt_app/utils/recurring_donation_date_utils.dart';
+import 'package:intl/date_symbol_data_local.dart';
+
+void main() {
+  final startDate = DateTime(2026, 6, 24);
+
+  setUpAll(() async {
+    await initializeDateFormatting('nl');
+    await initializeDateFormatting('en');
+  });
+
+  group('getLocalizedRecurringHintDay', () {
+    test('returns Dutch ordinal day for monthly frequency', () {
+      expect(
+        RecurringDonationDateUtils.getLocalizedRecurringHintDay(
+          startDate,
+          overview.Frequency.monthly,
+          'nl',
+        ),
+        '24e',
+      );
+    });
+
+    test('returns English ordinal day for monthly frequency', () {
+      expect(
+        RecurringDonationDateUtils.getLocalizedRecurringHintDay(
+          startDate,
+          overview.Frequency.monthly,
+          'en',
+        ),
+        '24th',
+      );
+    });
+
+    test('returns localized weekday for weekly frequency', () {
+      expect(
+        RecurringDonationDateUtils.getLocalizedRecurringHintDay(
+          startDate,
+          overview.Frequency.weekly,
+          'nl',
+        ),
+        'woensdag',
+      );
+    });
+  });
+
+  group('buildEndDateHintMessage', () {
+    test('uses weekly copy when frequency is weekly', () {
+      final l10n = AppLocalizationsNl();
+
+      final message = RecurringDonationDateUtils.buildEndDateHintMessage(
+        l10n: l10n,
+        frequency: overview.Frequency.weekly,
+        startDate: startDate,
+        locale: 'nl',
+      );
+
+      expect(
+        message,
+        'Je donatie vindt elke week plaats op de woensdag',
+      );
+    });
+
+    test('uses monthly copy with Dutch ordinal when frequency is monthly', () {
+      final l10n = AppLocalizationsNl();
+
+      final message = RecurringDonationDateUtils.buildEndDateHintMessage(
+        l10n: l10n,
+        frequency: overview.Frequency.monthly,
+        startDate: startDate,
+        locale: 'nl',
+      );
+
+      expect(
+        message,
+        'Je donatie vindt plaats op de 24e van elke maand',
+      );
+    });
+
+    test('uses English ordinal for monthly frequency', () {
+      final l10n = AppLocalizationsEn();
+
+      final message = RecurringDonationDateUtils.buildEndDateHintMessage(
+        l10n: l10n,
+        frequency: overview.Frequency.monthly,
+        startDate: startDate,
+        locale: 'en',
+      );
+
+      expect(
+        message,
+        'Your donation will occur on the 24th of every month',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Fix the recurring donation duration snackbar always showing the monthly hint regardless of selected frequency.
- Add `RecurringDonationDateUtils` for localized weekday/ordinal formatting (Dutch `24e`, English `24th`, etc.).
- Initialize `moment_dart` global localization from the app locale for supported languages.

Linear: https://linear.app/givt/issue/ENG-796/incorrect-banner-message-when-changing-donation-frequency

## Test plan
Commands run:
- `flutter analyze lib/utils/recurring_donation_date_utils.dart lib/features/recurring_donations/create/presentation/widgets/duration_options.dart lib/app/app.dart`
- `flutter test test/utils/recurring_donation_date_utils_test.dart`
- `flutter test --coverage --test-randomize-ordering-seed random` (163 passed; 1 pre-existing failure in `personal_info_edit_bottom_sheets_test.dart`)

Reviewer validation:
- In recurring donation step 3 (set duration), select weekly frequency on step 2, pick a start date, then choose "When I decide" — snackbar should show the weekly hint with a localized weekday.
- With monthly frequency, Dutch locale should show `24e` (not `24th`) in the monthly hint.
- English/German/Spanish ordinals should use locale-appropriate formatting via `moment_dart`.


Made with [Cursor](https://cursor.com)