### PR TITLE
Fix Personal Summary refresh after giving goal change (ENG-891)

### DIFF
--- a/lib/features/personal_summary/giving_goal_setup/pages/giving_goal_setup_page.dart
+++ b/lib/features/personal_summary/giving_goal_setup/pages/giving_goal_setup_page.dart
@@ -124,10 +124,14 @@ class _GivingGoalSetupPageState extends State<GivingGoalSetupPage> {
         return;
       }
 
-      context.pushReplacementNamed(
+      await context.pushNamed(
         Pages.givingGoalSetupSuccess.name,
         extra: _year,
       );
+      if (!mounted) {
+        return;
+      }
+      context.pop(true);
     } on GivtServerFailure {
       _showError(context, isNoInternet: false);
       if (mounted) {
@@ -162,7 +166,7 @@ class _GivingGoalSetupPageState extends State<GivingGoalSetupPage> {
       if (!mounted) {
         return;
       }
-      context.pop();
+      context.pop(true);
     } on GivtServerFailure {
       _showError(context, isNoInternet: false);
       if (mounted) {

--- a/lib/features/personal_summary/pages/personal_summary_page.dart
+++ b/lib/features/personal_summary/pages/personal_summary_page.dart
@@ -107,7 +107,7 @@ class _PersonalSummaryPageState extends State<PersonalSummaryPage> {
 
   Future<void> _navigateToGivingGoalSetup(BuildContext context) async {
     final goal = _uiModel?.givingGoal ?? const GivingGoal.empty();
-    await context.pushNamed(
+    final goalChanged = await context.pushNamed<bool>(
       Pages.givingGoalSetup.name,
       extra: GivingGoalSetupExtra(
         initialYearlyAmount:
@@ -115,7 +115,7 @@ class _PersonalSummaryPageState extends State<PersonalSummaryPage> {
         goalId: goal.id,
       ),
     );
-    if (context.mounted) {
+    if (context.mounted && (goalChanged ?? false)) {
       await _cubit.refreshGivingGoal();
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes test feedback on ENG-891: the My giving / Personal Summary screen did not refresh after setting or editing a giving goal.

## Root cause

The giving goal setup flow used `pushReplacementNamed` to navigate to the success screen. That broke the `await context.pushNamed(...)` on Personal Summary, so `refreshGivingGoal()` never ran when the user tapped Done.

## Fix

- Navigate to the success screen with `pushNamed` (same pattern as Gift Aid success flows).
- Pop the setup screen with `true` after the success screen is dismissed.
- Pop with `true` after removing a goal as well.
- Refresh the giving goal on Personal Summary only when the setup flow returns a positive result.

## Test plan

- [ ] Set a new giving goal from Personal Summary → confirm → Done → goal card appears with correct amount
- [ ] Edit an existing giving goal → confirm → Done → goal card shows updated amount
- [ ] Remove a giving goal → Personal Summary hides goal card and shows "Set my giving goal"
- [ ] Dismiss setup with X → Personal Summary does not unnecessarily refetch

Linear: ENG-891
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-891](https://linear.app/givt/issue/ENG-891/implement-set-up-giving-goal-flow)

<div><a href="https://cursor.com/agents/bc-f4b3f929-45a3-4156-810a-c8bd6ed1efad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4b3f929-45a3-4156-810a-c8bd6ed1efad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

