### PR TITLE
ENG-852 Update Dutch copy on For You screen

### DIFF
--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -853,7 +853,7 @@
   "forYouQrCodeTitle": "QR-code",
   "forYouQrCodeSubtitle": "Scanne einen Givt-QR-Code",
   "forYouCollectionDeviceTitle": "Sammelgerät",
-  "forYouCollectionDeviceSubtitle": "Gib, wenn das Schild oder die Tasche vorbeikommt",
+  "forYouCollectionDeviceSubtitle": "Gib, wenn die Kollektentasche oder -platte vorbeikommt",
   "forYouGoalsCountCollectionsOne": "1 Sammelziel",
   "forYouGoalsCountCollectionsMany": "{count} Sammelziele",
   "@forYouGoalsCountCollectionsMany": {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -850,7 +850,7 @@
   "forYouQrCodeTitle": "QR code",
   "forYouQrCodeSubtitle": "Scan a Givt QR code",
   "forYouCollectionDeviceTitle": "Collection device",
-  "forYouCollectionDeviceSubtitle": "Give when the plate or bag passes by",
+  "forYouCollectionDeviceSubtitle": "Give when the collection bag or plate passes by",
   "forYouGoalsCountCollectionsOne": "1 Collection Goal",
   "forYouGoalsCountCollectionsMany": "{count} Collection Goals",
   "@forYouGoalsCountCollectionsMany": {

--- a/lib/l10n/arb/app_en_US.arb
+++ b/lib/l10n/arb/app_en_US.arb
@@ -846,7 +846,7 @@
   "forYouQrCodeTitle": "QR-code",
   "forYouQrCodeSubtitle": "Scan a Givt QR code",
   "forYouCollectionDeviceTitle": "Collection device",
-  "forYouCollectionDeviceSubtitle": "Give when the plate or bag passes by",
+  "forYouCollectionDeviceSubtitle": "Give when the collection bag or plate passes by",
   "forYouGoalsCountCollectionsOne": "1 Collection Goal",
   "forYouGoalsCountCollectionsMany": "{count} Collection Goals",
   "@forYouGoalsCountCollectionsMany": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -853,7 +853,7 @@
   "forYouQrCodeTitle": "QR-code",
   "forYouQrCodeSubtitle": "Escanea un código QR de Givt",
   "forYouCollectionDeviceTitle": "Dispositivo de recaudación",
-  "forYouCollectionDeviceSubtitle": "Dona cuando pase la placa o la bolsa",
+  "forYouCollectionDeviceSubtitle": "Dona cuando pase la bolsa de colecta o la placa",
   "forYouGoalsCountCollectionsOne": "1 objetivo de colecta",
   "forYouGoalsCountCollectionsMany": "{count} objetivos de colecta",
   "@forYouGoalsCountCollectionsMany": {

--- a/lib/l10n/arb/app_es_419.arb
+++ b/lib/l10n/arb/app_es_419.arb
@@ -849,7 +849,7 @@
   "forYouQrCodeTitle": "QR-code",
   "forYouQrCodeSubtitle": "Escanea un código QR de Givt",
   "forYouCollectionDeviceTitle": "Dispositivo de recaudación",
-  "forYouCollectionDeviceSubtitle": "Dona cuando pase la placa o la bolsa",
+  "forYouCollectionDeviceSubtitle": "Dona cuando pase la bolsa de colecta o la placa",
   "forYouGoalsCountCollectionsOne": "1 objetivo de colecta",
   "forYouGoalsCountCollectionsMany": "{count} objetivos de colecta",
   "@forYouGoalsCountCollectionsMany": {

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -2384,7 +2384,7 @@ abstract class AppLocalizations {
   /// No description provided for @forYouCollectionDeviceSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'Give when the plate or bag passes by'**
+  /// **'Give when the collection bag or plate passes by'**
   String get forYouCollectionDeviceSubtitle;
 
   /// No description provided for @forYouGoalsCountCollectionsOne.

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -1299,7 +1299,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get forYouCollectionDeviceSubtitle =>
-      'Gib, wenn das Schild oder die Tasche vorbeikommt';
+      'Gib, wenn die Kollektentasche oder -platte vorbeikommt';
 
   @override
   String get forYouGoalsCountCollectionsOne => '1 Sammelziel';

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -1289,7 +1289,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get forYouCollectionDeviceSubtitle =>
-      'Give when the plate or bag passes by';
+      'Give when the collection bag or plate passes by';
 
   @override
   String get forYouGoalsCountCollectionsOne => '1 Collection Goal';
@@ -4562,7 +4562,7 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
 
   @override
   String get forYouCollectionDeviceSubtitle =>
-      'Give when the plate or bag passes by';
+      'Give when the collection bag or plate passes by';
 
   @override
   String get forYouGoalsCountCollectionsOne => '1 Collection Goal';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -1289,7 +1289,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get forYouCollectionDeviceSubtitle =>
-      'Dona cuando pase la placa o la bolsa';
+      'Dona cuando pase la bolsa de colecta o la placa';
 
   @override
   String get forYouGoalsCountCollectionsOne => '1 objetivo de colecta';
@@ -4583,7 +4583,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get forYouCollectionDeviceSubtitle =>
-      'Dona cuando pase la placa o la bolsa';
+      'Dona cuando pase la bolsa de colecta o la placa';
 
   @override
   String get forYouGoalsCountCollectionsOne => '1 objetivo de colecta';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -1294,7 +1294,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get forYouCollectionDeviceSubtitle =>
-      'Geef wanneer de plaat of tas langskomt';
+      'Geef wanneer de collectezak of -plaat langskomt';
 
   @override
   String get forYouGoalsCountCollectionsOne => '1 collectedoel';

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -853,7 +853,7 @@
   "forYouQrCodeTitle": "QR-code",
   "forYouQrCodeSubtitle": "Scan een Givt-QR-code",
   "forYouCollectionDeviceTitle": "Collectemiddel",
-  "forYouCollectionDeviceSubtitle": "Geef wanneer de plaat of tas langskomt",
+  "forYouCollectionDeviceSubtitle": "Geef wanneer de collectezak of -plaat langskomt",
   "forYouGoalsCountCollectionsOne": "1 collectedoel",
   "forYouGoalsCountCollectionsMany": "{count} collectedoelen",
   "@forYouGoalsCountCollectionsMany": {


### PR DESCRIPTION
## Summary

Updates the `forYouCollectionDeviceSubtitle` i18n key on the For You screen to use standard collection bag/plate terminology:

- **NL:** `Geef wanneer de collectezak of -plaat langskomt`
- **EN/EN-US:** `Give when the collection bag or plate passes by`
- **DE, ES, ES-419:** Auto-translated to match the improved terminology

Linear: https://linear.app/givt/issue/ENG-852/update-dutch-copy-on-for-you-screen

## Test plan

Commands run:
- `flutter gen-l10n`
- `flutter analyze` (pre-existing info-level findings only)
- `flutter test --coverage --test-randomize-ordering-seed random` (163 passed; 1 pre-existing flaky failure on `develop` unrelated to this change)

Reviewer validation:
- On the For You screen (second tab of Home/Give), the "Collectemiddel" / collection device tile subtitle shows the updated copy in Dutch and other locales.

Made with [Cursor](https://cursor.com)