### PR TITLE
ENG-968: Pledge manage screen and edit bottom sheets

### DIFF
--- a/lib/core/enums/analytics_event_name.dart
+++ b/lib/core/enums/analytics_event_name.dart
@@ -630,6 +630,15 @@ enum AnalyticsEventName {
   pledgesDetailOpened('pledges_detail_opened'),
   pledgesDetailGiveClicked('pledges_detail_give_clicked'),
   pledgesDetailEditClicked('pledges_detail_edit_clicked'),
+  pledgesManageOpened('pledges_manage_opened'),
+  pledgesManageGoalEditClicked('pledges_manage_goal_edit_clicked'),
+  pledgesManageFrequencyEditClicked('pledges_manage_frequency_edit_clicked'),
+  pledgesManageGivingMethodEditClicked(
+    'pledges_manage_giving_method_edit_clicked',
+  ),
+  pledgesEditAmountSaveClicked('pledges_edit_amount_save_clicked'),
+  pledgesEditFrequencySaveClicked('pledges_edit_frequency_save_clicked'),
+  pledgesEditGivingMethodSaveClicked('pledges_edit_giving_method_save_clicked'),
   menuNavigationRecurringDonationClicked(
     'menu_navigation_recurring_donation_clicked',
   ),

--- a/lib/core/network/api_service.dart
+++ b/lib/core/network/api_service.dart
@@ -684,6 +684,31 @@ class APIService {
     return decodedBody['item'] as Map<String, dynamic>;
   }
 
+  Future<bool> updatePledge(
+    String pledgeId,
+    Map<String, dynamic> body,
+  ) async {
+    final url = Uri.https(_apiURL, '/givtservice/v1/Pledge/$pledgeId');
+
+    final response = await client.put(
+      url,
+      body: jsonEncode(body),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    );
+
+    if (response.statusCode >= 300) {
+      throw GivtServerFailure(
+        statusCode: response.statusCode,
+        body: response.body.isNotEmpty
+            ? jsonDecode(response.body) as Map<String, dynamic>
+            : null,
+      );
+    }
+    return _decodeItemBool(response.body);
+  }
+
   Future<List<dynamic>> fetchExternalDonations() async {
     final url = Uri.https(_apiURL, '/givtservice/v1/externaldonations');
 

--- a/lib/core/network/api_service.dart
+++ b/lib/core/network/api_service.dart
@@ -1001,7 +1001,14 @@ class APIService {
       return true;
     }
     final decodedBody = jsonDecode(body) as Map<String, dynamic>;
-    return decodedBody['item'] as bool? ?? false;
+    final isError = decodedBody['isError'] as bool? ?? false;
+    if (isError) {
+      return false;
+    }
+    if (decodedBody.containsKey('item')) {
+      return decodedBody['item'] as bool? ?? false;
+    }
+    return true;
   }
 
   Future<bool> updateNotificationId({

--- a/lib/features/pledges/detail/cubit/pledge_detail_cubit.dart
+++ b/lib/features/pledges/detail/cubit/pledge_detail_cubit.dart
@@ -19,7 +19,8 @@ class PledgeDetailCubit extends CommonCubit<PledgeDetailUIModel, dynamic> {
       await _repository.loadDetail(pledgeGroupId);
       if (isClosed) return;
 
-      if (_repository.getError() != null || _repository.getPledgeGroup() == null) {
+      if (_repository.getError() != null ||
+          _repository.getPledgeGroup() == null) {
         emitError(null);
         return;
       }
@@ -70,6 +71,6 @@ class PledgeDetailCubit extends CommonCubit<PledgeDetailUIModel, dynamic> {
     }
     final first = goals.first.frequency;
     final allSame = goals.every((goal) => goal.frequency == first);
-    return allSame ? first : goals.first.frequency;
+    return allSame ? first : null;
   }
 }

--- a/lib/features/pledges/detail/pages/pledge_detail_page.dart
+++ b/lib/features/pledges/detail/pages/pledge_detail_page.dart
@@ -10,9 +10,11 @@ import 'package:givt_app/features/pledges/detail/widgets/pledge_detail_goals_sec
 import 'package:givt_app/features/pledges/detail/widgets/pledge_detail_history_section.dart';
 import 'package:givt_app/features/pledges/detail/widgets/pledge_detail_summary_card.dart';
 import 'package:givt_app/features/pledges/detail/widgets/pledge_detail_summary_tiles.dart';
+import 'package:givt_app/features/pledges/manage/pages/pledge_manage_page.dart';
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/shared/design_system/design_system.dart';
 import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
+import 'package:givt_app/shared/widgets/extensions/route_extensions.dart';
 import 'package:givt_app/shared/widgets/fun_scaffold.dart';
 import 'package:givt_app/utils/analytics_helper.dart';
 import 'package:go_router/go_router.dart';
@@ -163,7 +165,10 @@ class _PledgeDetailPageState extends State<PledgeDetailPage> {
           fullBorder: true,
           analyticsEvent:
               AnalyticsEventName.pledgesDetailEditClicked.toEvent(),
-          onTap: () {},
+          onTap: () => Navigator.of(context).push(
+            PledgeManagePage(pledgeGroupId: widget.pledgeGroupId)
+                .toRoute(context),
+          ),
         ),
       ],
     );

--- a/lib/features/pledges/detail/pages/pledge_detail_page.dart
+++ b/lib/features/pledges/detail/pages/pledge_detail_page.dart
@@ -146,7 +146,10 @@ class _PledgeDetailPageState extends State<PledgeDetailPage> {
     );
   }
 
-  Widget _buildBottomActions(BuildContext context, PledgeDetailUIModel uiModel) {
+  Widget _buildBottomActions(
+    BuildContext context,
+    PledgeDetailUIModel uiModel,
+  ) {
     final locals = context.l10n;
     final campaignName = uiModel.group.pledgeGroupName;
 
@@ -154,8 +157,7 @@ class _PledgeDetailPageState extends State<PledgeDetailPage> {
       children: [
         FunButton(
           text: locals.pledgesDetailGiveButton(campaignName),
-          analyticsEvent:
-              AnalyticsEventName.pledgesDetailGiveClicked.toEvent(),
+          analyticsEvent: AnalyticsEventName.pledgesDetailGiveClicked.toEvent(),
           onTap: () {},
         ),
         const SizedBox(height: 12),
@@ -163,12 +165,17 @@ class _PledgeDetailPageState extends State<PledgeDetailPage> {
           text: locals.pledgesDetailEditButton,
           variant: FunButtonVariant.secondary,
           fullBorder: true,
-          analyticsEvent:
-              AnalyticsEventName.pledgesDetailEditClicked.toEvent(),
-          onTap: () => Navigator.of(context).push(
-            PledgeManagePage(pledgeGroupId: widget.pledgeGroupId)
-                .toRoute(context),
-          ),
+          analyticsEvent: AnalyticsEventName.pledgesDetailEditClicked.toEvent(),
+          onTap: () async {
+            final didUpdate = await Navigator.of(context).push(
+              PledgeManagePage(
+                pledgeGroupId: widget.pledgeGroupId,
+              ).toRoute(context),
+            );
+            if (didUpdate == true && mounted) {
+              await _cubit.init(widget.pledgeGroupId);
+            }
+          },
         ),
       ],
     );

--- a/lib/features/pledges/detail/repositories/pledge_detail_repository.dart
+++ b/lib/features/pledges/detail/repositories/pledge_detail_repository.dart
@@ -9,6 +9,13 @@ mixin PledgeDetailRepository {
   PledgeGroup? getPledgeGroup();
 
   Future<void> loadDetail(String pledgeGroupId);
+
+  Future<bool> updatePledge({
+    required String pledgeId,
+    double? amount,
+    String? frequency,
+    String? type,
+  });
 }
 
 class PledgeDetailRepositoryImpl with PledgeDetailRepository {
@@ -42,5 +49,29 @@ class PledgeDetailRepositoryImpl with PledgeDetailRepository {
     } finally {
       _isLoading = false;
     }
+  }
+
+  @override
+  Future<bool> updatePledge({
+    required String pledgeId,
+    double? amount,
+    String? frequency,
+    String? type,
+  }) async {
+    final body = <String, dynamic>{};
+    if (amount != null) {
+      body['amount'] = amount;
+    }
+    if (frequency != null) {
+      body['frequency'] = frequency;
+    }
+    if (type != null) {
+      body['type'] = type;
+    }
+
+    return _givtRepository.updatePledge(
+      pledgeId: pledgeId,
+      body: body,
+    );
   }
 }

--- a/lib/features/pledges/injection.dart
+++ b/lib/features/pledges/injection.dart
@@ -1,6 +1,7 @@
 import 'package:givt_app/app/injection/injection.dart';
 import 'package:givt_app/features/pledges/detail/cubit/pledge_detail_cubit.dart';
 import 'package:givt_app/features/pledges/detail/repositories/pledge_detail_repository.dart';
+import 'package:givt_app/features/pledges/manage/cubit/pledge_manage_cubit.dart';
 import 'package:givt_app/features/pledges/overview/cubit/pledges_overview_cubit.dart';
 import 'package:givt_app/features/pledges/overview/repositories/pledges_overview_repository.dart';
 import 'package:givt_app/shared/repositories/givt_repository.dart';
@@ -24,6 +25,11 @@ void registerPledgesDependencies() {
     )
     ..registerFactory<PledgeDetailCubit>(
       () => PledgeDetailCubit(
+        getIt<PledgeDetailRepository>(),
+      ),
+    )
+    ..registerFactory<PledgeManageCubit>(
+      () => PledgeManageCubit(
         getIt<PledgeDetailRepository>(),
       ),
     );

--- a/lib/features/pledges/injection.dart
+++ b/lib/features/pledges/injection.dart
@@ -13,7 +13,7 @@ void registerPledgesDependencies() {
         getIt<GivtRepository>(),
       ),
     )
-    ..registerLazySingleton<PledgeDetailRepository>(
+    ..registerFactory<PledgeDetailRepository>(
       () => PledgeDetailRepositoryImpl(
         getIt<GivtRepository>(),
       ),

--- a/lib/features/pledges/manage/cubit/pledge_manage_cubit.dart
+++ b/lib/features/pledges/manage/cubit/pledge_manage_cubit.dart
@@ -24,6 +24,9 @@ class PledgeManageCubit
   }
 
   bool _isSaving = false;
+  bool _hasUpdates = false;
+
+  bool get hasUpdates => _hasUpdates;
 
   Future<void> init(String pledgeGroupId) async {
     emitLoading();
@@ -31,7 +34,8 @@ class PledgeManageCubit
       await _repository.loadDetail(pledgeGroupId);
       if (isClosed) return;
 
-      if (_repository.getError() != null || _repository.getPledgeGroup() == null) {
+      if (_repository.getError() != null ||
+          _repository.getPledgeGroup() == null) {
         emitError(null);
         return;
       }
@@ -51,6 +55,10 @@ class PledgeManageCubit
     required PledgeManageField field,
     PledgeGoal? goal,
   }) {
+    if (_isSaving) {
+      return;
+    }
+
     switch (field) {
       case PledgeManageField.goalAmount:
         if (goal == null) {
@@ -132,6 +140,10 @@ class PledgeManageCubit
     required Future<bool> Function() update,
     required String methodName,
   }) async {
+    if (_isSaving) {
+      return;
+    }
+
     final group = _repository.getPledgeGroup();
     if (group == null) {
       return;
@@ -145,9 +157,13 @@ class PledgeManageCubit
       if (isClosed) return;
 
       if (!success) {
+        await _repository.loadDetail(group.pledgeGroupId);
+        if (isClosed) return;
+
         _isSaving = false;
         emitCustom(const PledgeManageCustom.manageUpdateFailed());
-        emitData(_createUIModel(group));
+        final refreshedGroup = _repository.getPledgeGroup() ?? group;
+        emitData(_createUIModel(refreshedGroup));
         return;
       }
 
@@ -163,6 +179,7 @@ class PledgeManageCubit
       }
 
       _isSaving = false;
+      _hasUpdates = true;
       emitCustom(const PledgeManageCustom.manageUpdateSucceeded());
       emitData(_createUIModel(refreshedGroup));
     } catch (error) {
@@ -215,6 +232,6 @@ class PledgeManageCubit
     }
     final first = goals.first.frequency;
     final allSame = goals.every((goal) => goal.frequency == first);
-    return allSame ? first : goals.first.frequency;
+    return allSame ? first : null;
   }
 }

--- a/lib/features/pledges/manage/cubit/pledge_manage_cubit.dart
+++ b/lib/features/pledges/manage/cubit/pledge_manage_cubit.dart
@@ -1,0 +1,220 @@
+import 'package:givt_app/core/logging/logging_service.dart';
+import 'package:givt_app/features/pledges/detail/cubit/pledge_detail_cubit.dart';
+import 'package:givt_app/features/pledges/detail/pledge_detail_history_builder.dart';
+import 'package:givt_app/features/pledges/detail/repositories/pledge_detail_repository.dart';
+import 'package:givt_app/features/pledges/manage/models/pledge_manage_field.dart';
+import 'package:givt_app/features/pledges/shared/models/pledge.dart';
+import 'package:givt_app/shared/bloc/base_state.dart';
+import 'package:givt_app/shared/bloc/common_cubit.dart';
+
+part 'pledge_manage_state.dart';
+
+class PledgeManageCubit
+    extends CommonCubit<PledgeManageUIModel, PledgeManageCustom> {
+  PledgeManageCubit(this._repository) : super(const BaseState.loading());
+
+  final PledgeDetailRepository _repository;
+
+  PledgeManageUIModel? get currentUIModel {
+    final group = _repository.getPledgeGroup();
+    if (group == null) {
+      return null;
+    }
+    return _createUIModel(group);
+  }
+
+  bool _isSaving = false;
+
+  Future<void> init(String pledgeGroupId) async {
+    emitLoading();
+    try {
+      await _repository.loadDetail(pledgeGroupId);
+      if (isClosed) return;
+
+      if (_repository.getError() != null || _repository.getPledgeGroup() == null) {
+        emitError(null);
+        return;
+      }
+
+      emitData(_createUIModel(_repository.getPledgeGroup()!));
+    } catch (error) {
+      LoggingInfo.instance.error(
+        'Failed to load pledge manage screen: $error',
+        methodName: 'PledgeManageCubit.init',
+      );
+      if (isClosed) return;
+      emitError(null);
+    }
+  }
+
+  void onManageFieldPressed({
+    required PledgeManageField field,
+    PledgeGoal? goal,
+  }) {
+    switch (field) {
+      case PledgeManageField.goalAmount:
+        if (goal == null) {
+          return;
+        }
+        emitCustom(PledgeManageCustom.showAmountEditor(goal: goal));
+      case PledgeManageField.frequency:
+        emitCustom(const PledgeManageCustom.showFrequencyEditor());
+      case PledgeManageField.givingMethod:
+        emitCustom(const PledgeManageCustom.showGivingMethodEditor());
+    }
+    emitData(_createUIModel(_repository.getPledgeGroup()!));
+  }
+
+  Future<void> saveGoalAmount({
+    required PledgeGoal goal,
+    required double amount,
+  }) async {
+    await _saveUpdate(
+      update: () => _repository.updatePledge(
+        pledgeId: goal.id,
+        amount: amount,
+      ),
+      methodName: 'PledgeManageCubit.saveGoalAmount',
+    );
+  }
+
+  Future<void> saveFrequency({
+    required String frequency,
+  }) async {
+    final group = _repository.getPledgeGroup();
+    if (group == null) {
+      return;
+    }
+
+    await _saveUpdate(
+      update: () async {
+        for (final goal in group.goals) {
+          final success = await _repository.updatePledge(
+            pledgeId: goal.id,
+            frequency: frequency,
+          );
+          if (!success) {
+            return false;
+          }
+        }
+        return true;
+      },
+      methodName: 'PledgeManageCubit.saveFrequency',
+    );
+  }
+
+  Future<void> saveGivingMethod({
+    required String type,
+  }) async {
+    final group = _repository.getPledgeGroup();
+    if (group == null) {
+      return;
+    }
+
+    await _saveUpdate(
+      update: () async {
+        for (final goal in group.goals) {
+          final success = await _repository.updatePledge(
+            pledgeId: goal.id,
+            type: type,
+          );
+          if (!success) {
+            return false;
+          }
+        }
+        return true;
+      },
+      methodName: 'PledgeManageCubit.saveGivingMethod',
+    );
+  }
+
+  Future<void> _saveUpdate({
+    required Future<bool> Function() update,
+    required String methodName,
+  }) async {
+    final group = _repository.getPledgeGroup();
+    if (group == null) {
+      return;
+    }
+
+    _isSaving = true;
+    emitData(_createUIModel(group));
+
+    try {
+      final success = await update();
+      if (isClosed) return;
+
+      if (!success) {
+        _isSaving = false;
+        emitCustom(const PledgeManageCustom.manageUpdateFailed());
+        emitData(_createUIModel(group));
+        return;
+      }
+
+      await _repository.loadDetail(group.pledgeGroupId);
+      if (isClosed) return;
+
+      final refreshedGroup = _repository.getPledgeGroup();
+      if (refreshedGroup == null) {
+        _isSaving = false;
+        emitCustom(const PledgeManageCustom.manageUpdateFailed());
+        emitData(_createUIModel(group));
+        return;
+      }
+
+      _isSaving = false;
+      emitCustom(const PledgeManageCustom.manageUpdateSucceeded());
+      emitData(_createUIModel(refreshedGroup));
+    } catch (error) {
+      LoggingInfo.instance.error(
+        'Failed to update pledge: $error',
+        methodName: methodName,
+      );
+      if (isClosed) return;
+      _isSaving = false;
+      emitCustom(const PledgeManageCustom.manageUpdateFailed());
+      final currentGroup = _repository.getPledgeGroup() ?? group;
+      emitData(_createUIModel(currentGroup));
+    }
+  }
+
+  PledgeManageUIModel _createUIModel(PledgeGroup group) {
+    final detailModel = PledgeDetailUIModel(
+      group: group,
+      givenSoFar: group.givenSoFar,
+      totalPledged: group.totalPledged,
+      recurringTotal: group.goals.fold<double>(
+        0,
+        (sum, goal) => sum + goal.amount,
+      ),
+      recurringFrequency: _resolveRecurringFrequency(group.goals),
+      goalProgress: group.goals
+          .map(
+            (goal) => PledgeGoalProgress(
+              goal: goal,
+              given: goal.displayGivenAmount,
+              target: goal.pledgeTargetAmount,
+            ),
+          )
+          .toList(),
+      history: PledgeDetailHistoryBuilder.build(
+        group: group,
+        now: DateTime.now(),
+      ),
+    );
+
+    return PledgeManageUIModel(
+      detail: detailModel,
+      isSaving: _isSaving,
+    );
+  }
+
+  String? _resolveRecurringFrequency(List<PledgeGoal> goals) {
+    if (goals.isEmpty) {
+      return null;
+    }
+    final first = goals.first.frequency;
+    final allSame = goals.every((goal) => goal.frequency == first);
+    return allSame ? first : goals.first.frequency;
+  }
+}

--- a/lib/features/pledges/manage/cubit/pledge_manage_state.dart
+++ b/lib/features/pledges/manage/cubit/pledge_manage_state.dart
@@ -1,0 +1,64 @@
+part of 'pledge_manage_cubit.dart';
+
+class PledgeManageUIModel {
+  const PledgeManageUIModel({
+    required this.detail,
+    this.isSaving = false,
+  });
+
+  final PledgeDetailUIModel detail;
+  final bool isSaving;
+
+  PledgeGroup get group => detail.group;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PledgeManageUIModel &&
+        other.detail == detail &&
+        other.isSaving == isSaving;
+  }
+
+  @override
+  int get hashCode => Object.hash(detail, isSaving);
+}
+
+sealed class PledgeManageCustom {
+  const PledgeManageCustom();
+
+  const factory PledgeManageCustom.showAmountEditor({
+    required PledgeGoal goal,
+  }) = ShowAmountEditor;
+
+  const factory PledgeManageCustom.showFrequencyEditor() = ShowFrequencyEditor;
+
+  const factory PledgeManageCustom.showGivingMethodEditor() =
+      ShowGivingMethodEditor;
+
+  const factory PledgeManageCustom.manageUpdateSucceeded() =
+      ManageUpdateSucceeded;
+
+  const factory PledgeManageCustom.manageUpdateFailed() = ManageUpdateFailed;
+}
+
+class ShowAmountEditor extends PledgeManageCustom {
+  const ShowAmountEditor({required this.goal});
+
+  final PledgeGoal goal;
+}
+
+class ShowFrequencyEditor extends PledgeManageCustom {
+  const ShowFrequencyEditor();
+}
+
+class ShowGivingMethodEditor extends PledgeManageCustom {
+  const ShowGivingMethodEditor();
+}
+
+class ManageUpdateSucceeded extends PledgeManageCustom {
+  const ManageUpdateSucceeded();
+}
+
+class ManageUpdateFailed extends PledgeManageCustom {
+  const ManageUpdateFailed();
+}

--- a/lib/features/pledges/manage/models/pledge_manage_field.dart
+++ b/lib/features/pledges/manage/models/pledge_manage_field.dart
@@ -1,0 +1,5 @@
+enum PledgeManageField {
+  goalAmount,
+  frequency,
+  givingMethod,
+}

--- a/lib/features/pledges/manage/pages/pledge_manage_page.dart
+++ b/lib/features/pledges/manage/pages/pledge_manage_page.dart
@@ -32,6 +32,10 @@ class PledgeManagePage extends StatefulWidget {
 class _PledgeManagePageState extends State<PledgeManagePage> {
   late final PledgeManageCubit _cubit;
 
+  void _popWithResult() {
+    context.pop(_cubit.hasUpdates);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -93,7 +97,7 @@ class _PledgeManagePageState extends State<PledgeManagePage> {
           appBar: FunTopAppBar(
             variant: FunTopAppBarVariant.white,
             leading: GivtBackButtonFlat(
-              onPressed: () async => context.pop(),
+              onPressed: () async => _popWithResult(),
             ),
             title: context.l10n.pledgesManageTitle,
           ),
@@ -111,7 +115,7 @@ class _PledgeManagePageState extends State<PledgeManagePage> {
         appBar: FunTopAppBar(
           variant: FunTopAppBarVariant.white,
           leading: GivtBackButtonFlat(
-            onPressed: () async => context.pop(),
+            onPressed: () async => _popWithResult(),
           ),
           title: context.l10n.pledgesManageTitle,
         ),
@@ -123,7 +127,7 @@ class _PledgeManagePageState extends State<PledgeManagePage> {
           appBar: FunTopAppBar(
             variant: FunTopAppBarVariant.white,
             leading: GivtBackButtonFlat(
-              onPressed: () async => context.pop(),
+              onPressed: () async => _popWithResult(),
             ),
             title: locals.pledgesManageTitle,
           ),

--- a/lib/features/pledges/manage/pages/pledge_manage_page.dart
+++ b/lib/features/pledges/manage/pages/pledge_manage_page.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:givt_app/app/injection/injection.dart';
+import 'package:givt_app/core/enums/analytics_event_name.dart';
+import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
+import 'package:givt_app/features/family/shared/widgets/buttons/givt_back_button_flat.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/texts.dart';
+import 'package:givt_app/features/pledges/manage/cubit/pledge_manage_cubit.dart';
+import 'package:givt_app/features/pledges/manage/widgets/pledge_amount_editor_sheet.dart';
+import 'package:givt_app/features/pledges/manage/widgets/pledge_frequency_editor_sheet.dart';
+import 'package:givt_app/features/pledges/manage/widgets/pledge_giving_method_editor_sheet.dart';
+import 'package:givt_app/features/pledges/manage/widgets/pledge_manage_list.dart';
+import 'package:givt_app/l10n/l10n.dart';
+import 'package:givt_app/shared/design_system/design_system.dart';
+import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
+import 'package:givt_app/shared/widgets/fun_scaffold.dart';
+import 'package:givt_app/utils/analytics_helper.dart';
+import 'package:go_router/go_router.dart';
+
+class PledgeManagePage extends StatefulWidget {
+  const PledgeManagePage({
+    required this.pledgeGroupId,
+    super.key,
+  });
+
+  final String pledgeGroupId;
+
+  @override
+  State<PledgeManagePage> createState() => _PledgeManagePageState();
+}
+
+class _PledgeManagePageState extends State<PledgeManagePage> {
+  late final PledgeManageCubit _cubit;
+
+  @override
+  void initState() {
+    super.initState();
+    _cubit = getIt<PledgeManageCubit>();
+    AnalyticsHelper.logEvent(
+      eventName: AnalyticsEventName.pledgesManageOpened,
+      eventProperties: {'pledge_group_id': widget.pledgeGroupId},
+    );
+    _cubit.init(widget.pledgeGroupId);
+  }
+
+  @override
+  void dispose() {
+    _cubit.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseStateConsumer<PledgeManageUIModel, PledgeManageCustom>(
+      cubit: _cubit,
+      onCustom: (context, custom) {
+        final uiModel = _cubit.currentUIModel;
+        if (uiModel == null) {
+          return;
+        }
+
+        switch (custom) {
+          case ShowAmountEditor(:final goal):
+            PledgeAmountEditorSheet.show(
+              context,
+              cubit: _cubit,
+              uiModel: uiModel,
+              goal: goal,
+            );
+          case ShowFrequencyEditor():
+            PledgeFrequencyEditorSheet.show(
+              context,
+              cubit: _cubit,
+              uiModel: uiModel,
+            );
+          case ShowGivingMethodEditor():
+            PledgeGivingMethodEditorSheet.show(
+              context,
+              cubit: _cubit,
+              uiModel: uiModel,
+            );
+          case ManageUpdateSucceeded():
+            _showSuccessSnackBar(context);
+          case ManageUpdateFailed():
+            _showErrorSnackBar(context);
+        }
+      },
+      onData: (context, uiModel) {
+        final locale = Localizations.localeOf(context).toLanguageTag();
+        final countryCode = context.read<AuthCubit>().state.user.country;
+
+        return FunScaffold(
+          appBar: FunTopAppBar(
+            variant: FunTopAppBarVariant.white,
+            leading: GivtBackButtonFlat(
+              onPressed: () async => context.pop(),
+            ),
+            title: context.l10n.pledgesManageTitle,
+          ),
+          body: SingleChildScrollView(
+            child: PledgeManageList(
+              uiModel: uiModel,
+              countryCode: countryCode,
+              locale: locale,
+              onFieldPressed: _cubit.onManageFieldPressed,
+            ),
+          ),
+        );
+      },
+      onLoading: (context) => FunScaffold(
+        appBar: FunTopAppBar(
+          variant: FunTopAppBarVariant.white,
+          leading: GivtBackButtonFlat(
+            onPressed: () async => context.pop(),
+          ),
+          title: context.l10n.pledgesManageTitle,
+        ),
+        body: const Center(child: CircularProgressIndicator()),
+      ),
+      onError: (context, error) {
+        final locals = context.l10n;
+        return FunScaffold(
+          appBar: FunTopAppBar(
+            variant: FunTopAppBarVariant.white,
+            leading: GivtBackButtonFlat(
+              onPressed: () async => context.pop(),
+            ),
+            title: locals.pledgesManageTitle,
+          ),
+          body: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Icon(
+                  Icons.error_outline,
+                  size: 64,
+                  color: FamilyAppTheme.error80,
+                ),
+                const SizedBox(height: 16),
+                TitleMediumText(
+                  locals.somethingWentWrong,
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _showSuccessSnackBar(BuildContext context) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(context.l10n.pledgesEditUpdateSucceeded)),
+    );
+  }
+
+  void _showErrorSnackBar(BuildContext context) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(context.l10n.somethingWentWrong)),
+    );
+  }
+}

--- a/lib/features/pledges/manage/utils/pledge_amount_validation.dart
+++ b/lib/features/pledges/manage/utils/pledge_amount_validation.dart
@@ -1,0 +1,28 @@
+import 'package:givt_app/utils/donation_amount_validation.dart';
+
+abstract final class PledgeAmountValidation {
+  static bool isIncreaseOnly({
+    required double currentAmount,
+    required String input,
+  }) {
+    final parsed = DonationAmountValidation.parseAmount(input);
+    if (parsed == null) {
+      return false;
+    }
+    return parsed > currentAmount;
+  }
+
+  static bool canSave({
+    required double currentAmount,
+    required String input,
+    required String initialInput,
+  }) {
+    if (!DonationAmountValidation.isPositiveWithinInputLimit(input)) {
+      return false;
+    }
+    if (input.trim() == initialInput.trim()) {
+      return false;
+    }
+    return isIncreaseOnly(currentAmount: currentAmount, input: input);
+  }
+}

--- a/lib/features/pledges/manage/widgets/pledge_amount_editor_sheet.dart
+++ b/lib/features/pledges/manage/widgets/pledge_amount_editor_sheet.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:givt_app/core/constants/donation_amount_constants.dart';
+import 'package:givt_app/core/enums/analytics_event_name.dart';
+import 'package:givt_app/core/enums/country.dart';
+import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
+import 'package:givt_app/features/pledges/manage/cubit/pledge_manage_cubit.dart';
+import 'package:givt_app/features/pledges/manage/utils/pledge_amount_validation.dart';
+import 'package:givt_app/features/pledges/shared/models/pledge.dart';
+import 'package:givt_app/l10n/l10n.dart';
+import 'package:givt_app/shared/design_system/design_system.dart';
+import 'package:givt_app/utils/donation_amount_validation.dart';
+import 'package:givt_app/utils/util.dart';
+
+class PledgeAmountEditorSheet {
+  const PledgeAmountEditorSheet._();
+
+  static Future<void> show(
+    BuildContext context, {
+    required PledgeManageCubit cubit,
+    required PledgeManageUIModel uiModel,
+    required PledgeGoal goal,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (sheetContext) {
+        return _AmountEditorContent(
+          cubit: cubit,
+          uiModel: uiModel,
+          goal: goal,
+          onClose: () => Navigator.of(sheetContext).pop(),
+        );
+      },
+    );
+  }
+}
+
+class _AmountEditorContent extends StatefulWidget {
+  const _AmountEditorContent({
+    required this.cubit,
+    required this.uiModel,
+    required this.goal,
+    required this.onClose,
+  });
+
+  final PledgeManageCubit cubit;
+  final PledgeManageUIModel uiModel;
+  final PledgeGoal goal;
+  final VoidCallback onClose;
+
+  @override
+  State<_AmountEditorContent> createState() => _AmountEditorContentState();
+}
+
+class _AmountEditorContentState extends State<_AmountEditorContent> {
+  late final TextEditingController _amountController;
+  late final String _initialAmountInput;
+  late final Country _country;
+
+  @override
+  void initState() {
+    super.initState();
+    _country = Country.fromCode(
+      context.read<AuthCubit>().state.user.country,
+    );
+    _initialAmountInput =
+        Util.formatNumberComma(widget.goal.amount, _country);
+    _amountController = TextEditingController(text: _initialAmountInput);
+  }
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  String? _amountErrorText() {
+    final locals = context.l10n;
+    if (DonationAmountValidation.exceedsMaxInputAmount(_amountController.text)) {
+      final formattedMax = Util.formatNumberComma(
+        DonationAmountConstants.maxInputAmount,
+        _country,
+      );
+      return locals.donationAmountExceedsMaximum(formattedMax);
+    }
+
+    final parsed = DonationAmountValidation.parseAmount(_amountController.text);
+    if (parsed != null &&
+        parsed <= widget.goal.amount &&
+        _amountController.text.trim() != _initialAmountInput.trim()) {
+      return locals.pledgesEditValidationIncreaseOnly;
+    }
+
+    return null;
+  }
+
+  bool get _canSave => PledgeAmountValidation.canSave(
+        currentAmount: widget.goal.amount,
+        input: _amountController.text,
+        initialInput: _initialAmountInput,
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final locals = context.l10n;
+    final currency =
+        Util.getCurrencySymbol(countryCode: context.read<AuthCubit>().state.user.country);
+
+    return FunBottomSheet(
+      title: locals.pledgesEditTitle,
+      closeAction: widget.onClose,
+      content: FunInput(
+        label: locals.pledgesEditAmountLabel,
+        controller: _amountController,
+        hintText: locals.recurringDonationsCreateStep2AmountHint,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+        inputFormatters: [
+          FilteringTextInputFormatter.allow(
+            Util.numberInputFieldRegExp(),
+          ),
+          LengthLimitingTextInputFormatter(
+            DonationAmountConstants.maxIntegerDigits + 3,
+          ),
+        ],
+        prefixText: currency,
+        errorText: _amountErrorText(),
+        onChanged: (_) => setState(() {}),
+      ),
+      primaryButton: FunButton(
+        text: locals.pledgesEditSaveButton,
+        isDisabled: !_canSave,
+        isLoading: widget.uiModel.isSaving,
+        analyticsEvent:
+            AnalyticsEventName.pledgesEditAmountSaveClicked.toEvent(),
+        onTap: _canSave && !widget.uiModel.isSaving
+            ? () async {
+                final amount = DonationAmountValidation.parseAmount(
+                  _amountController.text,
+                );
+                if (amount == null) {
+                  return;
+                }
+                widget.onClose();
+                await widget.cubit.saveGoalAmount(
+                  goal: widget.goal,
+                  amount: amount,
+                );
+              }
+            : null,
+      ),
+    );
+  }
+}

--- a/lib/features/pledges/manage/widgets/pledge_frequency_editor_sheet.dart
+++ b/lib/features/pledges/manage/widgets/pledge_frequency_editor_sheet.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/core/enums/analytics_event_name.dart';
+import 'package:givt_app/features/external_donations/create/widgets/external_donation_frequency_dropdown.dart';
+import 'package:givt_app/features/external_donations/shared/models/external_donation_frequency.dart';
+import 'package:givt_app/features/pledges/manage/cubit/pledge_manage_cubit.dart';
+import 'package:givt_app/features/pledges/shared/pledge_display.dart';
+import 'package:givt_app/l10n/l10n.dart';
+import 'package:givt_app/shared/design_system/design_system.dart';
+
+class PledgeFrequencyEditorSheet {
+  const PledgeFrequencyEditorSheet._();
+
+  static Future<void> show(
+    BuildContext context, {
+    required PledgeManageCubit cubit,
+    required PledgeManageUIModel uiModel,
+  }) {
+    final locals = context.l10n;
+    final group = uiModel.group;
+    final currentFrequency = group.goals.firstOrNull?.frequency ?? 'Monthly';
+    final parsedFrequency =
+        PledgeDisplay.parseFrequency(currentFrequency) ??
+            ExternalDonationFrequency.monthly;
+    var frequency = ExternalDonationFrequencyDropdown.frequencyForEditor(
+      parsedFrequency,
+    );
+
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (sheetContext) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            final canSave =
+                PledgeDisplay.toApiFrequency(frequency) != currentFrequency;
+
+            return FunBottomSheet(
+              title: locals.pledgesEditFrequencyLabel,
+              closeAction: () => Navigator.of(sheetContext).pop(),
+              content: ExternalDonationFrequencyDropdown(
+                value: frequency,
+                frequencies: manageRecurringFrequencies,
+                label: locals.pledgesEditFrequencyLabel,
+                onChanged: (value) => setState(() => frequency = value),
+              ),
+              primaryButton: FunButton(
+                text: locals.pledgesEditSaveButton,
+                isDisabled: !canSave,
+                isLoading: uiModel.isSaving,
+                analyticsEvent:
+                    AnalyticsEventName.pledgesEditFrequencySaveClicked.toEvent(),
+                onTap: canSave && !uiModel.isSaving
+                    ? () async {
+                        Navigator.of(sheetContext).pop();
+                        await cubit.saveFrequency(
+                          frequency: PledgeDisplay.toApiFrequency(frequency),
+                        );
+                      }
+                    : null,
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/features/pledges/manage/widgets/pledge_frequency_editor_sheet.dart
+++ b/lib/features/pledges/manage/widgets/pledge_frequency_editor_sheet.dart
@@ -20,10 +20,11 @@ class PledgeFrequencyEditorSheet {
     final currentFrequency = group.goals.firstOrNull?.frequency ?? 'Monthly';
     final parsedFrequency =
         PledgeDisplay.parseFrequency(currentFrequency) ??
-            ExternalDonationFrequency.monthly;
+        ExternalDonationFrequency.monthly;
     var frequency = ExternalDonationFrequencyDropdown.frequencyForEditor(
       parsedFrequency,
     );
+    final initialFrequency = frequency;
 
     return showModalBottomSheet<void>(
       context: context,
@@ -35,8 +36,7 @@ class PledgeFrequencyEditorSheet {
       builder: (sheetContext) {
         return StatefulBuilder(
           builder: (context, setState) {
-            final canSave =
-                PledgeDisplay.toApiFrequency(frequency) != currentFrequency;
+            final canSave = frequency != initialFrequency;
 
             return FunBottomSheet(
               title: locals.pledgesEditFrequencyLabel,
@@ -51,8 +51,9 @@ class PledgeFrequencyEditorSheet {
                 text: locals.pledgesEditSaveButton,
                 isDisabled: !canSave,
                 isLoading: uiModel.isSaving,
-                analyticsEvent:
-                    AnalyticsEventName.pledgesEditFrequencySaveClicked.toEvent(),
+                analyticsEvent: AnalyticsEventName
+                    .pledgesEditFrequencySaveClicked
+                    .toEvent(),
                 onTap: canSave && !uiModel.isSaving
                     ? () async {
                         Navigator.of(sheetContext).pop();

--- a/lib/features/pledges/manage/widgets/pledge_giving_method_editor_sheet.dart
+++ b/lib/features/pledges/manage/widgets/pledge_giving_method_editor_sheet.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/core/enums/analytics_event_name.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/texts.dart';
+import 'package:givt_app/features/pledges/manage/cubit/pledge_manage_cubit.dart';
+import 'package:givt_app/l10n/l10n.dart';
+import 'package:givt_app/shared/design_system/design_system.dart';
+
+class PledgeGivingMethodEditorSheet {
+  const PledgeGivingMethodEditorSheet._();
+
+  static const _onlineType = 'Online';
+  static const _directDebitType = 'DirectDebit';
+
+  static Future<void> show(
+    BuildContext context, {
+    required PledgeManageCubit cubit,
+    required PledgeManageUIModel uiModel,
+  }) {
+    final locals = context.l10n;
+    final currentType = uiModel.group.goals.firstOrNull?.type ?? _onlineType;
+    var selectedType = currentType == _directDebitType
+        ? _directDebitType
+        : _onlineType;
+
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (sheetContext) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            final canSave = selectedType != currentType;
+
+            return FunBottomSheet(
+              title: locals.pledgesEditGivingMethodLabel,
+              closeAction: () => Navigator.of(sheetContext).pop(),
+              content: Column(
+                children: [
+                  _GivingMethodOption(
+                    title: locals.onlineGivingLabel,
+                    isSelected: selectedType == _onlineType,
+                    onTap: () => setState(() => selectedType = _onlineType),
+                  ),
+                  _GivingMethodOption(
+                    title: locals.pledgesGivingMethodAutomaticCollection,
+                    isSelected: selectedType == _directDebitType,
+                    onTap: () =>
+                        setState(() => selectedType = _directDebitType),
+                  ),
+                ],
+              ),
+              primaryButton: FunButton(
+                text: locals.pledgesEditSaveButton,
+                isDisabled: !canSave,
+                isLoading: uiModel.isSaving,
+                analyticsEvent: AnalyticsEventName
+                    .pledgesEditGivingMethodSaveClicked
+                    .toEvent(),
+                onTap: canSave && !uiModel.isSaving
+                    ? () async {
+                        Navigator.of(sheetContext).pop();
+                        await cubit.saveGivingMethod(type: selectedType);
+                      }
+                    : null,
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _GivingMethodOption extends StatelessWidget {
+  const _GivingMethodOption({
+    required this.title,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final String title;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FunTheme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: isSelected ? theme.primary40 : theme.neutralVariant80,
+                width: isSelected ? 2 : 1,
+              ),
+              color: isSelected ? theme.primary99 : theme.neutralVariant99,
+            ),
+            child: Row(
+              children: [
+                Expanded(child: LabelLargeText(title, color: theme.primary20)),
+                if (isSelected)
+                  Icon(Icons.check_circle, color: theme.primary40, size: 20),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/pledges/manage/widgets/pledge_giving_method_editor_sheet.dart
+++ b/lib/features/pledges/manage/widgets/pledge_giving_method_editor_sheet.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app/core/enums/analytics_event_name.dart';
+import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/texts.dart';
 import 'package:givt_app/features/pledges/manage/cubit/pledge_manage_cubit.dart';
 import 'package:givt_app/l10n/l10n.dart';
@@ -32,7 +34,12 @@ class PledgeGivingMethodEditorSheet {
       builder: (sheetContext) {
         return StatefulBuilder(
           builder: (context, setState) {
-            final canSave = selectedType != currentType;
+            final auth = context.read<AuthCubit>().state.user;
+            final hasBankDetails =
+                auth.iban.isNotEmpty || auth.accountNumber.isNotEmpty;
+            final missingBankDetails =
+                selectedType == _directDebitType && !hasBankDetails;
+            final canSave = selectedType != currentType && !missingBankDetails;
 
             return FunBottomSheet(
               title: locals.pledgesEditGivingMethodLabel,
@@ -50,6 +57,14 @@ class PledgeGivingMethodEditorSheet {
                     onTap: () =>
                         setState(() => selectedType = _directDebitType),
                   ),
+                  if (missingBankDetails) ...[
+                    const SizedBox(height: 8),
+                    BodySmallText(
+                      locals.pledgesEditValidationBankDetailsRequired,
+                      color: FamilyAppTheme.error80,
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
                 ],
               ),
               primaryButton: FunButton(

--- a/lib/features/pledges/manage/widgets/pledge_manage_list.dart
+++ b/lib/features/pledges/manage/widgets/pledge_manage_list.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:givt_app/core/enums/analytics_event_name.dart';
+import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
+import 'package:givt_app/features/external_donations/detail/widgets/external_donation_manage_list_item.dart';
+import 'package:givt_app/features/pledges/manage/cubit/pledge_manage_cubit.dart';
+import 'package:givt_app/features/pledges/manage/models/pledge_manage_field.dart';
+import 'package:givt_app/features/pledges/shared/models/pledge.dart';
+import 'package:givt_app/features/pledges/shared/pledge_display.dart';
+import 'package:givt_app/l10n/l10n.dart';
+
+class PledgeManageList extends StatelessWidget {
+  const PledgeManageList({
+    required this.uiModel,
+    required this.countryCode,
+    required this.locale,
+    required this.onFieldPressed,
+    super.key,
+  });
+
+  final PledgeManageUIModel uiModel;
+  final String countryCode;
+  final String locale;
+  final void Function({
+    required PledgeManageField field,
+    PledgeGoal? goal,
+  }) onFieldPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final locals = context.l10n;
+    final auth = context.read<AuthCubit>().state.user;
+    final group = uiModel.group;
+    final givingMethodType = group.goals.firstOrNull?.type ?? 'Online';
+
+    return Column(
+      children: [
+        for (final goal in group.goals)
+          ExternalDonationManageListItem(
+            icon: FontAwesomeIcons.solidHeart,
+            label: goal.goalName,
+            value: PledgeDisplay.buildManageGoalSubtitle(
+              locals: locals,
+              goal: goal,
+              countryCode: countryCode,
+            ),
+            analyticsEvent:
+                AnalyticsEventName.pledgesManageGoalEditClicked.toEvent(
+              parameters: {'goal_id': goal.goalId},
+            ),
+            onTap: () => onFieldPressed(
+              field: PledgeManageField.goalAmount,
+              goal: goal,
+            ),
+          ),
+        ExternalDonationManageListItem(
+          icon: FontAwesomeIcons.arrowsRotate,
+          label: locals.pledgesEditFrequencyLabel,
+          value: PledgeDisplay.buildManageFrequencySubtitle(
+            locals: locals,
+            group: group,
+            locale: locale,
+          ),
+          analyticsEvent:
+              AnalyticsEventName.pledgesManageFrequencyEditClicked.toEvent(),
+          onTap: () => onFieldPressed(field: PledgeManageField.frequency),
+        ),
+        ExternalDonationManageListItem(
+          icon: FontAwesomeIcons.buildingColumns,
+          label: locals.pledgesEditGivingMethodLabel,
+          value: PledgeDisplay.buildGivingMethodSubtitle(
+            locals: locals,
+            pledgeType: givingMethodType,
+            iban: auth.iban,
+            accountNumber: auth.accountNumber,
+          ),
+          analyticsEvent:
+              AnalyticsEventName.pledgesManageGivingMethodEditClicked.toEvent(),
+          onTap: () => onFieldPressed(field: PledgeManageField.givingMethod),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/pledges/manage/widgets/pledge_manage_list.dart
+++ b/lib/features/pledges/manage/widgets/pledge_manage_list.dart
@@ -25,7 +25,8 @@ class PledgeManageList extends StatelessWidget {
   final void Function({
     required PledgeManageField field,
     PledgeGoal? goal,
-  }) onFieldPressed;
+  })
+  onFieldPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -37,49 +38,80 @@ class PledgeManageList extends StatelessWidget {
     return Column(
       children: [
         for (final goal in group.goals)
-          ExternalDonationManageListItem(
-            icon: FontAwesomeIcons.solidHeart,
-            label: goal.goalName,
-            value: PledgeDisplay.buildManageGoalSubtitle(
+          _ManageListItem(
+            isDisabled: uiModel.isSaving,
+            child: ExternalDonationManageListItem(
+              icon: FontAwesomeIcons.solidHeart,
+              label: goal.goalName,
+              value: PledgeDisplay.buildManageGoalSubtitle(
+                locals: locals,
+                goal: goal,
+                countryCode: countryCode,
+              ),
+              analyticsEvent: AnalyticsEventName.pledgesManageGoalEditClicked
+                  .toEvent(
+                    parameters: {'goal_id': goal.goalId},
+                  ),
+              onTap: () => onFieldPressed(
+                field: PledgeManageField.goalAmount,
+                goal: goal,
+              ),
+            ),
+          ),
+        _ManageListItem(
+          isDisabled: uiModel.isSaving,
+          child: ExternalDonationManageListItem(
+            icon: FontAwesomeIcons.arrowsRotate,
+            label: locals.pledgesEditFrequencyLabel,
+            value: PledgeDisplay.buildManageFrequencySubtitle(
               locals: locals,
-              goal: goal,
-              countryCode: countryCode,
+              group: group,
+              locale: locale,
             ),
-            analyticsEvent:
-                AnalyticsEventName.pledgesManageGoalEditClicked.toEvent(
-              parameters: {'goal_id': goal.goalId},
-            ),
-            onTap: () => onFieldPressed(
-              field: PledgeManageField.goalAmount,
-              goal: goal,
-            ),
+            analyticsEvent: AnalyticsEventName.pledgesManageFrequencyEditClicked
+                .toEvent(),
+            onTap: () => onFieldPressed(field: PledgeManageField.frequency),
           ),
-        ExternalDonationManageListItem(
-          icon: FontAwesomeIcons.arrowsRotate,
-          label: locals.pledgesEditFrequencyLabel,
-          value: PledgeDisplay.buildManageFrequencySubtitle(
-            locals: locals,
-            group: group,
-            locale: locale,
-          ),
-          analyticsEvent:
-              AnalyticsEventName.pledgesManageFrequencyEditClicked.toEvent(),
-          onTap: () => onFieldPressed(field: PledgeManageField.frequency),
         ),
-        ExternalDonationManageListItem(
-          icon: FontAwesomeIcons.buildingColumns,
-          label: locals.pledgesEditGivingMethodLabel,
-          value: PledgeDisplay.buildGivingMethodSubtitle(
-            locals: locals,
-            pledgeType: givingMethodType,
-            iban: auth.iban,
-            accountNumber: auth.accountNumber,
+        _ManageListItem(
+          isDisabled: uiModel.isSaving,
+          child: ExternalDonationManageListItem(
+            icon: FontAwesomeIcons.buildingColumns,
+            label: locals.pledgesEditGivingMethodLabel,
+            value: PledgeDisplay.buildGivingMethodSubtitle(
+              locals: locals,
+              pledgeType: givingMethodType,
+              iban: auth.iban,
+              accountNumber: auth.accountNumber,
+            ),
+            analyticsEvent: AnalyticsEventName
+                .pledgesManageGivingMethodEditClicked
+                .toEvent(),
+            onTap: () => onFieldPressed(field: PledgeManageField.givingMethod),
           ),
-          analyticsEvent:
-              AnalyticsEventName.pledgesManageGivingMethodEditClicked.toEvent(),
-          onTap: () => onFieldPressed(field: PledgeManageField.givingMethod),
         ),
       ],
+    );
+  }
+}
+
+class _ManageListItem extends StatelessWidget {
+  const _ManageListItem({
+    required this.isDisabled,
+    required this.child,
+  });
+
+  final bool isDisabled;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      ignoring: isDisabled,
+      child: Opacity(
+        opacity: isDisabled ? 0.5 : 1,
+        child: child,
+      ),
     );
   }
 }

--- a/lib/features/pledges/shared/pledge_display.dart
+++ b/lib/features/pledges/shared/pledge_display.dart
@@ -7,8 +7,6 @@ import 'package:givt_app/l10n/arb/app_localizations.dart';
 import 'package:givt_app/shared/widgets/goal_progress_bar/goal_progress_uimodel.dart';
 import 'package:givt_app/utils/util.dart';
 import 'package:intl/intl.dart';
-
-/// Display helpers for [Pledge] list UI.
 abstract final class PledgeDisplay {
   static String formatAmount({
     required double amount,
@@ -316,6 +314,182 @@ abstract final class PledgeDisplay {
     }
 
     return parts.join(' · ');
+  }
+
+  static String buildManageGoalSubtitle({
+    required AppLocalizations locals,
+    required PledgeGoal goal,
+    required String countryCode,
+  }) {
+    final target = goal.pledgeTargetAmount;
+    final amountParts = parseGoalAmountFrequency(
+      locals: locals,
+      goal: goal,
+      countryCode: countryCode,
+    );
+
+    if (amountParts.isAllAtOnce) {
+      return amountParts.allAtOnceText ?? '';
+    }
+
+    final recurring = '${amountParts.amount}${amountParts.unitSuffix ?? ''}';
+    if (target == null) {
+      return recurring;
+    }
+
+    return locals.pledgesManageGoalSubtitle(
+      formatAmount(amount: target, countryCode: countryCode),
+      recurring,
+    );
+  }
+
+  static String formatFrequencyWithDay({
+    required AppLocalizations locals,
+    required String frequencyString,
+    required DateTime anchorDate,
+    required String locale,
+  }) {
+    final frequency = _parseFrequency(frequencyString);
+    if (frequency == null) {
+      return formatFrequency(locals, frequencyString);
+    }
+
+    final frequencyLabel = ExternalDonationFrequencyDropdown.frequencyLabel(
+      locals,
+      frequency,
+    ).toLowerCase();
+
+    switch (frequency) {
+      case ExternalDonationFrequency.weekly:
+        final weekday = DateFormat.EEEE(locale).format(anchorDate);
+        return locals.externalDonationsManageFrequencyWeeklyOnDay(weekday);
+      case ExternalDonationFrequency.monthly:
+        return locals.externalDonationsManageFrequencyMonthlyOnDay(
+          anchorDate.day.toString(),
+        );
+      case ExternalDonationFrequency.halfYearly:
+        return locals.externalDonationsManageFrequencyHalfYearlyOnDay(
+          anchorDate.day.toString(),
+        );
+      case ExternalDonationFrequency.yearly:
+        return locals.externalDonationsManageFrequencyYearlyOnDate(
+          formatHistoryDate(anchorDate, locale),
+        );
+      case ExternalDonationFrequency.quarterly:
+        return locals.externalDonationsManageFrequencyQuarterlyOnDay(
+          anchorDate.day.toString(),
+        );
+      case ExternalDonationFrequency.once:
+        return frequencyLabel;
+    }
+  }
+
+  static String buildManageFrequencySubtitle({
+    required AppLocalizations locals,
+    required PledgeGroup group,
+    required String locale,
+  }) {
+    final frequency = _resolveSharedFrequency(group.goals);
+    if (frequency == null) {
+      return '';
+    }
+
+    final anchorDate = _resolveFrequencyAnchorDate(group.goals) ?? DateTime.now();
+    return formatFrequencyWithDay(
+      locals: locals,
+      frequencyString: frequency,
+      anchorDate: anchorDate,
+      locale: locale,
+    );
+  }
+
+  static String buildGivingMethodSubtitle({
+    required AppLocalizations locals,
+    required String pledgeType,
+    required String iban,
+    required String accountNumber,
+  }) {
+    final typeLabel = formatGivingMethodType(locals, pledgeType);
+    final maskedAccount = maskBankAccount(iban: iban, accountNumber: accountNumber);
+    if (maskedAccount.isEmpty) {
+      return typeLabel;
+    }
+    return '$typeLabel · $maskedAccount';
+  }
+
+  static String formatGivingMethodType(
+    AppLocalizations locals,
+    String pledgeType,
+  ) {
+    switch (pledgeType) {
+      case 'DirectDebit':
+        return locals.pledgesGivingMethodAutomaticCollection;
+      case 'Online':
+      default:
+        return locals.onlineGivingLabel;
+    }
+  }
+
+  static String maskBankAccount({
+    required String iban,
+    required String accountNumber,
+  }) {
+    final value = iban.isNotEmpty
+        ? iban.replaceAll(' ', '')
+        : accountNumber.replaceAll(' ', '');
+    if (value.length < 4) {
+      return '';
+    }
+
+    final last4 = value.substring(value.length - 4);
+    if (value.length >= 4 && RegExp(r'^[A-Z]{2}').hasMatch(value)) {
+      return '${value.substring(0, 2)}•• •• $last4';
+    }
+    return '•••• $last4';
+  }
+
+  static ExternalDonationFrequency? parseFrequency(String frequencyString) {
+    return _parseFrequency(frequencyString);
+  }
+
+  static String toApiFrequency(ExternalDonationFrequency frequency) {
+    switch (frequency) {
+      case ExternalDonationFrequency.once:
+        return 'Once';
+      case ExternalDonationFrequency.weekly:
+        return 'Weekly';
+      case ExternalDonationFrequency.monthly:
+        return 'Monthly';
+      case ExternalDonationFrequency.quarterly:
+        return 'Quarterly';
+      case ExternalDonationFrequency.halfYearly:
+        return 'HalfYearly';
+      case ExternalDonationFrequency.yearly:
+        return 'Yearly';
+    }
+  }
+
+  static String? _resolveSharedFrequency(List<PledgeGoal> goals) {
+    if (goals.isEmpty) {
+      return null;
+    }
+    final first = goals.first.frequency;
+    final allSame = goals.every((goal) => goal.frequency == first);
+    return allSame ? first : goals.first.frequency;
+  }
+
+  static DateTime? _resolveFrequencyAnchorDate(List<PledgeGoal> goals) {
+    DateTime? earliest;
+    for (final goal in goals) {
+      final date = goal.nextExecutionDateTime;
+      if (date == null) {
+        continue;
+      }
+      if (earliest == null || date.isBefore(earliest)) {
+        earliest = date;
+      }
+    }
+    return earliest;
   }
 
   static bool _displaysAsAllAtOnce(String frequencyString) {

--- a/lib/features/pledges/shared/pledge_display.dart
+++ b/lib/features/pledges/shared/pledge_display.dart
@@ -7,6 +7,7 @@ import 'package:givt_app/l10n/arb/app_localizations.dart';
 import 'package:givt_app/shared/widgets/goal_progress_bar/goal_progress_uimodel.dart';
 import 'package:givt_app/utils/util.dart';
 import 'package:intl/intl.dart';
+
 abstract final class PledgeDisplay {
   static String formatAmount({
     required double amount,
@@ -56,7 +57,8 @@ abstract final class PledgeDisplay {
     required Pledge pledge,
     required List<Pledge> sectionPledges,
   }) {
-    final hasDuplicatePledgeGroup = sectionPledges
+    final hasDuplicatePledgeGroup =
+        sectionPledges
             .where((item) => item.pledgeGroupName == pledge.pledgeGroupName)
             .length >
         1;
@@ -167,8 +169,8 @@ abstract final class PledgeDisplay {
     final target = goalAmount != null && goalAmount > 0
         ? goalAmount
         : _displaysAsAllAtOnce(pledge.frequency)
-            ? pledge.amount
-            : null;
+        ? pledge.amount
+        : null;
     if (target == null || target <= 0) {
       return null;
     }
@@ -258,8 +260,14 @@ abstract final class PledgeDisplay {
     required String countryCode,
     required AppLocalizations locals,
   }) {
-    final formattedGiven = formatAmount(amount: given, countryCode: countryCode);
-    final formattedTarget = formatAmount(amount: target, countryCode: countryCode);
+    final formattedGiven = formatAmount(
+      amount: given,
+      countryCode: countryCode,
+    );
+    final formattedTarget = formatAmount(
+      amount: target,
+      countryCode: countryCode,
+    );
     return locals.pledgesDetailGoalProgress(formattedGiven, formattedTarget);
   }
 
@@ -389,12 +397,17 @@ abstract final class PledgeDisplay {
     required PledgeGroup group,
     required String locale,
   }) {
-    final frequency = _resolveSharedFrequency(group.goals);
-    if (frequency == null) {
+    if (group.goals.isEmpty) {
       return '';
     }
 
-    final anchorDate = _resolveFrequencyAnchorDate(group.goals) ?? DateTime.now();
+    final frequency = _resolveSharedFrequency(group.goals);
+    if (frequency == null) {
+      return locals.pledgesManageMixedFrequency;
+    }
+
+    final anchorDate =
+        _resolveFrequencyAnchorDate(group.goals) ?? DateTime.now();
     return formatFrequencyWithDay(
       locals: locals,
       frequencyString: frequency,
@@ -410,7 +423,10 @@ abstract final class PledgeDisplay {
     required String accountNumber,
   }) {
     final typeLabel = formatGivingMethodType(locals, pledgeType);
-    final maskedAccount = maskBankAccount(iban: iban, accountNumber: accountNumber);
+    final maskedAccount = maskBankAccount(
+      iban: iban,
+      accountNumber: accountNumber,
+    );
     if (maskedAccount.isEmpty) {
       return typeLabel;
     }
@@ -475,7 +491,7 @@ abstract final class PledgeDisplay {
     }
     final first = goals.first.frequency;
     final allSame = goals.every((goal) => goal.frequency == first);
-    return allSame ? first : goals.first.frequency;
+    return allSame ? first : null;
   }
 
   static DateTime? _resolveFrequencyAnchorDate(List<PledgeGoal> goals) {

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -898,6 +898,26 @@
   },
   "pledgesDetailEditButton": "Zusage bearbeiten",
   "pledgesDetailEndsLabel": "Endet",
+  "pledgesManageTitle": "Zusage verwalten",
+  "pledgesEditTitle": "Zusage bearbeiten",
+  "pledgesEditAmountLabel": "Betrag",
+  "pledgesEditFrequencyLabel": "Häufigkeit",
+  "pledgesEditGivingMethodLabel": "Geben von",
+  "pledgesEditValidationIncreaseOnly": "Du kannst deinen Zusagenbetrag nur erhöhen.",
+  "pledgesEditSaveButton": "Änderungen speichern",
+  "pledgesEditUpdateSucceeded": "Änderungen gespeichert",
+  "pledgesGivingMethodAutomaticCollection": "Automatische Abbuchung",
+  "pledgesManageGoalSubtitle": "{target} zugesagt · {recurring}",
+  "@pledgesManageGoalSubtitle": {
+    "placeholders": {
+      "target": {
+        "type": "String"
+      },
+      "recurring": {
+        "type": "String"
+      }
+    }
+  },
   "setupRecurringGiftHalfYear": "Halbes Jahr",
   "setupRecurringGiftText6": "Mal",
   "recurringGiftsSetupCreate": "Plane deine",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -906,6 +906,8 @@
   "pledgesEditValidationIncreaseOnly": "Du kannst deinen Zusagenbetrag nur erhöhen.",
   "pledgesEditSaveButton": "Änderungen speichern",
   "pledgesEditUpdateSucceeded": "Änderungen gespeichert",
+  "pledgesEditValidationBankDetailsRequired": "Füge deine Bankdaten unter Persönliche Daten hinzu, um automatische Abbuchung zu nutzen.",
+  "pledgesManageMixedFrequency": "Mehrere Frequenzen",
   "pledgesGivingMethodAutomaticCollection": "Automatische Abbuchung",
   "pledgesManageGoalSubtitle": "{target} zugesagt · {recurring}",
   "@pledgesManageGoalSubtitle": {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -898,6 +898,26 @@
   },
   "pledgesDetailEditButton": "Edit pledge",
   "pledgesDetailEndsLabel": "Ends",
+  "pledgesManageTitle": "Manage pledge",
+  "pledgesEditTitle": "Edit pledge",
+  "pledgesEditAmountLabel": "Amount",
+  "pledgesEditFrequencyLabel": "Frequency",
+  "pledgesEditGivingMethodLabel": "Give from",
+  "pledgesEditValidationIncreaseOnly": "You can only increase your pledge amount.",
+  "pledgesEditSaveButton": "Save changes",
+  "pledgesEditUpdateSucceeded": "Changes saved",
+  "pledgesGivingMethodAutomaticCollection": "Automatic collection",
+  "pledgesManageGoalSubtitle": "{target} pledged · {recurring}",
+  "@pledgesManageGoalSubtitle": {
+    "placeholders": {
+      "target": {
+        "type": "String"
+      },
+      "recurring": {
+        "type": "String"
+      }
+    }
+  },
   "setupRecurringGiftHalfYear": "half year",
   "setupRecurringGiftText6": "times",
   "recurringGiftsSetupCreate": "Schedule your",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -906,6 +906,8 @@
   "pledgesEditValidationIncreaseOnly": "You can only increase your pledge amount.",
   "pledgesEditSaveButton": "Save changes",
   "pledgesEditUpdateSucceeded": "Changes saved",
+  "pledgesEditValidationBankDetailsRequired": "Add your bank details in Personal information to use automatic collection.",
+  "pledgesManageMixedFrequency": "Multiple frequencies",
   "pledgesGivingMethodAutomaticCollection": "Automatic collection",
   "pledgesManageGoalSubtitle": "{target} pledged · {recurring}",
   "@pledgesManageGoalSubtitle": {

--- a/lib/l10n/arb/app_en_US.arb
+++ b/lib/l10n/arb/app_en_US.arb
@@ -894,6 +894,26 @@
   },
   "pledgesDetailEditButton": "Edit pledge",
   "pledgesDetailEndsLabel": "Ends",
+  "pledgesManageTitle": "Manage pledge",
+  "pledgesEditTitle": "Edit pledge",
+  "pledgesEditAmountLabel": "Amount",
+  "pledgesEditFrequencyLabel": "Frequency",
+  "pledgesEditGivingMethodLabel": "Give from",
+  "pledgesEditValidationIncreaseOnly": "You can only increase your pledge amount.",
+  "pledgesEditSaveButton": "Save changes",
+  "pledgesEditUpdateSucceeded": "Changes saved",
+  "pledgesGivingMethodAutomaticCollection": "Automatic collection",
+  "pledgesManageGoalSubtitle": "{target} pledged · {recurring}",
+  "@pledgesManageGoalSubtitle": {
+    "placeholders": {
+      "target": {
+        "type": "String"
+      },
+      "recurring": {
+        "type": "String"
+      }
+    }
+  },
   "setupRecurringGiftHalfYear": "half year",
   "setupRecurringGiftText6": "times",
   "recurringGiftsSetupCreate": "Schedule your",

--- a/lib/l10n/arb/app_en_US.arb
+++ b/lib/l10n/arb/app_en_US.arb
@@ -902,6 +902,8 @@
   "pledgesEditValidationIncreaseOnly": "You can only increase your pledge amount.",
   "pledgesEditSaveButton": "Save changes",
   "pledgesEditUpdateSucceeded": "Changes saved",
+  "pledgesEditValidationBankDetailsRequired": "Add your bank details in Personal information to use automatic collection.",
+  "pledgesManageMixedFrequency": "Multiple frequencies",
   "pledgesGivingMethodAutomaticCollection": "Automatic collection",
   "pledgesManageGoalSubtitle": "{target} pledged · {recurring}",
   "@pledgesManageGoalSubtitle": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -898,6 +898,26 @@
   },
   "pledgesDetailEditButton": "Editar compromiso",
   "pledgesDetailEndsLabel": "Finaliza",
+  "pledgesManageTitle": "Gestionar compromiso",
+  "pledgesEditTitle": "Editar compromiso",
+  "pledgesEditAmountLabel": "Importe",
+  "pledgesEditFrequencyLabel": "Frecuencia",
+  "pledgesEditGivingMethodLabel": "Dar desde",
+  "pledgesEditValidationIncreaseOnly": "Solo puedes aumentar el importe de tu compromiso.",
+  "pledgesEditSaveButton": "Guardar cambios",
+  "pledgesEditUpdateSucceeded": "Cambios guardados",
+  "pledgesGivingMethodAutomaticCollection": "Cobro automático",
+  "pledgesManageGoalSubtitle": "{target} comprometidos · {recurring}",
+  "@pledgesManageGoalSubtitle": {
+    "placeholders": {
+      "target": {
+        "type": "String"
+      },
+      "recurring": {
+        "type": "String"
+      }
+    }
+  },
   "setupRecurringGiftHalfYear": "half year",
   "setupRecurringGiftText6": "times",
   "recurringGiftsSetupCreate": "Schedule your",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -906,6 +906,8 @@
   "pledgesEditValidationIncreaseOnly": "Solo puedes aumentar el importe de tu compromiso.",
   "pledgesEditSaveButton": "Guardar cambios",
   "pledgesEditUpdateSucceeded": "Cambios guardados",
+  "pledgesEditValidationBankDetailsRequired": "Añade tus datos bancarios en Información personal para usar el cobro automático.",
+  "pledgesManageMixedFrequency": "Varias frecuencias",
   "pledgesGivingMethodAutomaticCollection": "Cobro automático",
   "pledgesManageGoalSubtitle": "{target} comprometidos · {recurring}",
   "@pledgesManageGoalSubtitle": {

--- a/lib/l10n/arb/app_es_419.arb
+++ b/lib/l10n/arb/app_es_419.arb
@@ -902,6 +902,8 @@
   "pledgesEditValidationIncreaseOnly": "Solo puedes aumentar el importe de tu compromiso.",
   "pledgesEditSaveButton": "Guardar cambios",
   "pledgesEditUpdateSucceeded": "Cambios guardados",
+  "pledgesEditValidationBankDetailsRequired": "Agrega tus datos bancarios en Información personal para usar el cobro automático.",
+  "pledgesManageMixedFrequency": "Varias frecuencias",
   "pledgesGivingMethodAutomaticCollection": "Cobro automático",
   "pledgesManageGoalSubtitle": "{target} comprometidos · {recurring}",
   "@pledgesManageGoalSubtitle": {

--- a/lib/l10n/arb/app_es_419.arb
+++ b/lib/l10n/arb/app_es_419.arb
@@ -894,6 +894,26 @@
   },
   "pledgesDetailEditButton": "Editar compromiso",
   "pledgesDetailEndsLabel": "Finaliza",
+  "pledgesManageTitle": "Gestionar compromiso",
+  "pledgesEditTitle": "Editar compromiso",
+  "pledgesEditAmountLabel": "Importe",
+  "pledgesEditFrequencyLabel": "Frecuencia",
+  "pledgesEditGivingMethodLabel": "Dar desde",
+  "pledgesEditValidationIncreaseOnly": "Solo puedes aumentar el importe de tu compromiso.",
+  "pledgesEditSaveButton": "Guardar cambios",
+  "pledgesEditUpdateSucceeded": "Cambios guardados",
+  "pledgesGivingMethodAutomaticCollection": "Cobro automático",
+  "pledgesManageGoalSubtitle": "{target} comprometidos · {recurring}",
+  "@pledgesManageGoalSubtitle": {
+    "placeholders": {
+      "target": {
+        "type": "String"
+      },
+      "recurring": {
+        "type": "String"
+      }
+    }
+  },
   "setupRecurringGiftHalfYear": "semestre",
   "setupRecurringGiftText6": "veces",
   "recurringGiftsSetupCreate": "Programe su",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -2265,6 +2265,66 @@ abstract class AppLocalizations {
   /// **'Ends'**
   String get pledgesDetailEndsLabel;
 
+  /// No description provided for @pledgesManageTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Manage pledge'**
+  String get pledgesManageTitle;
+
+  /// No description provided for @pledgesEditTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit pledge'**
+  String get pledgesEditTitle;
+
+  /// No description provided for @pledgesEditAmountLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Amount'**
+  String get pledgesEditAmountLabel;
+
+  /// No description provided for @pledgesEditFrequencyLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Frequency'**
+  String get pledgesEditFrequencyLabel;
+
+  /// No description provided for @pledgesEditGivingMethodLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Give from'**
+  String get pledgesEditGivingMethodLabel;
+
+  /// No description provided for @pledgesEditValidationIncreaseOnly.
+  ///
+  /// In en, this message translates to:
+  /// **'You can only increase your pledge amount.'**
+  String get pledgesEditValidationIncreaseOnly;
+
+  /// No description provided for @pledgesEditSaveButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Save changes'**
+  String get pledgesEditSaveButton;
+
+  /// No description provided for @pledgesEditUpdateSucceeded.
+  ///
+  /// In en, this message translates to:
+  /// **'Changes saved'**
+  String get pledgesEditUpdateSucceeded;
+
+  /// No description provided for @pledgesGivingMethodAutomaticCollection.
+  ///
+  /// In en, this message translates to:
+  /// **'Automatic collection'**
+  String get pledgesGivingMethodAutomaticCollection;
+
+  /// No description provided for @pledgesManageGoalSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'{target} pledged · {recurring}'**
+  String pledgesManageGoalSubtitle(String target, String recurring);
+
   /// No description provided for @setupRecurringGiftHalfYear.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -2313,6 +2313,18 @@ abstract class AppLocalizations {
   /// **'Changes saved'**
   String get pledgesEditUpdateSucceeded;
 
+  /// No description provided for @pledgesEditValidationBankDetailsRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Add your bank details in Personal information to use automatic collection.'**
+  String get pledgesEditValidationBankDetailsRequired;
+
+  /// No description provided for @pledgesManageMixedFrequency.
+  ///
+  /// In en, this message translates to:
+  /// **'Multiple frequencies'**
+  String get pledgesManageMixedFrequency;
+
   /// No description provided for @pledgesGivingMethodAutomaticCollection.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -1267,6 +1267,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get pledgesEditUpdateSucceeded => 'Änderungen gespeichert';
 
   @override
+  String get pledgesEditValidationBankDetailsRequired =>
+      'Füge deine Bankdaten unter Persönliche Daten hinzu, um automatische Abbuchung zu nutzen.';
+
+  @override
+  String get pledgesManageMixedFrequency => 'Mehrere Frequenzen';
+
+  @override
   String get pledgesGivingMethodAutomaticCollection => 'Automatische Abbuchung';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -1242,6 +1242,39 @@ class AppLocalizationsDe extends AppLocalizations {
   String get pledgesDetailEndsLabel => 'Endet';
 
   @override
+  String get pledgesManageTitle => 'Zusage verwalten';
+
+  @override
+  String get pledgesEditTitle => 'Zusage bearbeiten';
+
+  @override
+  String get pledgesEditAmountLabel => 'Betrag';
+
+  @override
+  String get pledgesEditFrequencyLabel => 'Häufigkeit';
+
+  @override
+  String get pledgesEditGivingMethodLabel => 'Geben von';
+
+  @override
+  String get pledgesEditValidationIncreaseOnly =>
+      'Du kannst deinen Zusagenbetrag nur erhöhen.';
+
+  @override
+  String get pledgesEditSaveButton => 'Änderungen speichern';
+
+  @override
+  String get pledgesEditUpdateSucceeded => 'Änderungen gespeichert';
+
+  @override
+  String get pledgesGivingMethodAutomaticCollection => 'Automatische Abbuchung';
+
+  @override
+  String pledgesManageGoalSubtitle(String target, String recurring) {
+    return '$target zugesagt · $recurring';
+  }
+
+  @override
   String get setupRecurringGiftHalfYear => 'Halbes Jahr';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -1258,6 +1258,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pledgesEditUpdateSucceeded => 'Changes saved';
 
   @override
+  String get pledgesEditValidationBankDetailsRequired =>
+      'Add your bank details in Personal information to use automatic collection.';
+
+  @override
+  String get pledgesManageMixedFrequency => 'Multiple frequencies';
+
+  @override
   String get pledgesGivingMethodAutomaticCollection => 'Automatic collection';
 
   @override
@@ -4773,6 +4780,13 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
 
   @override
   String get pledgesEditUpdateSucceeded => 'Changes saved';
+
+  @override
+  String get pledgesEditValidationBankDetailsRequired =>
+      'Add your bank details in Personal information to use automatic collection.';
+
+  @override
+  String get pledgesManageMixedFrequency => 'Multiple frequencies';
 
   @override
   String get pledgesGivingMethodAutomaticCollection => 'Automatic collection';

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -1233,6 +1233,39 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pledgesDetailEndsLabel => 'Ends';
 
   @override
+  String get pledgesManageTitle => 'Manage pledge';
+
+  @override
+  String get pledgesEditTitle => 'Edit pledge';
+
+  @override
+  String get pledgesEditAmountLabel => 'Amount';
+
+  @override
+  String get pledgesEditFrequencyLabel => 'Frequency';
+
+  @override
+  String get pledgesEditGivingMethodLabel => 'Give from';
+
+  @override
+  String get pledgesEditValidationIncreaseOnly =>
+      'You can only increase your pledge amount.';
+
+  @override
+  String get pledgesEditSaveButton => 'Save changes';
+
+  @override
+  String get pledgesEditUpdateSucceeded => 'Changes saved';
+
+  @override
+  String get pledgesGivingMethodAutomaticCollection => 'Automatic collection';
+
+  @override
+  String pledgesManageGoalSubtitle(String target, String recurring) {
+    return '$target pledged · $recurring';
+  }
+
+  @override
   String get setupRecurringGiftHalfYear => 'half year';
 
   @override
@@ -4715,6 +4748,39 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
 
   @override
   String get pledgesDetailEndsLabel => 'Ends';
+
+  @override
+  String get pledgesManageTitle => 'Manage pledge';
+
+  @override
+  String get pledgesEditTitle => 'Edit pledge';
+
+  @override
+  String get pledgesEditAmountLabel => 'Amount';
+
+  @override
+  String get pledgesEditFrequencyLabel => 'Frequency';
+
+  @override
+  String get pledgesEditGivingMethodLabel => 'Give from';
+
+  @override
+  String get pledgesEditValidationIncreaseOnly =>
+      'You can only increase your pledge amount.';
+
+  @override
+  String get pledgesEditSaveButton => 'Save changes';
+
+  @override
+  String get pledgesEditUpdateSucceeded => 'Changes saved';
+
+  @override
+  String get pledgesGivingMethodAutomaticCollection => 'Automatic collection';
+
+  @override
+  String pledgesManageGoalSubtitle(String target, String recurring) {
+    return '$target pledged · $recurring';
+  }
 
   @override
   String get setupRecurringGiftHalfYear => 'half year';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -1258,6 +1258,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get pledgesEditUpdateSucceeded => 'Cambios guardados';
 
   @override
+  String get pledgesEditValidationBankDetailsRequired =>
+      'Añade tus datos bancarios en Información personal para usar el cobro automático.';
+
+  @override
+  String get pledgesManageMixedFrequency => 'Varias frecuencias';
+
+  @override
   String get pledgesGivingMethodAutomaticCollection => 'Cobro automático';
 
   @override
@@ -4794,6 +4801,13 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get pledgesEditUpdateSucceeded => 'Cambios guardados';
+
+  @override
+  String get pledgesEditValidationBankDetailsRequired =>
+      'Agrega tus datos bancarios en Información personal para usar el cobro automático.';
+
+  @override
+  String get pledgesManageMixedFrequency => 'Varias frecuencias';
 
   @override
   String get pledgesGivingMethodAutomaticCollection => 'Cobro automático';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -1233,6 +1233,39 @@ class AppLocalizationsEs extends AppLocalizations {
   String get pledgesDetailEndsLabel => 'Finaliza';
 
   @override
+  String get pledgesManageTitle => 'Gestionar compromiso';
+
+  @override
+  String get pledgesEditTitle => 'Editar compromiso';
+
+  @override
+  String get pledgesEditAmountLabel => 'Importe';
+
+  @override
+  String get pledgesEditFrequencyLabel => 'Frecuencia';
+
+  @override
+  String get pledgesEditGivingMethodLabel => 'Dar desde';
+
+  @override
+  String get pledgesEditValidationIncreaseOnly =>
+      'Solo puedes aumentar el importe de tu compromiso.';
+
+  @override
+  String get pledgesEditSaveButton => 'Guardar cambios';
+
+  @override
+  String get pledgesEditUpdateSucceeded => 'Cambios guardados';
+
+  @override
+  String get pledgesGivingMethodAutomaticCollection => 'Cobro automático';
+
+  @override
+  String pledgesManageGoalSubtitle(String target, String recurring) {
+    return '$target comprometidos · $recurring';
+  }
+
+  @override
   String get setupRecurringGiftHalfYear => 'half year';
 
   @override
@@ -4736,6 +4769,39 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get pledgesDetailEndsLabel => 'Finaliza';
+
+  @override
+  String get pledgesManageTitle => 'Gestionar compromiso';
+
+  @override
+  String get pledgesEditTitle => 'Editar compromiso';
+
+  @override
+  String get pledgesEditAmountLabel => 'Importe';
+
+  @override
+  String get pledgesEditFrequencyLabel => 'Frecuencia';
+
+  @override
+  String get pledgesEditGivingMethodLabel => 'Dar desde';
+
+  @override
+  String get pledgesEditValidationIncreaseOnly =>
+      'Solo puedes aumentar el importe de tu compromiso.';
+
+  @override
+  String get pledgesEditSaveButton => 'Guardar cambios';
+
+  @override
+  String get pledgesEditUpdateSucceeded => 'Cambios guardados';
+
+  @override
+  String get pledgesGivingMethodAutomaticCollection => 'Cobro automático';
+
+  @override
+  String pledgesManageGoalSubtitle(String target, String recurring) {
+    return '$target comprometidos · $recurring';
+  }
 
   @override
   String get setupRecurringGiftHalfYear => 'semestre';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -1262,6 +1262,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get pledgesEditUpdateSucceeded => 'Wijzigingen opgeslagen';
 
   @override
+  String get pledgesEditValidationBankDetailsRequired =>
+      'Voeg je bankgegevens toe bij Persoonlijke gegevens om automatische incasso te gebruiken.';
+
+  @override
+  String get pledgesManageMixedFrequency => 'Meerdere frequenties';
+
+  @override
   String get pledgesGivingMethodAutomaticCollection => 'Automatische incasso';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -1237,6 +1237,39 @@ class AppLocalizationsNl extends AppLocalizations {
   String get pledgesDetailEndsLabel => 'Eindigt';
 
   @override
+  String get pledgesManageTitle => 'Toezegging beheren';
+
+  @override
+  String get pledgesEditTitle => 'Toezegging bewerken';
+
+  @override
+  String get pledgesEditAmountLabel => 'Bedrag';
+
+  @override
+  String get pledgesEditFrequencyLabel => 'Frequentie';
+
+  @override
+  String get pledgesEditGivingMethodLabel => 'Geven vanaf';
+
+  @override
+  String get pledgesEditValidationIncreaseOnly =>
+      'Je kunt je toezeggingsbedrag alleen verhogen.';
+
+  @override
+  String get pledgesEditSaveButton => 'Wijzigingen opslaan';
+
+  @override
+  String get pledgesEditUpdateSucceeded => 'Wijzigingen opgeslagen';
+
+  @override
+  String get pledgesGivingMethodAutomaticCollection => 'Automatische incasso';
+
+  @override
+  String pledgesManageGoalSubtitle(String target, String recurring) {
+    return '$target toegezegd · $recurring';
+  }
+
+  @override
   String get setupRecurringGiftHalfYear => 'half jaar';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -898,6 +898,26 @@
   },
   "pledgesDetailEditButton": "Toezegging bewerken",
   "pledgesDetailEndsLabel": "Eindigt",
+  "pledgesManageTitle": "Toezegging beheren",
+  "pledgesEditTitle": "Toezegging bewerken",
+  "pledgesEditAmountLabel": "Bedrag",
+  "pledgesEditFrequencyLabel": "Frequentie",
+  "pledgesEditGivingMethodLabel": "Geven vanaf",
+  "pledgesEditValidationIncreaseOnly": "Je kunt je toezeggingsbedrag alleen verhogen.",
+  "pledgesEditSaveButton": "Wijzigingen opslaan",
+  "pledgesEditUpdateSucceeded": "Wijzigingen opgeslagen",
+  "pledgesGivingMethodAutomaticCollection": "Automatische incasso",
+  "pledgesManageGoalSubtitle": "{target} toegezegd · {recurring}",
+  "@pledgesManageGoalSubtitle": {
+    "placeholders": {
+      "target": {
+        "type": "String"
+      },
+      "recurring": {
+        "type": "String"
+      }
+    }
+  },
   "setupRecurringGiftHalfYear": "half jaar",
   "setupRecurringGiftText6": "keer",
   "recurringGiftsSetupCreate": "Plan je",

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -906,6 +906,8 @@
   "pledgesEditValidationIncreaseOnly": "Je kunt je toezeggingsbedrag alleen verhogen.",
   "pledgesEditSaveButton": "Wijzigingen opslaan",
   "pledgesEditUpdateSucceeded": "Wijzigingen opgeslagen",
+  "pledgesEditValidationBankDetailsRequired": "Voeg je bankgegevens toe bij Persoonlijke gegevens om automatische incasso te gebruiken.",
+  "pledgesManageMixedFrequency": "Meerdere frequenties",
   "pledgesGivingMethodAutomaticCollection": "Automatische incasso",
   "pledgesManageGoalSubtitle": "{target} toegezegd · {recurring}",
   "@pledgesManageGoalSubtitle": {

--- a/lib/shared/repositories/givt_repository.dart
+++ b/lib/shared/repositories/givt_repository.dart
@@ -29,6 +29,11 @@ mixin GivtRepository {
 
   Future<PledgeGroup> fetchPledgeGroupDetail(String pledgeGroupId);
 
+  Future<bool> updatePledge({
+    required String pledgeId,
+    required Map<String, dynamic> body,
+  });
+
   Future<List<ExternalDonation>> fetchExternalDonations();
 
   Future<List<ExternalDonation>> fetchExternalDonationSummary({
@@ -248,6 +253,14 @@ class GivtRepositoryImpl with GivtRepository {
   Future<PledgeGroup> fetchPledgeGroupDetail(String pledgeGroupId) async {
     final item = await apiClient.fetchPledgeGroupDetail(pledgeGroupId);
     return PledgeGroup.fromJson(item);
+  }
+
+  @override
+  Future<bool> updatePledge({
+    required String pledgeId,
+    required Map<String, dynamic> body,
+  }) async {
+    return apiClient.updatePledge(pledgeId, body);
   }
 
   @override

--- a/test/features/pledges/pledge_amount_validation_test.dart
+++ b/test/features/pledges/pledge_amount_validation_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/features/pledges/manage/utils/pledge_amount_validation.dart';
+
+void main() {
+  group('PledgeAmountValidation', () {
+    test('isIncreaseOnly returns true when amount is higher', () {
+      expect(
+        PledgeAmountValidation.isIncreaseOnly(
+          currentAmount: 150,
+          input: '200',
+        ),
+        isTrue,
+      );
+    });
+
+    test('isIncreaseOnly returns false when amount is equal', () {
+      expect(
+        PledgeAmountValidation.isIncreaseOnly(
+          currentAmount: 150,
+          input: '150',
+        ),
+        isFalse,
+      );
+    });
+
+    test('isIncreaseOnly returns false when amount is lower', () {
+      expect(
+        PledgeAmountValidation.isIncreaseOnly(
+          currentAmount: 150,
+          input: '100',
+        ),
+        isFalse,
+      );
+    });
+
+    test('canSave requires positive increase and changed input', () {
+      expect(
+        PledgeAmountValidation.canSave(
+          currentAmount: 150,
+          input: '200',
+          initialInput: '150',
+        ),
+        isTrue,
+      );
+      expect(
+        PledgeAmountValidation.canSave(
+          currentAmount: 150,
+          input: '150',
+          initialInput: '150',
+        ),
+        isFalse,
+      );
+      expect(
+        PledgeAmountValidation.canSave(
+          currentAmount: 150,
+          input: '100',
+          initialInput: '150',
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/features/pledges/pledge_display_test.dart
+++ b/test/features/pledges/pledge_display_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:givt_app/features/pledges/shared/models/pledge.dart';
 import 'package:givt_app/features/pledges/shared/pledge_display.dart';
+import 'package:givt_app/l10n/arb/app_localizations_en.dart';
 
 void main() {
   group('PledgeDisplay.buildCardProgress', () {
@@ -33,25 +34,28 @@ void main() {
       expect(progress.displayText, contains('1500'));
     });
 
-    test('returns progress using pledge amount for all-at-once without goalAmount', () {
-      final progress = PledgeDisplay.buildCardProgress(
-        pledge: const Pledge(
-          id: '1',
-          goalId: 'goal-1',
-          pledgeGroupId: 'pg-1',
-          type: 'DirectDebit',
-          amount: 26,
-          frequency: 'Yearly',
-          collectGroup: collectGroup,
-          pledgeGroupName: 'Campaign',
-          goalName: 'Building fund',
-        ),
-        countryCode: 'NL',
-      );
+    test(
+      'returns progress using pledge amount for all-at-once without goalAmount',
+      () {
+        final progress = PledgeDisplay.buildCardProgress(
+          pledge: const Pledge(
+            id: '1',
+            goalId: 'goal-1',
+            pledgeGroupId: 'pg-1',
+            type: 'DirectDebit',
+            amount: 26,
+            frequency: 'Yearly',
+            collectGroup: collectGroup,
+            pledgeGroupName: 'Campaign',
+            goalName: 'Building fund',
+          ),
+          countryCode: 'NL',
+        );
 
-      expect(progress, isNotNull);
-      expect(progress!.totalAmount, 26);
-    });
+        expect(progress, isNotNull);
+        expect(progress!.totalAmount, 26);
+      },
+    );
 
     test('returns combined progress for pledge group card', () {
       final card = PledgeOverviewCard.fromPledges([
@@ -87,6 +91,50 @@ void main() {
       expect(progress, isNotNull);
       expect(progress!.totalAmount, 41);
       expect(progress.displayText, contains('41'));
+    });
+  });
+
+  group('PledgeDisplay.buildManageFrequencySubtitle', () {
+    const collectGroup = PledgeCollectGroup(
+      id: 'cg-1',
+      namespace: 'org.example',
+      name: 'Example Church',
+    );
+
+    test('shows mixed-frequency label when goals differ', () {
+      final group = PledgeGroup(
+        pledgeGroupId: 'pg-1',
+        pledgeGroupName: 'Campaign',
+        collectGroup: collectGroup,
+        startDate: null,
+        endDate: null,
+        goals: const [
+          PledgeGoal(
+            id: '1',
+            goalId: 'goal-1',
+            goalName: 'Building fund',
+            amount: 10,
+            frequency: 'Monthly',
+            type: 'Online',
+          ),
+          PledgeGoal(
+            id: '2',
+            goalId: 'goal-2',
+            goalName: 'Mission',
+            amount: 15,
+            frequency: 'Weekly',
+            type: 'Online',
+          ),
+        ],
+      );
+
+      final subtitle = PledgeDisplay.buildManageFrequencySubtitle(
+        locals: AppLocalizationsEn(),
+        group: group,
+        locale: 'en',
+      );
+
+      expect(subtitle, 'Multiple frequencies');
     });
   });
 }

--- a/test/features/pledges/pledge_frequency_editor_test.dart
+++ b/test/features/pledges/pledge_frequency_editor_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/features/external_donations/create/widgets/external_donation_frequency_dropdown.dart';
+import 'package:givt_app/features/external_donations/shared/models/external_donation_frequency.dart';
+import 'package:givt_app/features/pledges/shared/pledge_display.dart';
+
+void main() {
+  group('Pledge frequency editor save eligibility', () {
+    test('does not treat mapped Once frequency as changed on open', () {
+      final parsedFrequency =
+          PledgeDisplay.parseFrequency('Once') ??
+          ExternalDonationFrequency.monthly;
+      final initialFrequency =
+          ExternalDonationFrequencyDropdown.frequencyForEditor(
+            parsedFrequency,
+          );
+
+      expect(initialFrequency, ExternalDonationFrequency.monthly);
+      expect(initialFrequency != initialFrequency, isFalse);
+    });
+
+    test('detects user-selected frequency changes', () {
+      final parsedFrequency =
+          PledgeDisplay.parseFrequency('Monthly') ??
+          ExternalDonationFrequency.monthly;
+      final initialFrequency =
+          ExternalDonationFrequencyDropdown.frequencyForEditor(
+            parsedFrequency,
+          );
+      const selectedFrequency = ExternalDonationFrequency.weekly;
+
+      expect(selectedFrequency != initialFrequency, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add pledge manage screen with amount, frequency, and giving-method edit bottom sheets wired from pledge detail
- Call `PUT /givtservice/v1/Pledge/{pledgeId}` for updates with increase-only amount validation
- Address Bugbot review findings: refresh detail after edits, fix frequency save eligibility for mapped values, factory-scoped detail repository, concurrent-save guards, bank-details validation for direct debit, mixed-frequency display, and partial-failure reload

## Test plan
- [ ] Open pledge detail → Edit → change amount (verify increase-only validation blocks decreases)
- [ ] Save amount/frequency/giving method and navigate back — detail screen shows updated values
- [ ] Open frequency editor on a one-time (`Once`) pledge — Save is disabled until user changes selection
- [ ] Attempt direct debit without bank details — validation message shown, save disabled
- [ ] Verify manage list items are disabled while a save is in progress
- [ ] Run `flutter test test/features/pledges/` (passes locally)


Made with [Cursor](https://cursor.com)