### PR TITLE
fix(ENG-876): improve email address validation

### DIFF
--- a/lib/features/account_details/pages/change_email_address_bottom_sheet.dart
+++ b/lib/features/account_details/pages/change_email_address_bottom_sheet.dart
@@ -124,7 +124,7 @@ class _ChangeEmailAddressBottomSheetState
 
   bool _validateEmail(String invalidEmailMessage) {
     final value = emailController.text;
-    if (value.isEmpty || !value.contains(Util.emailRegEx)) {
+    if (value.isEmpty || !Util.emailRegEx.hasMatch(value)) {
       setState(() {
         _emailError = invalidEmailMessage;
       });
@@ -140,6 +140,6 @@ class _ChangeEmailAddressBottomSheetState
     final text = emailController.text;
     if (text == widget.email) return false;
     if (text.isEmpty) return false;
-    return text.contains(Util.emailRegEx);
+    return Util.emailRegEx.hasMatch(text);
   }
 }

--- a/lib/features/family/features/reset_password/presentation/pages/reset_password_sheet.dart
+++ b/lib/features/family/features/reset_password/presentation/pages/reset_password_sheet.dart
@@ -173,7 +173,7 @@ class _ResetPasswordSheetState extends State<ResetPasswordSheet> {
 
   bool _validateEmail(String invalidEmailMessage) {
     final value = emailController.text;
-    if (value.isEmpty || !value.contains(Util.emailRegEx)) {
+    if (value.isEmpty || !Util.emailRegEx.hasMatch(value)) {
       setState(() {
         _emailError = invalidEmailMessage;
       });
@@ -189,6 +189,6 @@ class _ResetPasswordSheetState extends State<ResetPasswordSheet> {
     if (widget.initialEmail.isNotEmpty) return true;
     final text = emailController.text;
     if (text.isEmpty) return false;
-    return text.contains(Util.emailRegEx);
+    return Util.emailRegEx.hasMatch(text);
   }
 }

--- a/lib/utils/util.dart
+++ b/lib/utils/util.dart
@@ -42,7 +42,8 @@ class Util {
       RegExp(r'^(\([0-9]{3}\) |[0-9]{3}-)[0-9]{3}-[0-9]{4}$');
   static final ukSortCodeRegEx = RegExp(r'^\d{2}-\d{2}-\d{2}$');
   static final emailRegEx = RegExp(
-      r'^(?!.*\.\.)[a-zA-Z0-9][\w-\.]*[a-zA-Z0-9_\.]?(\+[\w-\.]+)?@([\w-]+\.)+[\w]+$');
+    r'^(?!.*\.\.)[a-zA-Z0-9]([\w-\.]*[a-zA-Z0-9_ ])?(\+[\w-\.]*[a-zA-Z0-9_])?@([\w-]+\.)+[\w]+$',
+  );
   static final nameFieldsRegEx =
       RegExp(r'^[^0-9_!,¡?÷?¿/\\+=@#$%ˆ&*(){}|~<>;:[\]]{2,}$');
 

--- a/lib/utils/util.dart
+++ b/lib/utils/util.dart
@@ -42,7 +42,7 @@ class Util {
       RegExp(r'^(\([0-9]{3}\) |[0-9]{3}-)[0-9]{3}-[0-9]{4}$');
   static final ukSortCodeRegEx = RegExp(r'^\d{2}-\d{2}-\d{2}$');
   static final emailRegEx = RegExp(
-    r'^(?!.*\.\.)[a-zA-Z0-9]([\w-\.]*[a-zA-Z0-9_ ])?(\+[\w-\.]*[a-zA-Z0-9_])?@([\w-]+\.)+[\w]+$',
+    r'^(?!.*\.\.)[a-zA-Z0-9]([\w-\.]*[a-zA-Z0-9_])?(\+[\w-\.]*[a-zA-Z0-9_])?@([\w-]+\.)+[\w]+$',
   );
   static final nameFieldsRegEx =
       RegExp(r'^[^0-9_!,¡?÷?¿/\\+=@#$%ˆ&*(){}|~<>;:[\]]{2,}$');

--- a/test/utils/util_test.dart
+++ b/test/utils/util_test.dart
@@ -30,6 +30,39 @@ void main() {
     });
   });
 
+  group('Util.emailRegEx', () {
+    const validEmails = [
+      'user@example.com',
+      'user.name@example.co.uk',
+      'user+tag@example.com',
+      'u@example.com',
+      'user_name@example.com',
+    ];
+
+    const invalidEmails = [
+      'donna.@givtapp.net',
+      'user.+@example.com',
+      'user+tag.@example.com',
+      '.user@example.com',
+      'user..name@example.com',
+      '@example.com',
+      'user@example',
+      '',
+    ];
+
+    for (final email in validEmails) {
+      test('should validate $email as valid', () {
+        expect(Util.emailRegEx.hasMatch(email), isTrue);
+      });
+    }
+
+    for (final email in invalidEmails) {
+      test('should validate $email as invalid', () {
+        expect(Util.emailRegEx.hasMatch(email), isFalse);
+      });
+    }
+  });
+
   group('Util.resolveLocale', () {
     const supportedLocales = [
       Locale('de'),

--- a/test/utils/util_test.dart
+++ b/test/utils/util_test.dart
@@ -45,6 +45,7 @@ void main() {
       'user+tag.@example.com',
       '.user@example.com',
       'user..name@example.com',
+      'user @example.com',
       '@example.com',
       'user@example',
       '',


### PR DESCRIPTION
## Summary
- Reject invalid email local parts: trailing dots, consecutive dots, leading dots, and trailing spaces before `@` (e.g. `donna.@givtapp.net`, `user @example.com`)
- Centralize stricter rules in `Util.emailRegEx` with unit test coverage
- Use `hasMatch` consistently in change-email and reset-password sheets (Bugbot follow-up)

## Test plan
- [x] `flutter test test/utils/util_test.dart` — all email regex tests pass
- [x] `flutter analyze` — no new errors (pre-existing info-level findings only)
- [ ] Email signup: `donna.@givtapp.net` rejected; `user.name@example.co.uk` and `user+tag@example.com` accepted
- [ ] Change email (account details): same invalid address blocked
- [ ] Reset password sheet: same invalid address blocked

Linear: https://linear.app/givt/issue/ENG-876

Made with [Cursor](https://cursor.com)