### PR TITLE
Fix null country crash on email signup continue tap (ENG-708)

### DIFF
--- a/integration_test/eu_login_test.dart
+++ b/integration_test/eu_login_test.dart
@@ -23,6 +23,7 @@ void main() {
 
 
     await emailSignupPage.verifyEmailInputIsVisible();
+    await emailSignupPage.selectCountry('Netherlands');
     await emailSignupPage.enterEmail('tamara+test3@givtapp.net');
     await emailSignupPage.tapContinueButton();
 

--- a/integration_test/features/email_signup/presentation/pages/email_signup_test_page.dart
+++ b/integration_test/features/email_signup/presentation/pages/email_signup_test_page.dart
@@ -13,7 +13,7 @@ class EmailSignupTestPage {
   final Finder emailInput = find.byKey(const ValueKey('Email-Input'));
   final Finder continueButton = find.byKey(const ValueKey('Email-Continue-Button'));
   final Finder scrollable = find.byKey(const ValueKey('Email-Signup-Scrollable'));
-  final Finder countryDropdown = find.byKey(const ValueKey('Country-Dropdown'));
+  final Finder countryDropdown = find.byKey(const ValueKey('CountryDropDown'));
 
   // Actions
   Future<void> enterEmail(String email) async {

--- a/lib/features/email_signup/cubit/email_signup_cubit.dart
+++ b/lib/features/email_signup/cubit/email_signup_cubit.dart
@@ -140,14 +140,18 @@ class EmailSignupCubit
   Future<void> login() async {
     emitCustom(const EmailSignupCustom.checkingEmail());
 
-    if (!shouldContinueBeEnabled(_currentEmail)) {
-      // It shouldn't be possible to get here
+    final country = _currentCountry;
+    if (country == null) {
+      emitSnackbarMessage('Please select a country');
+      return;
+    }
+
+    if (!validateEmail(_currentEmail)) {
       emitSnackbarMessage('Invalid email address');
       return;
     }
 
-    if (!_currentCountry!.isUS) {
-      // It shouldn't be possible to get here
+    if (!country.isUS) {
       emitSnackbarMessage("EU shouldn't make use of family login");
       return;
     }
@@ -182,9 +186,9 @@ class EmailSignupCubit
     final tempUser = TempUser.prefilled(
       email: _currentEmail,
       appLanguage: _language!,
-      country: _currentCountry!.countryCode,
+      country: country.countryCode,
       timeZoneId: (await FlutterTimezone.getLocalTimezone()).identifier,
-      amountLimit: _currentCountry!.isUS ? 4999 : 499,
+      amountLimit: country.isUS ? 4999 : 499,
     );
 
     try {

--- a/lib/features/email_signup/cubit/email_signup_cubit.dart
+++ b/lib/features/email_signup/cubit/email_signup_cubit.dart
@@ -37,7 +37,7 @@ class EmailSignupCubit
       EmailSignupUiModel(
         email: _currentEmail,
         country: _currentCountry,
-        continueButtonEnabled: validateEmail(_currentEmail),
+        continueButtonEnabled: shouldContinueBeEnabled(_currentEmail),
       ),
     );
   }
@@ -90,12 +90,14 @@ class EmailSignupCubit
       EmailSignupUiModel(
         email: _currentEmail,
         country: _currentCountry,
-        continueButtonEnabled: validateEmail(_currentEmail),
+        continueButtonEnabled: shouldContinueBeEnabled(_currentEmail),
       ),
     );
   }
 
   void updateApi() {
+    if (_currentCountry == null) return;
+
     var baseUrl = const String.fromEnvironment('API_URL_EU');
 
     if (_currentCountry!.isUS) {

--- a/lib/features/email_signup/presentation/pages/email_signup_page.dart
+++ b/lib/features/email_signup/presentation/pages/email_signup_page.dart
@@ -73,6 +73,7 @@ class _EmailSignupPageState extends State<EmailSignupPage> {
   }
 
   void setLoading({bool state = true}) {
+    if (!mounted) return;
     setState(() {
       _isLoading = state;
     });
@@ -267,6 +268,10 @@ class _EmailSignupPageState extends State<EmailSignupPage> {
                                       // Hide keyboard when continue button is tapped
                                       FocusScope.of(context).unfocus();
 
+                                      final country =
+                                          state.country ?? _cubit.currentCountry;
+                                      if (country == null) return;
+
                                       _cubit.updateApi();
                                       setLoading();
                                       AppThemeSwitcher.of(context)
@@ -275,7 +280,7 @@ class _EmailSignupPageState extends State<EmailSignupPage> {
                                         await context
                                             .read<AuthCubit>()
                                             .register(
-                                              country: state.country!,
+                                              country: country,
                                               email: state.email,
                                               locale: Localizations.localeOf(
                                                       context)
@@ -284,6 +289,7 @@ class _EmailSignupPageState extends State<EmailSignupPage> {
                                       } catch (e) {
                                         // Error surfaced via AuthCubit / dialogs.
                                       }
+                                      if (!mounted) return;
                                       setLoading(state: false);
                                     }
                                   : null,

--- a/lib/features/email_signup/presentation/pages/email_signup_page.dart
+++ b/lib/features/email_signup/presentation/pages/email_signup_page.dart
@@ -8,7 +8,6 @@ import 'package:givt_app/app/injection/injection.dart';
 import 'package:givt_app/app/routes/routes.dart';
 import 'package:givt_app/core/auth/local_auth_info.dart';
 import 'package:givt_app/core/enums/analytics_event_name.dart';
-import 'package:givt_app/core/enums/country.dart';
 import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/features/auth/widgets/country_dropdown.dart';
 import 'package:givt_app/features/auth/widgets/terms_and_conditions_dialog.dart';
@@ -27,6 +26,7 @@ import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
 import 'package:givt_app/shared/widgets/fun_scaffold.dart';
 import 'package:givt_app/shared/widgets/theme/app_theme_switcher.dart';
 import 'package:givt_app/utils/auth_utils.dart';
+import 'package:givt_app/utils/snack_bar_helper.dart';
 import 'package:go_router/go_router.dart';
 
 class EmailSignupPage extends StatefulWidget {
@@ -189,9 +189,7 @@ class _EmailSignupPageState extends State<EmailSignupPage> {
                             const Spacer(),
                             CountryDropDown(
                               selectedCountry: state.country,
-                              onChanged: (Country? newValue) {
-                                _cubit.updateCountry(newValue!);
-                              },
+                              onChanged: _cubit.updateCountry,
                             ),
                             const SizedBox(height: 12),
                             Semantics(
@@ -270,7 +268,13 @@ class _EmailSignupPageState extends State<EmailSignupPage> {
 
                                       final country =
                                           state.country ?? _cubit.currentCountry;
-                                      if (country == null) return;
+                                      if (country == null) {
+                                        SnackBarHelper.showMessage(
+                                          context,
+                                          text: locals.selectCountryHint,
+                                        );
+                                        return;
+                                      }
 
                                       _cubit.updateApi();
                                       setLoading();

--- a/test/features/email_signup/cubit/email_signup_cubit_test.dart
+++ b/test/features/email_signup/cubit/email_signup_cubit_test.dart
@@ -174,5 +174,20 @@ void main() {
     test('updateApi does not throw when country is null', () {
       expect(cubit.updateApi, returnsNormally);
     });
+
+    test('login emits snackbar when country is unset', () async {
+      await cubit.init();
+      await cubit.updateEmail('test@example.com');
+
+      await cubit.login();
+
+      expect(
+        cubit.state,
+        isA<SnackbarState<EmailSignupUiModel, EmailSignupCustom>>(),
+      );
+      final snackbar =
+          cubit.state as SnackbarState<EmailSignupUiModel, EmailSignupCustom>;
+      expect(snackbar.text, 'Please select a country');
+    });
   });
 }

--- a/test/features/email_signup/cubit/email_signup_cubit_test.dart
+++ b/test/features/email_signup/cubit/email_signup_cubit_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/app/injection/injection.dart';
+import 'package:givt_app/core/enums/country.dart';
+import 'package:givt_app/features/amount_presets/models/user_presets.dart';
+import 'package:givt_app/features/auth/models/session.dart';
+import 'package:givt_app/features/email_signup/cubit/email_signup_cubit.dart';
+import 'package:givt_app/features/email_signup/cubit/email_signup_custom.dart';
+import 'package:givt_app/features/email_signup/presentation/models/email_signup_uimodel.dart';
+import 'package:givt_app/features/family/features/auth/data/family_auth_repository.dart';
+import 'package:givt_app/shared/bloc/base_state.dart';
+import 'package:givt_app/shared/models/temp_user.dart';
+import 'package:givt_app/shared/models/user_ext.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeFamilyAuthRepository implements FamilyAuthRepository {
+  @override
+  Stream<UserExt?> authenticatedUserStream() => const Stream.empty();
+
+  @override
+  Future<String> checkEmail({required String email}) async => '';
+
+  @override
+  Future<void> checkUserExt({required String email}) async {}
+
+  @override
+  UserExt? getCurrentUser() => null;
+
+  @override
+  bool hasUserStartedRegistration() => false;
+
+  @override
+  Future<void> initAuth() async {}
+
+  @override
+  Future<(UserExt, Session, UserPresets)?> isAuthenticated() async => null;
+
+  @override
+  Future<void> login(String email, String password) async {}
+
+  @override
+  Future<bool> logout() async => true;
+
+  @override
+  void onRegistrationCancelled() {}
+
+  @override
+  Future<void> onRegistrationFinished() async {}
+
+  @override
+  void onRegistrationStarted() {}
+
+  @override
+  Future<void> refreshUser() async {}
+
+  @override
+  Stream<void> refreshTokenFailedStream() => const Stream.empty();
+
+  @override
+  Future<Session> refreshToken() async => Session(
+        email: '',
+        userGUID: '',
+        accessToken: '',
+        refreshToken: '',
+        expires: '',
+        expiresIn: 0,
+        isLoggedIn: false,
+      );
+
+  @override
+  Future<void> registerUser({
+    required TempUser tempUser,
+    required bool isNewUser,
+  }) async {}
+
+  @override
+  Stream<void> registrationFinishedStream() => const Stream.empty();
+
+  @override
+  Session getStoredSession() => Session(
+        email: '',
+        userGUID: '',
+        accessToken: '',
+        refreshToken: '',
+        expires: '',
+        expiresIn: 0,
+        isLoggedIn: false,
+      );
+
+  @override
+  Future<UserExt> fetchUserExtension(String guid) async =>
+      const UserExt(email: '', guid: '', amountLimit: 0);
+
+  @override
+  Future<void> updateNotificationId() async {}
+
+  @override
+  Future<bool> updateUser({
+    required String guid,
+    required Map<String, dynamic> newUserExt,
+  }) async =>
+      true;
+
+  @override
+  Future<bool> updateUserExt(Map<String, dynamic> newUserExt) async => true;
+
+  @override
+  Future<void> updateNumber(String number) async {}
+
+  @override
+  Future<void> updateEmail(String email) async {}
+}
+
+EmailSignupUiModel _dataState(EmailSignupCubit cubit) {
+  final state = cubit.state;
+  expect(state, isA<DataState<EmailSignupUiModel, EmailSignupCustom>>());
+  return (state as DataState<EmailSignupUiModel, EmailSignupCustom>).data;
+}
+
+void main() {
+  group('EmailSignupCubit', () {
+    late EmailSignupCubit cubit;
+
+    setUpAll(() async {
+      SharedPreferences.setMockInitialValues({});
+      getIt.allowReassignment = true;
+      if (!getIt.isRegistered<SharedPreferences>()) {
+        getIt.registerSingleton<SharedPreferences>(
+          await SharedPreferences.getInstance(),
+        );
+      }
+    });
+
+    setUp(() {
+      cubit = EmailSignupCubit(_FakeFamilyAuthRepository());
+    });
+
+    tearDown(() async {
+      await cubit.close();
+    });
+
+    test('init emits continueButtonEnabled false when country is unset', () async {
+      await cubit.init();
+
+      final data = _dataState(cubit);
+      expect(data.continueButtonEnabled, isFalse);
+    });
+
+    test(
+        'updateEmail emits continueButtonEnabled false when country is unset',
+        () async {
+      await cubit.init();
+
+      await cubit.updateEmail('test@example.com');
+
+      final data = _dataState(cubit);
+      expect(data.email, 'test@example.com');
+      expect(data.country, isNull);
+      expect(data.continueButtonEnabled, isFalse);
+    });
+
+    test(
+        'updateCountry enables continue when email is valid and country selected',
+        () async {
+      await cubit.init();
+      await cubit.updateEmail('test@example.com');
+
+      await cubit.updateCountry(Country.nl);
+
+      final data = _dataState(cubit);
+      expect(data.country, Country.nl);
+      expect(data.continueButtonEnabled, isTrue);
+    });
+
+    test('updateApi does not throw when country is null', () {
+      expect(cubit.updateApi, returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Prevent `_TypeError` on email signup when Continue is tapped before a country is selected by requiring country selection before enabling Continue and guarding `updateApi()`.
- Add defensive snackbar feedback on the continue handler, remove unsafe null assertions in `login()` and the country dropdown callback, and harden page lifecycle with `mounted` checks.
- Update EU login integration test to select a country before continuing.

## Test plan
- [x] `flutter analyze` on changed files (info-level only)
- [x] `make test` — 218 tests passed
- [ ] `flutter build apk` — blocked locally (no Android SDK); CI will verify build
- [ ] Manual: fresh install → enter email only → Continue stays disabled
- [ ] Manual: select country + valid email → Continue proceeds to registration/login


Made with [Cursor](https://cursor.com)