### PR TITLE
feat(ENG-1015): add donation type properties to personal summary continue event

### DIFF
--- a/lib/features/personal_summary/widgets/personal_summary_sheets.dart
+++ b/lib/features/personal_summary/widgets/personal_summary_sheets.dart
@@ -4,7 +4,6 @@ import 'package:givt_app/core/enums/enums.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/texts.dart';
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/shared/design_system/design_system.dart';
-import 'package:givt_app/shared/models/analytics_event.dart';
 
 enum _AddDonationOption { giveThroughGivt, addExternal }
 
@@ -77,8 +76,13 @@ class _AddDonationBottomSheetState extends State<AddDonationBottomSheet> {
       primaryButton: FunButton(
         text: locals.buttonContinue,
         isDisabled: _selected == null,
-        analyticsEvent: AnalyticsEvent(
-          AnalyticsEventName.personalSummaryAddDonationContinueClicked,
+        analyticsEvent: AnalyticsEventName
+            .personalSummaryAddDonationContinueClicked
+            .toEvent(
+          parameters: {
+            'givt_donation': _selected == _AddDonationOption.giveThroughGivt,
+            'external_donation': _selected == _AddDonationOption.addExternal,
+          },
         ),
         onTap: _selected == null
             ? null


### PR DESCRIPTION
## Summary
- Add `givt_donation` and `external_donation` boolean properties to the `personal_summary_add_donation_continue_clicked` PostHog event in `AddDonationBottomSheet`.
- Properties reflect the user's selected donation option when tapping Continue (mutually exclusive; only sent when a selection is made).

## Test plan
- [ ] Open Personal Summary and trigger the add-donation bottom sheet
- [ ] Select "Give through Givt" and tap Continue — verify `personal_summary_add_donation_continue_clicked` fires with `givt_donation: true`, `external_donation: false`
- [ ] Repeat with "Add external donation" — verify `givt_donation: false`, `external_donation: true`
- [ ] Verify Continue remains disabled until an option is selected (no event with both flags false)


Made with [Cursor](https://cursor.com)