### PR TITLE
Remove unsupported Give to… button from pledge detail (ENG-1134)

### DIFF
--- a/lib/core/enums/analytics_event_name.dart
+++ b/lib/core/enums/analytics_event_name.dart
@@ -628,7 +628,6 @@ enum AnalyticsEventName {
   pledgesTabsChanged('pledges_tabs_changed'),
   pledgesAddClicked('pledges_add_clicked'),
   pledgesDetailOpened('pledges_detail_opened'),
-  pledgesDetailGiveClicked('pledges_detail_give_clicked'),
   pledgesDetailEditClicked('pledges_detail_edit_clicked'),
   pledgesEditRequestSendClicked('pledges_edit_request_send_clicked'),
   menuNavigationRecurringDonationClicked(

--- a/lib/features/pledges/detail/pages/pledge_detail_page.dart
+++ b/lib/features/pledges/detail/pages/pledge_detail_page.dart
@@ -150,27 +150,16 @@ class _PledgeDetailPageState extends State<PledgeDetailPage> {
     PledgeDetailUIModel uiModel,
   ) {
     final locals = context.l10n;
-    final campaignName = uiModel.group.pledgeGroupName;
 
-    return Column(
-      children: [
-        FunButton(
-          text: locals.pledgesDetailGiveButton(campaignName),
-          analyticsEvent: AnalyticsEventName.pledgesDetailGiveClicked.toEvent(),
-          onTap: () {},
-        ),
-        const SizedBox(height: 12),
-        FunButton(
-          text: locals.pledgesDetailEditButton,
-          variant: FunButtonVariant.secondary,
-          fullBorder: true,
-          analyticsEvent: AnalyticsEventName.pledgesDetailEditClicked.toEvent(),
-          onTap: () => PledgeEditRequestBottomSheet.show(
-            context,
-            uiModel: uiModel,
-          ),
-        ),
-      ],
+    return FunButton(
+      text: locals.pledgesDetailEditButton,
+      variant: FunButtonVariant.secondary,
+      fullBorder: true,
+      analyticsEvent: AnalyticsEventName.pledgesDetailEditClicked.toEvent(),
+      onTap: () => PledgeEditRequestBottomSheet.show(
+        context,
+        uiModel: uiModel,
+      ),
     );
   }
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -888,14 +888,6 @@
       }
     }
   },
-  "pledgesDetailGiveButton": "An {campaign} geben",
-  "@pledgesDetailGiveButton": {
-    "placeholders": {
-      "campaign": {
-        "type": "String"
-      }
-    }
-  },
   "pledgesDetailEditButton": "Zusage bearbeiten",
   "pledgesDetailEndsLabel": "Endet",
   "pledgesDetailTransactionsLabel": "Transaktionen",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -888,14 +888,6 @@
       }
     }
   },
-  "pledgesDetailGiveButton": "Give to {campaign}",
-  "@pledgesDetailGiveButton": {
-    "placeholders": {
-      "campaign": {
-        "type": "String"
-      }
-    }
-  },
   "pledgesDetailEditButton": "Edit pledge",
   "pledgesDetailEndsLabel": "Ends",
   "pledgesDetailTransactionsLabel": "Transactions",

--- a/lib/l10n/arb/app_en_US.arb
+++ b/lib/l10n/arb/app_en_US.arb
@@ -884,14 +884,6 @@
       }
     }
   },
-  "pledgesDetailGiveButton": "Give to {campaign}",
-  "@pledgesDetailGiveButton": {
-    "placeholders": {
-      "campaign": {
-        "type": "String"
-      }
-    }
-  },
   "pledgesDetailEditButton": "Edit pledge",
   "pledgesDetailEndsLabel": "Ends",
   "pledgesDetailTransactionsLabel": "Transactions",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -888,14 +888,6 @@
       }
     }
   },
-  "pledgesDetailGiveButton": "Dar a {campaign}",
-  "@pledgesDetailGiveButton": {
-    "placeholders": {
-      "campaign": {
-        "type": "String"
-      }
-    }
-  },
   "pledgesDetailEditButton": "Editar compromiso",
   "pledgesDetailEndsLabel": "Finaliza",
   "pledgesDetailTransactionsLabel": "Transacciones",

--- a/lib/l10n/arb/app_es_419.arb
+++ b/lib/l10n/arb/app_es_419.arb
@@ -884,14 +884,6 @@
       }
     }
   },
-  "pledgesDetailGiveButton": "Dar a {campaign}",
-  "@pledgesDetailGiveButton": {
-    "placeholders": {
-      "campaign": {
-        "type": "String"
-      }
-    }
-  },
   "pledgesDetailEditButton": "Editar compromiso",
   "pledgesDetailEndsLabel": "Finaliza",
   "pledgesDetailTransactionsLabel": "Transacciones",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -2247,12 +2247,6 @@ abstract class AppLocalizations {
   /// **'{given} given of {target}'**
   String pledgesDetailGoalProgress(String given, String target);
 
-  /// No description provided for @pledgesDetailGiveButton.
-  ///
-  /// In en, this message translates to:
-  /// **'Give to {campaign}'**
-  String pledgesDetailGiveButton(String campaign);
-
   /// No description provided for @pledgesDetailEditButton.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -1231,11 +1231,6 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String pledgesDetailGiveButton(String campaign) {
-    return 'An $campaign geben';
-  }
-
-  @override
   String get pledgesDetailEditButton => 'Zusage bearbeiten';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -1222,11 +1222,6 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String pledgesDetailGiveButton(String campaign) {
-    return 'Give to $campaign';
-  }
-
-  @override
   String get pledgesDetailEditButton => 'Edit pledge';
 
   @override
@@ -4723,11 +4718,6 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
   @override
   String pledgesDetailGoalProgress(String given, String target) {
     return '$given given of $target';
-  }
-
-  @override
-  String pledgesDetailGiveButton(String campaign) {
-    return 'Give to $campaign';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -1222,11 +1222,6 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String pledgesDetailGiveButton(String campaign) {
-    return 'Dar a $campaign';
-  }
-
-  @override
   String get pledgesDetailEditButton => 'Editar compromiso';
 
   @override
@@ -4744,11 +4739,6 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   @override
   String pledgesDetailGoalProgress(String given, String target) {
     return '$given dado de $target';
-  }
-
-  @override
-  String pledgesDetailGiveButton(String campaign) {
-    return 'Dar a $campaign';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -1226,11 +1226,6 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String pledgesDetailGiveButton(String campaign) {
-    return 'Geef aan $campaign';
-  }
-
-  @override
   String get pledgesDetailEditButton => 'Toezegging bewerken';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -888,14 +888,6 @@
       }
     }
   },
-  "pledgesDetailGiveButton": "Geef aan {campaign}",
-  "@pledgesDetailGiveButton": {
-    "placeholders": {
-      "campaign": {
-        "type": "String"
-      }
-    }
-  },
   "pledgesDetailEditButton": "Toezegging bewerken",
   "pledgesDetailEndsLabel": "Eindigt",
   "pledgesDetailTransactionsLabel": "Transacties",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: givt_app
 description: Givt App
-version: 6.4.0
+version: 6.4.1
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Summary

Removes the unsupported primary **Give to…** button from the EU pledge detail screen (`PledgeDetailPage`). That button was a no-op stub (`onTap: () {}`) and is not supported yet; giving from pledges will be a separate feature.

Keeps the secondary **Edit pledge** button.

## Changes

* Remove Give to… `FunButton` and spacing from `_buildBottomActions`
* Remove unused `pledgesDetailGiveClicked` analytics event
* Remove unused `pledgesDetailGiveButton` l10n key from all ARB files + regenerate
* Bump version `6.4.0` → `6.4.1`

## Test plan

- [X] Open a pledge from the pledges overview
- [X] Confirm the **Give to…** button is no longer visible
- [X] Confirm **Edit pledge** still opens the edit request bottom sheet

<img src="https://camo.githubusercontent.com/ae5336cc4565ed7dd126cd5bfcb9f6a53979c32e32819e23ffd98524f0526bc9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d7765622d6461726b2e706e67 " alt="Open in Web" width="114" data-linear-height="28" /> <img src="https://camo.githubusercontent.com/583722e75417432aa96019715ba989e7851c00ce91b7725e7246cf7c45b1dae9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d637572736f722d6461726b2e706e67 " alt="Open in Cursor" width="131" data-linear-height="28" />