### PR TITLE
Track home FAQ icon clicks in PostHog (ENG-1050)

### DIFF
--- a/lib/core/enums/analytics_event_name.dart
+++ b/lib/core/enums/analytics_event_name.dart
@@ -678,7 +678,8 @@ enum AnalyticsEventName {
   flowGenericErrorContactSupportClicked(
     'flow_generic_error_contact_support_clicked',
   ),
-  flowGenericErrorGoHomeClicked('flow_generic_error_go_home_clicked');
+  flowGenericErrorGoHomeClicked('flow_generic_error_go_home_clicked'),
+  homeFaqIconClicked('home_faq_icon_clicked');
 
   const AnalyticsEventName(this.value);
 

--- a/lib/features/give/pages/home_page.dart
+++ b/lib/features/give/pages/home_page.dart
@@ -11,6 +11,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:givt_app/app/injection/injection.dart';
 import 'package:givt_app/app/routes/routes.dart';
 import 'package:givt_app/core/config/app_config.dart';
+import 'package:givt_app/core/enums/analytics_event_name.dart';
 import 'package:givt_app/core/logging/logging.dart';
 import 'package:givt_app/core/network/request_helper.dart';
 import 'package:givt_app/core/notification/notification.dart';
@@ -272,13 +273,20 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
           ),
           actions: [
             IconButton(
-              onPressed: () => showModalBottomSheet<void>(
-                context: context,
-                isScrollControlled: true,
-                useSafeArea: true,
-                backgroundColor: AppTheme.givtPurple,
-                builder: (_) => const FAQBottomSheet(),
-              ),
+              onPressed: () {
+                unawaited(
+                  AnalyticsHelper.logEvent(
+                    eventName: AnalyticsEventName.homeFaqIconClicked,
+                  ),
+                );
+                showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  useSafeArea: true,
+                  backgroundColor: AppTheme.givtPurple,
+                  builder: (_) => const FAQBottomSheet(),
+                );
+              },
               icon: const Icon(
                 semanticLabel: 'homeQuestionMark',
                 Icons.question_mark_outlined,

--- a/lib/features/give/pages/home_page.dart
+++ b/lib/features/give/pages/home_page.dart
@@ -272,25 +272,29 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
             ),
           ),
           actions: [
-            IconButton(
-              onPressed: () {
-                unawaited(
-                  AnalyticsHelper.logEvent(
-                    eventName: AnalyticsEventName.homeFaqIconClicked,
-                  ),
-                );
-                showModalBottomSheet<void>(
-                  context: context,
-                  isScrollControlled: true,
-                  useSafeArea: true,
-                  backgroundColor: AppTheme.givtPurple,
-                  builder: (_) => const FAQBottomSheet(),
-                );
-              },
-              icon: const Icon(
-                semanticLabel: 'homeQuestionMark',
-                Icons.question_mark_outlined,
-                size: 26,
+            Semantics(
+              identifier: 'homeQuestionMark',
+              button: true,
+              child: IconButton(
+                onPressed: () {
+                  unawaited(
+                    AnalyticsHelper.logEvent(
+                      eventName: AnalyticsEventName.homeFaqIconClicked,
+                    ),
+                  );
+                  showModalBottomSheet<void>(
+                    context: context,
+                    isScrollControlled: true,
+                    useSafeArea: true,
+                    backgroundColor: AppTheme.givtPurple,
+                    builder: (_) => const FAQBottomSheet(),
+                  );
+                },
+                icon: const Icon(
+                  semanticLabel: 'homeQuestionMark',
+                  Icons.question_mark_outlined,
+                  size: 26,
+                ),
               ),
             ),
             Visibility(

--- a/test/Maestro/README.md
+++ b/test/Maestro/README.md
@@ -90,6 +90,7 @@ In Flutter, expose IDs via `Semantics(identifier: …)` or the `semanticsIdentif
 | ID | Element |
 |----|---------|
 | `homeMenu` | Home drawer menu button |
+| `homeQuestionMark` | Home FAQ question mark button |
 | `menuPersonalInfo` | Drawer → Personal info |
 | `accountSettingsScreen` | Account settings page |
 | `accountSettingsRowChangePassword` | Change password row |

--- a/test/core/enums/analytics_event_name_test.dart
+++ b/test/core/enums/analytics_event_name_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/core/enums/analytics_event_name.dart';
+
+void main() {
+  group('AnalyticsEventName.homeFaqIconClicked', () {
+    test('uses the expected PostHog event name', () {
+      expect(
+        AnalyticsEventName.homeFaqIconClicked.value,
+        'home_faq_icon_clicked',
+      );
+    });
+
+    test('builds an AnalyticsEvent without parameters', () {
+      final event = AnalyticsEventName.homeFaqIconClicked.toEvent();
+
+      expect(event.name, AnalyticsEventName.homeFaqIconClicked);
+      expect(event.parameters, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Log `home_faq_icon_clicked` when users tap the question mark help icon on `HomePage`.
- Add `Semantics(identifier: 'homeQuestionMark')` on the FAQ button for Maestro/accessibility parity with `homeMenu`.
- Add unit tests for the new `AnalyticsEventName.homeFaqIconClicked` enum value.

## Test plan
- [x] `flutter analyze` (pre-existing info-level findings only)
- [x] `make test` — 206 tests passed
- [ ] `flutter build apk` — skipped locally (no Android SDK); CI build on merge
- [ ] Manual: tap FAQ icon on Home → verify `home_faq_icon_clicked` in PostHog live events
- [ ] Manual: confirm FAQ bottom sheet still opens after tap

Closes ENG-1050

Made with [Cursor](https://cursor.com)