### PR TITLE
Show pledge transaction progress on detail summary tile

### DIFF
--- a/lib/features/pledges/detail/cubit/pledge_detail_cubit.dart
+++ b/lib/features/pledges/detail/cubit/pledge_detail_cubit.dart
@@ -46,8 +46,8 @@ class PledgeDetailCubit extends CommonCubit<PledgeDetailUIModel, dynamic> {
       group: group,
       givenSoFar: group.givenSoFar,
       totalPledged: group.totalPledged,
-      recurringTotal: group.upcomingRecurringTotal ?? 0,
-      recurringFrequency: _resolveRecurringFrequency(group.goals),
+      completedTransactionCount: group.completedTransactionCount,
+      totalTransactionCount: group.totalTransactionCount,
       goalProgress: group.goals
           .map(
             (goal) => PledgeGoalProgress(
@@ -61,13 +61,4 @@ class PledgeDetailCubit extends CommonCubit<PledgeDetailUIModel, dynamic> {
     );
   }
 
-  /// Shared frequency when all goals match; otherwise first goal's frequency.
-  String? _resolveRecurringFrequency(List<PledgeGoal> goals) {
-    if (goals.isEmpty) {
-      return null;
-    }
-    final first = goals.first.frequency;
-    final allSame = goals.every((goal) => goal.frequency == first);
-    return allSame ? first : null;
-  }
 }

--- a/lib/features/pledges/detail/cubit/pledge_detail_state.dart
+++ b/lib/features/pledges/detail/cubit/pledge_detail_state.dart
@@ -5,8 +5,8 @@ class PledgeDetailUIModel {
     required this.group,
     required this.givenSoFar,
     required this.totalPledged,
-    required this.recurringTotal,
-    required this.recurringFrequency,
+    required this.completedTransactionCount,
+    required this.totalTransactionCount,
     required this.goalProgress,
     required this.history,
   });
@@ -14,8 +14,8 @@ class PledgeDetailUIModel {
   final PledgeGroup group;
   final double givenSoFar;
   final double? totalPledged;
-  final double recurringTotal;
-  final String? recurringFrequency;
+  final int completedTransactionCount;
+  final int totalTransactionCount;
   final List<PledgeGoalProgress> goalProgress;
   final List<PledgeHistoryItem> history;
 
@@ -26,8 +26,8 @@ class PledgeDetailUIModel {
         other.group == group &&
         other.givenSoFar == givenSoFar &&
         other.totalPledged == totalPledged &&
-        other.recurringTotal == recurringTotal &&
-        other.recurringFrequency == recurringFrequency &&
+        other.completedTransactionCount == completedTransactionCount &&
+        other.totalTransactionCount == totalTransactionCount &&
         other.goalProgress == goalProgress &&
         other.history == history;
   }
@@ -37,8 +37,8 @@ class PledgeDetailUIModel {
         group,
         givenSoFar,
         totalPledged,
-        recurringTotal,
-        recurringFrequency,
+        completedTransactionCount,
+        totalTransactionCount,
         goalProgress,
         history,
       );

--- a/lib/features/pledges/detail/widgets/pledge_detail_summary_tiles.dart
+++ b/lib/features/pledges/detail/widgets/pledge_detail_summary_tiles.dart
@@ -3,7 +3,6 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:givt_app/core/datetime/api_date_time.dart';
 import 'package:givt_app/core/enums/analytics_event_name.dart';
 import 'package:givt_app/features/pledges/detail/cubit/pledge_detail_cubit.dart';
-import 'package:givt_app/features/pledges/shared/pledge_display.dart';
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/shared/design_system/design_system.dart';
 
@@ -23,30 +22,28 @@ class PledgeDetailSummaryTiles extends StatelessWidget {
   Widget build(BuildContext context) {
     final locals = context.l10n;
     final endDate = uiModel.group.endDateTime;
-    final frequencyLabel = uiModel.recurringFrequency == null
-        ? null
-        : PledgeDisplay.formatFrequency(locals, uiModel.recurringFrequency!);
+    final showTransactionTile = uiModel.totalTransactionCount > 0;
 
     return Row(
       children: [
-        Expanded(
-          child: FunTile(
-            variant: FunTileVariant.six,
-            iconData: FontAwesomeIcons.arrowsRotate,
-            assetSize: 32,
-            iconPath: '',
-            analyticsEvent:
-                AnalyticsEventName.pledgesDetailOpened.toEvent(),
-            isPressedDown: true,
-            titleBig: PledgeDisplay.formatAmount(
-              amount: uiModel.recurringTotal,
-              countryCode: countryCode,
+        if (showTransactionTile) ...[
+          Expanded(
+            child: FunTile(
+              variant: FunTileVariant.six,
+              iconData: FontAwesomeIcons.arrowsRotate,
+              assetSize: 32,
+              iconPath: '',
+              analyticsEvent:
+                  AnalyticsEventName.pledgesDetailOpened.toEvent(),
+              isPressedDown: true,
+              titleBig:
+                  '${uiModel.completedTransactionCount} / ${uiModel.totalTransactionCount}',
+              subtitle: locals.pledgesDetailTransactionsLabel,
             ),
-            subtitle: frequencyLabel ?? '',
           ),
-        ),
+        ],
         if (endDate != null) ...[
-          const SizedBox(width: 16),
+          if (showTransactionTile) const SizedBox(width: 16),
           Expanded(
             child: FunTile(
               variant: FunTileVariant.six,

--- a/lib/features/pledges/shared/models/pledge.dart
+++ b/lib/features/pledges/shared/models/pledge.dart
@@ -62,8 +62,27 @@ class PledgeTransaction extends Equatable {
       id: json['id'].toString(),
       amount: (json['amount'] as num).toDouble(),
       executionDate: (json['executionDate'] ?? json['donationDate']) as String,
-      state: (json['state'] ?? json['status']) as String,
+      state: parseState(json['state'] ?? json['status']),
     );
+  }
+
+  /// Maps [PledgeTransactionState] from the pledge API (string or int).
+  static String parseState(dynamic raw) {
+    if (raw is int) {
+      return switch (raw) {
+        2 => 'Processed',
+        3 => 'Canceled',
+        _ => 'Entered',
+      };
+    }
+
+    final value = raw?.toString();
+    return switch (value) {
+      'Processed' || '2' => 'Processed',
+      'Canceled' || '3' => 'Canceled',
+      'Entered' || '1' || null || '' => 'Entered',
+      _ => value,
+    };
   }
 
   final String id;
@@ -74,6 +93,11 @@ class PledgeTransaction extends Equatable {
   bool get isProcessed => state == 'Processed';
 
   bool get isEntered => state == 'Entered';
+
+  bool get isCanceled => state == 'Canceled';
+
+  /// Entered or Processed; canceled pledge transactions are excluded from counts.
+  bool get isScheduled => isEntered || isProcessed;
 
   DateTime? get executionDateTime => ApiDateTime.parseLocal(executionDate);
 
@@ -271,6 +295,14 @@ class PledgeGoal extends Equatable {
       .where((donation) => donation.isProcessed)
       .fold(0, (sum, donation) => sum + donation.amount);
 
+  /// Completed scheduled pledge transactions ([PledgeTransaction.isProcessed]).
+  int get completedPledgeTransactionCount =>
+      transactions.where((transaction) => transaction.isProcessed).length;
+
+  /// Scheduled pledge transactions (Entered + Processed; not wallet donations).
+  int get totalPledgeTransactionCount =>
+      transactions.where((transaction) => transaction.isScheduled).length;
+
   /// Wallet donations on detail; otherwise processed scheduled transactions.
   double get displayGivenAmount {
     if (donations.isNotEmpty) {
@@ -351,6 +383,18 @@ class PledgeGroup extends Equatable {
     }
     return targets.fold<double>(0, (sum, target) => sum + target!);
   }
+
+  /// All scheduled pledge transactions across goals (non-canceled in API).
+  int get totalTransactionCount => goals.fold(
+        0,
+        (sum, goal) => sum + goal.totalPledgeTransactionCount,
+      );
+
+  /// Scheduled pledge transactions with [PledgeTransaction.isProcessed] state.
+  int get completedTransactionCount => goals.fold(
+        0,
+        (sum, goal) => sum + goal.completedPledgeTransactionCount,
+      );
 
   /// Denominator for the segmented "Given so far" bar (Figma).
   double? get segmentBarTotal {

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -898,6 +898,7 @@
   },
   "pledgesDetailEditButton": "Zusage bearbeiten",
   "pledgesDetailEndsLabel": "Endet",
+  "pledgesDetailTransactionsLabel": "Transaktionen",
   "pledgesEditRequestTitle": "Zusageänderung anfragen",
   "pledgesEditRequestBody": "Du kannst deine Zusage noch nicht selbst ändern. Sag uns, was du ändern möchtest, und wir melden uns bei dir.",
   "pledgesEditRequestPrefilledText": "Ich möchte meine Zusage ändern:",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -898,6 +898,7 @@
   },
   "pledgesDetailEditButton": "Edit pledge",
   "pledgesDetailEndsLabel": "Ends",
+  "pledgesDetailTransactionsLabel": "Transactions",
   "pledgesEditRequestTitle": "Request a pledge change",
   "pledgesEditRequestBody": "You can't change your pledge yourself yet. Tell us what you'd like to change and we'll get back to you.",
   "pledgesEditRequestPrefilledText": "I'd like to change my pledge:",

--- a/lib/l10n/arb/app_en_US.arb
+++ b/lib/l10n/arb/app_en_US.arb
@@ -894,6 +894,7 @@
   },
   "pledgesDetailEditButton": "Edit pledge",
   "pledgesDetailEndsLabel": "Ends",
+  "pledgesDetailTransactionsLabel": "Transactions",
   "pledgesEditRequestTitle": "Request a pledge change",
   "pledgesEditRequestBody": "You can't change your pledge yourself yet. Tell us what you'd like to change and we'll get back to you.",
   "pledgesEditRequestPrefilledText": "I'd like to change my pledge:",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -898,6 +898,7 @@
   },
   "pledgesDetailEditButton": "Editar compromiso",
   "pledgesDetailEndsLabel": "Finaliza",
+  "pledgesDetailTransactionsLabel": "Transacciones",
   "pledgesEditRequestTitle": "Solicitar un cambio de compromiso",
   "pledgesEditRequestBody": "Aún no puedes cambiar tu compromiso tú mismo. Cuéntanos qué te gustaría cambiar y nos pondremos en contacto contigo.",
   "pledgesEditRequestPrefilledText": "Me gustaría cambiar mi compromiso:",

--- a/lib/l10n/arb/app_es_419.arb
+++ b/lib/l10n/arb/app_es_419.arb
@@ -894,6 +894,7 @@
   },
   "pledgesDetailEditButton": "Editar compromiso",
   "pledgesDetailEndsLabel": "Finaliza",
+  "pledgesDetailTransactionsLabel": "Transacciones",
   "pledgesEditRequestTitle": "Solicitar un cambio de compromiso",
   "pledgesEditRequestBody": "Aún no puedes cambiar tu compromiso tú mismo. Cuéntanos qué te gustaría cambiar y nos pondremos en contacto contigo.",
   "pledgesEditRequestPrefilledText": "Me gustaría cambiar mi compromiso:",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -2265,6 +2265,12 @@ abstract class AppLocalizations {
   /// **'Ends'**
   String get pledgesDetailEndsLabel;
 
+  /// No description provided for @pledgesDetailTransactionsLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Transactions'**
+  String get pledgesDetailTransactionsLabel;
+
   /// No description provided for @pledgesEditRequestTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -1242,6 +1242,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get pledgesDetailEndsLabel => 'Endet';
 
   @override
+  String get pledgesDetailTransactionsLabel => 'Transaktionen';
+
+  @override
   String get pledgesEditRequestTitle => 'Zusageänderung anfragen';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -1233,6 +1233,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pledgesDetailEndsLabel => 'Ends';
 
   @override
+  String get pledgesDetailTransactionsLabel => 'Transactions';
+
+  @override
   String get pledgesEditRequestTitle => 'Request a pledge change';
 
   @override
@@ -4732,6 +4735,9 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
 
   @override
   String get pledgesDetailEndsLabel => 'Ends';
+
+  @override
+  String get pledgesDetailTransactionsLabel => 'Transactions';
 
   @override
   String get pledgesEditRequestTitle => 'Request a pledge change';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -1233,6 +1233,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get pledgesDetailEndsLabel => 'Finaliza';
 
   @override
+  String get pledgesDetailTransactionsLabel => 'Transacciones';
+
+  @override
   String get pledgesEditRequestTitle => 'Solicitar un cambio de compromiso';
 
   @override
@@ -4753,6 +4756,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get pledgesDetailEndsLabel => 'Finaliza';
+
+  @override
+  String get pledgesDetailTransactionsLabel => 'Transacciones';
 
   @override
   String get pledgesEditRequestTitle => 'Solicitar un cambio de compromiso';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -1237,6 +1237,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get pledgesDetailEndsLabel => 'Eindigt';
 
   @override
+  String get pledgesDetailTransactionsLabel => 'Transacties';
+
+  @override
   String get pledgesEditRequestTitle => 'Toezegging wijzigen aanvragen';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -898,6 +898,7 @@
   },
   "pledgesDetailEditButton": "Toezegging bewerken",
   "pledgesDetailEndsLabel": "Eindigt",
+  "pledgesDetailTransactionsLabel": "Transacties",
   "pledgesEditRequestTitle": "Toezegging wijzigen aanvragen",
   "pledgesEditRequestBody": "Je kunt je toezegging nog niet zelf wijzigen. Laat ons weten wat je wilt veranderen, dan nemen we contact met je op.",
   "pledgesEditRequestPrefilledText": "Ik wil mijn toezegging wijzigen:",

--- a/test/features/pledges/pledge_detail_test.dart
+++ b/test/features/pledges/pledge_detail_test.dart
@@ -17,6 +17,32 @@ void main() {
       expect(transaction.isProcessed, isTrue);
       expect(transaction.executionDateTime, isNotNull);
     });
+
+    test('fromJson parses numeric PledgeTransactionState values', () {
+      final entered = PledgeTransaction.fromJson({
+        'id': 'tx-1',
+        'amount': 10,
+        'executionDate': '2026-06-15T00:00:00Z',
+        'state': 1,
+      });
+      final processed = PledgeTransaction.fromJson({
+        'id': 'tx-2',
+        'amount': 10,
+        'executionDate': '2026-06-15T00:00:00Z',
+        'state': 2,
+      });
+
+      expect(entered.isEntered, isTrue);
+      expect(processed.isProcessed, isTrue);
+    });
+
+    test('parseState maps backend enum values', () {
+      expect(PledgeTransaction.parseState('Entered'), 'Entered');
+      expect(PledgeTransaction.parseState('Processed'), 'Processed');
+      expect(PledgeTransaction.parseState(1), 'Entered');
+      expect(PledgeTransaction.parseState(2), 'Processed');
+      expect(PledgeTransaction.parseState(3), 'Canceled');
+    });
   });
 
   group('PledgeDonation', () {
@@ -109,6 +135,145 @@ void main() {
       expect(group.givenSoFar, 350);
       expect(group.totalPledged, 2400);
       expect(group.segmentBarTotal, 2400);
+    });
+
+    test('transaction counts sum processed and total across goals', () {
+      expect(group.totalTransactionCount, 3);
+      expect(group.completedTransactionCount, 3);
+    });
+
+    test('transaction counts treat Entered as not completed', () {
+      final singleGoalGroup = PledgeGroup.fromJson({
+        'pledgeGroupId': 'group-1',
+        'pledgeGroupName': 'Actie Kerkbalans',
+        'collectGroupId': 'church-1',
+        'collectGroupNamespace': 'church',
+        'collectGroupName': 'Church',
+        'goals': [
+          {
+            'id': 'goal-1',
+            'goalId': 'g1',
+            'goalName': 'Church fund',
+            'totalAmount': 450,
+            'type': 'Online',
+            'transactions': [
+              {
+                'id': 'tx-1',
+                'amount': 150,
+                'executionDate': '2026-04-15T00:00:00Z',
+                'state': 'Processed',
+              },
+              {
+                'id': 'tx-2',
+                'amount': 150,
+                'executionDate': '2026-05-15T00:00:00Z',
+                'state': 'Processed',
+              },
+              {
+                'id': 'tx-3',
+                'amount': 150,
+                'executionDate': '2026-06-15T00:00:00Z',
+                'state': 'Entered',
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(singleGoalGroup.totalTransactionCount, 3);
+      expect(singleGoalGroup.completedTransactionCount, 2);
+    });
+
+    test('transaction counts are zero when no transactions exist', () {
+      final emptyGroup = PledgeGroup.fromJson({
+        'pledgeGroupId': 'group-1',
+        'pledgeGroupName': 'Actie Kerkbalans',
+        'collectGroupId': 'church-1',
+        'collectGroupNamespace': 'church',
+        'collectGroupName': 'Church',
+        'goals': [
+          {
+            'id': 'goal-1',
+            'goalId': 'g1',
+            'goalName': 'Church fund',
+            'totalAmount': 0,
+            'type': 'Online',
+            'transactions': const [],
+          },
+        ],
+      });
+
+      expect(emptyGroup.totalTransactionCount, 0);
+      expect(emptyGroup.completedTransactionCount, 0);
+    });
+
+    test('transaction counts ignore wallet donations', () {
+      final groupWithDonations = PledgeGroup.fromJson({
+        'pledgeGroupId': 'group-1',
+        'pledgeGroupName': 'Actie Kerkbalans',
+        'collectGroupId': 'church-1',
+        'collectGroupNamespace': 'church',
+        'collectGroupName': 'Church',
+        'goals': [
+          {
+            'id': 'goal-1',
+            'goalId': 'g1',
+            'goalName': 'Church fund',
+            'totalAmount': 450,
+            'type': 'Online',
+            'transactions': [
+              {
+                'id': 'tx-1',
+                'amount': 150,
+                'executionDate': '2026-04-15T00:00:00Z',
+                'state': 'Processed',
+              },
+              {
+                'id': 'tx-2',
+                'amount': 150,
+                'executionDate': '2026-05-15T00:00:00Z',
+                'state': 'Entered',
+              },
+              {
+                'id': 'tx-3',
+                'amount': 150,
+                'executionDate': '2026-06-15T00:00:00Z',
+                'state': 'Entered',
+              },
+            ],
+            'donations': [
+              {
+                'id': 1,
+                'amount': 150,
+                'donationDate': '2026-04-15T00:00:00Z',
+                'status': 'Processed',
+              },
+              {
+                'id': 2,
+                'amount': 150,
+                'donationDate': '2026-05-15T00:00:00Z',
+                'status': 'Processed',
+              },
+              {
+                'id': 3,
+                'amount': 150,
+                'donationDate': '2026-06-15T00:00:00Z',
+                'status': 'Processed',
+              },
+              {
+                'id': 4,
+                'amount': 150,
+                'donationDate': '2026-07-15T00:00:00Z',
+                'status': 'Processed',
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(groupWithDonations.totalTransactionCount, 3);
+      expect(groupWithDonations.completedTransactionCount, 1);
+      expect(groupWithDonations.givenSoFar, 600);
     });
 
     test('segmentBarTotal falls back to givenSoFar without commitment totals', () {


### PR DESCRIPTION
## Summary
- Replace the pledge detail left summary tile (amount + frequency) with completed vs total scheduled pledge transaction counts (`Processed` / total)
- Derive counts from `goal.transactions[].state` (not wallet donations), with robust string/int state parsing
- Add `pledgesDetailTransactionsLabel` l10n and unit tests for aggregation

## Test plan
- [ ] Open a pledge detail screen with scheduled transactions and confirm the left tile shows `{completed} / {total}` with label “Transactions”
- [ ] Confirm completed count only increases for `Processed` pledge transactions (not wallet donations alone)
- [ ] Confirm left tile is hidden when there are no scheduled transactions
- [ ] Confirm “Ends” tile still shows correctly when an end date exists
- [ ] Run `flutter test test/features/pledges/pledge_detail_test.dart`


Made with [Cursor](https://cursor.com)