### PR TITLE
Fix ENG-974: null check crash when closing personal info sheets

### DIFF
--- a/lib/features/account_details/pages/change_email_address_bottom_sheet.dart
+++ b/lib/features/account_details/pages/change_email_address_bottom_sheet.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app/core/enums/analytics_event_name.dart';
 import 'package:givt_app/features/account_details/bloc/personal_info_edit_bloc.dart';
-import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
-import 'package:givt_app/shared/design_system/design_system.dart';
+import 'package:givt_app/features/account_details/widgets/personal_info_edit_sheet_success.dart';
 import 'package:givt_app/l10n/l10n.dart';
+import 'package:givt_app/shared/design_system/design_system.dart';
 import 'package:givt_app/shared/models/analytics_event.dart';
 import 'package:givt_app/utils/util.dart';
 
@@ -94,10 +94,10 @@ class _ChangeEmailAddressBottomSheetState
                       return;
                     }
                     context.read<PersonalInfoEditBloc>().add(
-                          PersonalInfoEditEmail(
-                            email: emailController.text,
-                          ),
-                        );
+                      PersonalInfoEditEmail(
+                        email: emailController.text,
+                      ),
+                    );
                   }
                 : null,
             text: isLoading ? locals.loadingTitle : locals.save,
@@ -115,11 +115,7 @@ class _ChangeEmailAddressBottomSheetState
   }
 
   void _onEmailChangeSuccessDone(BuildContext context) {
-    context.read<PersonalInfoEditBloc>().add(
-          const PersonalInfoEditStatusReset(),
-        );
-    Navigator.of(context).pop();
-    context.read<AuthCubit>().refreshUser();
+    completePersonalInfoEditSheet(context);
   }
 
   bool _validateEmail(String invalidEmailMessage) {

--- a/lib/features/account_details/personal_info_edit_sheets.dart
+++ b/lib/features/account_details/personal_info_edit_sheets.dart
@@ -8,94 +8,101 @@ import 'package:givt_app/features/account_details/pages/change_email_address_bot
 import 'package:givt_app/features/account_details/pages/change_name_bottom_sheet.dart';
 import 'package:givt_app/features/account_details/pages/change_phone_number_bottom_sheet.dart';
 import 'package:givt_app/features/account_details/widgets/personal_info_edit_feedback_listener.dart';
+import 'package:givt_app/features/account_details/widgets/personal_info_edit_sheet_success.dart';
+import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/features/auth/repositories/auth_repository.dart';
 import 'package:givt_app/shared/models/user_ext.dart';
 
-/// Opens the same change bottom sheets as [PersonalInfoEditPage], with a
-/// dedicated [PersonalInfoEditBloc] and shared feedback handling.
+/// Opens the same change bottom sheets as the account settings personal info
+/// edit page, with a dedicated [PersonalInfoEditBloc] and shared feedback
+/// handling.
 Future<void> showChangeNameSheetForUser(
   BuildContext context,
   UserExt user,
-) =>
-    _showSheet(
-      context,
-      user,
-      ChangeNameBottomSheet(
-        firstName: user.firstName,
-        lastName: user.lastName,
-      ),
-    );
+) => _showSheet(
+  context,
+  user,
+  ChangeNameBottomSheet(
+    firstName: user.firstName,
+    lastName: user.lastName,
+  ),
+);
 
 Future<void> showChangeEmailSheetForUser(
   BuildContext context,
   UserExt user,
-) =>
-    _showSheet(
-      context,
-      user,
-      ChangeEmailAddressBottomSheet(
-        email: user.email,
-      ),
-    );
+) => _showSheet(
+  context,
+  user,
+  ChangeEmailAddressBottomSheet(
+    email: user.email,
+  ),
+);
 
 Future<void> showChangeAddressSheetForUser(
   BuildContext context,
   UserExt user,
-) =>
-    _showSheet(
-      context,
-      user,
-      ChangeAddressBottomSheet(
-        address: user.address,
-        postalCode: user.postalCode,
-        city: user.city,
-        country: user.country,
-      ),
-    );
+) => _showSheet(
+  context,
+  user,
+  ChangeAddressBottomSheet(
+    address: user.address,
+    postalCode: user.postalCode,
+    city: user.city,
+    country: user.country,
+  ),
+);
 
 Future<void> showChangePhoneSheetForUser(
   BuildContext context,
   UserExt user,
-) =>
-    _showSheet(
-      context,
-      user,
-      ChangePhoneNumberBottomSheet(
-        country: user.country,
-        phoneNumber: user.phoneNumber,
-      ),
-    );
+) => _showSheet(
+  context,
+  user,
+  ChangePhoneNumberBottomSheet(
+    country: user.country,
+    phoneNumber: user.phoneNumber,
+  ),
+);
 
 Future<void> showChangeBankDetailsSheetForUser(
   BuildContext context,
   UserExt user,
-) =>
-    _showSheet(
-      context,
-      user,
-      ChangeBankDetailsBottomSheet(
-        sortCode: user.sortCode,
-        accountNumber: user.accountNumber,
-        iban: user.iban,
-      ),
-    );
+) => _showSheet(
+  context,
+  user,
+  ChangeBankDetailsBottomSheet(
+    sortCode: user.sortCode,
+    accountNumber: user.accountNumber,
+    iban: user.iban,
+  ),
+);
 
 Future<void> _showSheet(
   BuildContext context,
   UserExt user,
   Widget sheet,
-) =>
-    showModalBottomSheet<void>(
+) async {
+  final authCubit = context.read<AuthCubit>();
+  final bloc = PersonalInfoEditBloc(
+    authRepository: getIt<AuthRepository>(),
+    loggedInUserExt: user,
+  );
+  try {
+    await showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       useSafeArea: true,
-      builder: (_) => BlocProvider(
-        create: (_) => PersonalInfoEditBloc(
-          authRepository: getIt<AuthRepository>(),
-          loggedInUserExt: user,
-        ),
+      builder: (_) => BlocProvider.value(
+        value: bloc,
         child: PersonalInfoEditFeedbackListener(
           child: sheet,
         ),
       ),
     );
+    if (!context.mounted) return;
+    resetPersonalInfoEditSheetOnDismiss(bloc, authCubit);
+  } finally {
+    await bloc.close();
+  }
+}

--- a/lib/features/account_details/widgets/personal_info_edit_sheet_success.dart
+++ b/lib/features/account_details/widgets/personal_info_edit_sheet_success.dart
@@ -1,15 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app/features/account_details/bloc/personal_info_edit_bloc.dart';
 import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 
 /// Closes a personal-info edit bottom sheet after an in-sheet success state.
+/// Reset and refresh are handled by [resetPersonalInfoEditSheetOnDismiss] when
+/// the modal future completes.
 void completePersonalInfoEditSheet(BuildContext context) {
-  context.read<PersonalInfoEditBloc>().add(
-        const PersonalInfoEditStatusReset(),
-      );
   Navigator.of(context).pop();
-  context.read<AuthCubit>().refreshUser();
 }
 
 /// Clears stale [PersonalInfoEditBloc] state when a bottom sheet is dismissed

--- a/lib/features/registration/pages/personal_info_page.dart
+++ b/lib/features/registration/pages/personal_info_page.dart
@@ -79,7 +79,11 @@ class _PersonalInfoPageState extends State<PersonalInfoPage> {
         actions: [
           IconButton(
             onPressed: () => FunBottomSheet(
-              closeAction: () => context.pop(),
+              closeAction: () {
+                if (context.mounted) {
+                  Navigator.of(context).pop();
+                }
+              },
               title: locals.personalInfo,
               content: BodyMediumText(
                 locals.informationPersonalData,

--- a/test/features/account_details/personal_info_edit_bottom_sheets_test.dart
+++ b/test/features/account_details/personal_info_edit_bottom_sheets_test.dart
@@ -18,6 +18,7 @@ import 'package:givt_app/shared/models/stripe_response.dart';
 import 'package:givt_app/shared/models/temp_user.dart';
 import 'package:givt_app/shared/models/user_ext.dart';
 import 'package:givt_app/features/amount_presets/models/models.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   late _FakeAuthRepository repository;
@@ -25,6 +26,7 @@ void main() {
   late PersonalInfoEditBloc personalInfoEditBloc;
 
   setUp(() {
+    SharedPreferences.setMockInitialValues({});
     repository = _FakeAuthRepository();
     authCubit = AuthCubit(repository);
     personalInfoEditBloc = PersonalInfoEditBloc(
@@ -69,20 +71,58 @@ void main() {
     );
   }
 
-  test('resetPersonalInfoEditSheetOnDismiss clears leaked success state', () async {
-    personalInfoEditBloc.add(
-      const PersonalInfoEditName(firstName: 'Jane', lastName: 'Doe'),
-    );
-    await personalInfoEditBloc.stream.firstWhere(
-      (state) => state.status == PersonalInfoEditStatus.success,
-    );
+  test(
+    'resetPersonalInfoEditSheetOnDismiss clears leaked success state',
+    () async {
+      personalInfoEditBloc.add(
+        const PersonalInfoEditName(firstName: 'Jane', lastName: 'Doe'),
+      );
+      await personalInfoEditBloc.stream.firstWhere(
+        (state) => state.status == PersonalInfoEditStatus.success,
+      );
 
-    resetPersonalInfoEditSheetOnDismiss(personalInfoEditBloc, authCubit);
+      resetPersonalInfoEditSheetOnDismiss(personalInfoEditBloc, authCubit);
 
-    await personalInfoEditBloc.stream.firstWhere(
-      (state) => state.status == PersonalInfoEditStatus.initial,
-    );
-  });
+      await personalInfoEditBloc.stream.firstWhere(
+        (state) => state.status == PersonalInfoEditStatus.initial,
+      );
+    },
+  );
+
+  testWidgets(
+    'completePersonalInfoEditSheet pops without post-pop provider access',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: ElevatedButton(
+                onPressed: () {
+                  showModalBottomSheet<void>(
+                    context: context,
+                    builder: (sheetContext) => TextButton(
+                      onPressed: () =>
+                          completePersonalInfoEditSheet(sheetContext),
+                      child: const Text('Done'),
+                    ),
+                  );
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      expect(find.text('Done'), findsOneWidget);
+
+      await tester.tap(find.text('Done'));
+      await tester.pumpAndSettle();
+      expect(find.text('Done'), findsNothing);
+    },
+  );
 
   testWidgets('name sheet disables save until name changes', (tester) async {
     await pumpSheet(
@@ -133,11 +173,16 @@ void main() {
     final locals = AppLocalizations.of(context)!;
 
     expect(find.text(locals.sortCodePlaceholder), findsAtLeastNWidgets(1));
-    expect(find.text(locals.bankAccountNumberPlaceholder), findsAtLeastNWidgets(1));
+    expect(
+      find.text(locals.bankAccountNumberPlaceholder),
+      findsAtLeastNWidgets(1),
+    );
     expect(find.text(locals.editIbanAccount), findsNothing);
   });
 
-  testWidgets('address sheet shows split fields for Netherlands', (tester) async {
+  testWidgets('address sheet shows split fields for Netherlands', (
+    tester,
+  ) async {
     await pumpSheet(
       tester,
       ChangeAddressBottomSheet(
@@ -157,7 +202,9 @@ void main() {
     expect(saveButton(tester).isDisabled, isTrue);
   });
 
-  testWidgets('address sheet shows single address field for UK', (tester) async {
+  testWidgets('address sheet shows single address field for UK', (
+    tester,
+  ) async {
     await pumpSheet(
       tester,
       ChangeAddressBottomSheet(
@@ -198,10 +245,10 @@ class _FakeAuthRepository with AuthRepository {
 
   @override
   Future<(UserExt, Session, UserPresets)?> isAuthenticated() async => (
-        const UserExt(email: '', guid: '', amountLimit: 0),
-        const Session.empty(),
-        const UserPresets.empty(),
-      );
+    const UserExt(email: '', guid: '', amountLimit: 0),
+    const Session.empty(),
+    const UserPresets.empty(),
+  );
 
   @override
   Future<bool> logout() async => true;
@@ -219,8 +266,7 @@ class _FakeAuthRepository with AuthRepository {
   Future<String> signSepaMandate({
     required String guid,
     required String appLanguage,
-  }) async =>
-      '';
+  }) async => '';
 
   @override
   Future<StripeResponse> fetchStripeSetupIntent() async =>
@@ -230,15 +276,13 @@ class _FakeAuthRepository with AuthRepository {
   Future<UserExt> registerUser({
     required TempUser tempUser,
     required bool isNewUser,
-  }) async =>
-      const UserExt(email: '', guid: '', amountLimit: 0);
+  }) async => const UserExt(email: '', guid: '', amountLimit: 0);
 
   @override
   Future<bool> changeGiftAid({
     required String guid,
     required bool giftAid,
-  }) async =>
-      true;
+  }) async => true;
 
   @override
   Future<bool> unregisterUser({required String email}) async => true;
@@ -247,8 +291,7 @@ class _FakeAuthRepository with AuthRepository {
   Future<bool> updateUser({
     required String guid,
     required Map<String, dynamic> newUserExt,
-  }) async =>
-      true;
+  }) async => true;
 
   @override
   Future<bool> updateUserExt(Map<String, dynamic> newUserExt) async => true;
@@ -256,8 +299,7 @@ class _FakeAuthRepository with AuthRepository {
   @override
   Future<bool> updateLocalUserPresets({
     required UserPresets newUserPresets,
-  }) async =>
-      true;
+  }) async => true;
 
   @override
   Future<void> checkUserExt({required String email}) async {}
@@ -267,8 +309,7 @@ class _FakeAuthRepository with AuthRepository {
     required String guid,
     required String notificationId,
     required bool notificationPermissionStatus,
-  }) async =>
-      true;
+  }) async => true;
 
   @override
   void updateSessionStream(bool hasSession) {


### PR DESCRIPTION
## Summary
- Fix registration personal info info-sheet close crash by using `Navigator.pop` with a mounted guard instead of `context.pop()` (GoRouter).
- Fix account-settings personal info edit sheets: `completePersonalInfoEditSheet` now only pops the modal; bloc reset and `refreshUser` run in `resetPersonalInfoEditSheetOnDismiss` after the sheet closes (Done, X, or barrier).
- Standalone personal info sheets (registration payment confirm, sign mandate) now await dismissal and run the same cleanup.
- Align email change success close with the shared safe close helper.

## Test plan
- [x] `make test` — 198 tests passed
- [x] `flutter analyze` on changed files — no errors (info/warnings only)
- [ ] Android APK build — skipped locally (no Android SDK in environment)
- [ ] Registration personal info: open info bottom sheet → tap X → no crash
- [ ] Account settings: edit name/phone/address/bank → save → tap Done/X → no crash, user data refreshes
- [ ] Account settings: edit email → save → tap Done/X → no crash, user data refreshes
- [ ] Registration payment confirm / sign mandate: edit personal info via standalone sheets → dismiss via barrier after success → user refreshes

Fixes ENG-974

Made with [Cursor](https://cursor.com)