### PR TITLE
fix(give): support retry for cancelled donations with namespace-only medium IDs (ENG-765)

### DIFF
--- a/lib/features/give/bloc/give/give_bloc.dart
+++ b/lib/features/give/bloc/give/give_bloc.dart
@@ -4,7 +4,6 @@ import 'dart:developer';
 import 'dart:io';
 
 import 'package:bloc/bloc.dart';
-import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:geolocator/geolocator.dart';
@@ -1026,31 +1025,7 @@ class GiveBloc extends Bloc<GiveEvent, GiveState> {
     final collectGroupList = await _collectGroupRepository
         .getCollectGroupList();
     if (!mediumId.contains('.')) {
-      final namespace = mediumId;
-      final exactMatch = collectGroupList
-          .where((org) => org.nameSpace == namespace)
-          .firstOrNull;
-      final matchingGroup =
-          exactMatch ??
-          collectGroupList.firstWhere(
-            (org) => org.nameSpace.startsWith(namespace),
-            orElse: () => const CollectGroup.empty(),
-          );
-      if (matchingGroup.nameSpace.isEmpty) {
-        return const QrCode.empty();
-      }
-
-      for (final qrCode in matchingGroup.qrCodes) {
-        if (qrCode.isActive && qrCode.name.trim().isEmpty) {
-          return qrCode;
-        }
-      }
-
-      return QrCode(
-        name: '',
-        instance: namespace,
-        isActive: true,
-      );
+      return const QrCode.empty();
     }
     final namespace = mediumId.split('.').first;
     final instance = mediumId.split('.').last;

--- a/lib/features/give/bloc/give/give_bloc.dart
+++ b/lib/features/give/bloc/give/give_bloc.dart
@@ -4,6 +4,7 @@ import 'dart:developer';
 import 'dart:io';
 
 import 'package:bloc/bloc.dart';
+import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:geolocator/geolocator.dart';
@@ -317,7 +318,12 @@ class GiveBloc extends Bloc<GiveEvent, GiveState> {
           return;
         }
       } catch (e, stackTrace) {
-        if (_handleDonationSubmissionTimeout(e, stackTrace, emit, organisation)) {
+        if (_handleDonationSubmissionTimeout(
+          e,
+          stackTrace,
+          emit,
+          organisation,
+        )) {
           return;
         }
         rethrow;
@@ -1020,7 +1026,31 @@ class GiveBloc extends Bloc<GiveEvent, GiveState> {
     final collectGroupList = await _collectGroupRepository
         .getCollectGroupList();
     if (!mediumId.contains('.')) {
-      return const QrCode.empty();
+      final namespace = mediumId;
+      final exactMatch = collectGroupList
+          .where((org) => org.nameSpace == namespace)
+          .firstOrNull;
+      final matchingGroup =
+          exactMatch ??
+          collectGroupList.firstWhere(
+            (org) => org.nameSpace.startsWith(namespace),
+            orElse: () => const CollectGroup.empty(),
+          );
+      if (matchingGroup.nameSpace.isEmpty) {
+        return const QrCode.empty();
+      }
+
+      for (final qrCode in matchingGroup.qrCodes) {
+        if (qrCode.isActive && qrCode.name.trim().isEmpty) {
+          return qrCode;
+        }
+      }
+
+      return QrCode(
+        name: '',
+        instance: namespace,
+        isActive: true,
+      );
     }
     final namespace = mediumId.split('.').first;
     final instance = mediumId.split('.').last;

--- a/lib/features/give/models/for_you_flow_context.dart
+++ b/lib/features/give/models/for_you_flow_context.dart
@@ -16,24 +16,28 @@ class ForYouFlowContext extends Equatable {
     this.selectedOrganisation,
     this.entryMediumId,
     this.restrictToEntryQrGoal = false,
+    this.initialAmount,
   });
 
   final ForYouEntrySource source;
   final CollectGroup? selectedOrganisation;
   final String? entryMediumId;
   final bool restrictToEntryQrGoal;
+  final double? initialAmount;
 
   ForYouFlowContext copyWith({
     ForYouEntrySource? source,
     CollectGroup? selectedOrganisation,
     String? entryMediumId,
     bool? restrictToEntryQrGoal,
+    double? initialAmount,
   }) {
     return ForYouFlowContext(
       source: source ?? this.source,
       selectedOrganisation: selectedOrganisation ?? this.selectedOrganisation,
       entryMediumId: entryMediumId ?? this.entryMediumId,
       restrictToEntryQrGoal: restrictToEntryQrGoal ?? this.restrictToEntryQrGoal,
+      initialAmount: initialAmount ?? this.initialAmount,
     );
   }
 
@@ -43,6 +47,7 @@ class ForYouFlowContext extends Equatable {
       'selectedOrganisation': selectedOrganisation?.toJson(),
       'entryMediumId': entryMediumId,
       'restrictToEntryQrGoal': restrictToEntryQrGoal,
+      'initialAmount': initialAmount,
     };
   }
 
@@ -60,12 +65,17 @@ class ForYouFlowContext extends Equatable {
 
     final entryMediumId = map['entryMediumId'] as String?;
     final restrictToEntryQrGoal = map['restrictToEntryQrGoal'] as bool? ?? false;
+    final initialAmountRaw = map['initialAmount'];
+    final initialAmount = initialAmountRaw is num
+        ? initialAmountRaw.toDouble()
+        : double.tryParse(initialAmountRaw?.toString() ?? '');
 
     return ForYouFlowContext(
       source: resolvedSource,
       selectedOrganisation: selectedOrganisation,
       entryMediumId: entryMediumId,
       restrictToEntryQrGoal: restrictToEntryQrGoal,
+      initialAmount: initialAmount,
     );
   }
 
@@ -75,5 +85,6 @@ class ForYouFlowContext extends Equatable {
     selectedOrganisation,
     entryMediumId,
     restrictToEntryQrGoal,
+    initialAmount,
   ];
 }

--- a/lib/features/give/pages/for_you_giving_page.dart
+++ b/lib/features/give/pages/for_you_giving_page.dart
@@ -776,7 +776,9 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
     }
     _controllers.clear();
     for (var i = 0; i < lines.length; i++) {
-      _controllers.add(TextEditingController(text: '0'));
+      _controllers.add(
+        TextEditingController(text: _controllerTextForLineIndex(i)),
+      );
     }
     _accordionKeys.clear();
     for (var i = 0; i < lines.length; i++) {
@@ -789,6 +791,19 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
       _selectedField = 0;
       _isLoadingGoals = false;
     });
+  }
+
+  String _controllerTextForLineIndex(int index) {
+    final initialAmount = widget.flowContext.initialAmount;
+    if (index != 0 || initialAmount == null || initialAmount <= 0) {
+      return '0';
+    }
+
+    if (initialAmount % 1 == 0) {
+      return initialAmount.toInt().toString();
+    }
+
+    return initialAmount.toStringAsFixed(2).replaceAll('.', _decimalSeparator);
   }
 }
 

--- a/lib/features/give/pages/for_you_giving_page.dart
+++ b/lib/features/give/pages/for_you_giving_page.dart
@@ -50,7 +50,16 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
   bool _didStartGoalInitialization = false;
   OrganisationGoalsResponse? _goalsResponse;
 
-  String _decimalSeparator = ',';
+  static String decimalSeparatorForCountry(Country country) {
+    return country.countryCode == Country.us.countryCode ||
+            Country.unitedKingdomCodes().contains(country.countryCode)
+        ? '.'
+        : ',';
+  }
+
+  String get _decimalSeparator => decimalSeparatorForCountry(
+    Country.fromCode(context.read<AuthCubit>().state.user.country),
+  );
 
   Set<String> get _addedGeneralMediumIds => {
     for (final line in _goalLines)
@@ -82,23 +91,11 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _syncDecimalSeparatorFromLocale();
     if (_didStartGoalInitialization) {
       return;
     }
     _didStartGoalInitialization = true;
     _initializeGoals();
-  }
-
-  void _syncDecimalSeparatorFromLocale() {
-    final country = Country.fromCode(
-      context.read<AuthCubit>().state.user.country,
-    );
-    _decimalSeparator =
-        country.countryCode == Country.us.countryCode ||
-            Country.unitedKingdomCodes().contains(country.countryCode)
-        ? '.'
-        : ',';
   }
 
   @override

--- a/lib/features/give/pages/for_you_giving_page.dart
+++ b/lib/features/give/pages/for_you_giving_page.dart
@@ -82,11 +82,23 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    _syncDecimalSeparatorFromLocale();
     if (_didStartGoalInitialization) {
       return;
     }
     _didStartGoalInitialization = true;
     _initializeGoals();
+  }
+
+  void _syncDecimalSeparatorFromLocale() {
+    final country = Country.fromCode(
+      context.read<AuthCubit>().state.user.country,
+    );
+    _decimalSeparator =
+        country.countryCode == Country.us.countryCode ||
+            Country.unitedKingdomCodes().contains(country.countryCode)
+        ? '.'
+        : ',';
   }
 
   @override
@@ -109,15 +121,12 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
       countryCode: country.countryCode,
     );
     final amountLimit = auth.user.amountLimit;
-    if (country.countryCode == Country.us.countryCode ||
-        Country.unitedKingdomCodes().contains(country.countryCode)) {
-      _decimalSeparator = '.';
-    }
-    final hasAmountLimitViolation = DonationAmountValidation.anyExceedsUserAmountLimit(
-      values: _controllers.map((controller) => controller.text),
-      amountLimit: amountLimit,
-      decimalSeparator: _decimalSeparator,
-    );
+    final hasAmountLimitViolation =
+        DonationAmountValidation.anyExceedsUserAmountLimit(
+          values: _controllers.map((controller) => controller.text),
+          amountLimit: amountLimit,
+          decimalSeparator: _decimalSeparator,
+        );
     final canSubmit = _hasValidAmounts && !hasAmountLimitViolation;
 
     if (organisation == null) {
@@ -404,10 +413,10 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
     final borderColor = exceedsLimit
         ? theme.error50
         : isComplete
-            ? theme.primary30
-            : isExpanded
-                ? theme.primary70
-                : theme.neutralVariant90;
+        ? theme.primary30
+        : isExpanded
+        ? theme.primary70
+        : theme.neutralVariant90;
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
@@ -689,7 +698,9 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
       final allocation = allocations[listIndex];
       final parsedGoalIndex = int.tryParse(allocation.collectId);
       final resolvedGoalIndex =
-          parsedGoalIndex != null && parsedGoalIndex >= 1 && parsedGoalIndex <= 3
+          parsedGoalIndex != null &&
+              parsedGoalIndex >= 1 &&
+              parsedGoalIndex <= 3
           ? parsedGoalIndex
           : listIndex + 1;
       if (resolvedGoalIndex < 1 || resolvedGoalIndex > 3) {

--- a/lib/features/give/pages/home_page.dart
+++ b/lib/features/give/pages/home_page.dart
@@ -411,6 +411,9 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
                   'qr-entry-${widget.code}-$_scanCounter-${auth.status}',
                 ),
                 code: widget.code,
+                initialAmount: widget.initialAmount,
+                retry: widget.retry,
+                afterGivingRedirection: widget.afterGivingRedirection,
                 initialPageIndex: pageIndex,
                 onPageChanged: (index) => setState(
                   () {

--- a/lib/features/give/pages/home_page_with_qr_code.dart
+++ b/lib/features/give/pages/home_page_with_qr_code.dart
@@ -29,6 +29,9 @@ import 'package:go_router/go_router.dart';
 class HomePageWithQRCode extends StatefulWidget {
   const HomePageWithQRCode({
     required this.code,
+    required this.initialAmount,
+    required this.retry,
+    required this.afterGivingRedirection,
     required this.initialPageIndex,
     required this.onPageChanged,
     required this.auth,
@@ -37,6 +40,9 @@ class HomePageWithQRCode extends StatefulWidget {
   });
 
   final String code;
+  final double? initialAmount;
+  final bool retry;
+  final String afterGivingRedirection;
   final int initialPageIndex;
   final void Function(int) onPageChanged;
   final AuthState auth;
@@ -231,6 +237,7 @@ class _HomePageWithQRCodeState extends State<HomePageWithQRCode> {
         selectedOrganisation: collectGroup,
         entryMediumId: mediumId,
         restrictToEntryQrGoal: restrictToEntryQrGoal,
+        initialAmount: widget.initialAmount,
       ).toMap(),
     );
   }
@@ -264,11 +271,11 @@ class _HomePageWithQRCodeState extends State<HomePageWithQRCode> {
       ],
       child: SafeArea(
         child: HomePageView(
-          initialAmount: null,
+          initialAmount: widget.initialAmount,
           given: false,
-          retry: false,
+          retry: widget.retry,
           code: widget.code,
-          afterGivingRedirection: '',
+          afterGivingRedirection: widget.afterGivingRedirection,
           initialPageIndex: widget.initialPageIndex,
           onPageChanged: widget.onPageChanged,
         ),

--- a/lib/features/give/utils/for_you_discovery_resolvers.dart
+++ b/lib/features/give/utils/for_you_discovery_resolvers.dart
@@ -78,8 +78,43 @@ class ForYouDiscoveryResolvers {
     }
 
     if (!mediumId.contains('.')) {
-      return const ForYouDiscoveryResult.failure(
-        ForYouDiscoveryFailure.notFound,
+      final namespace = mediumId;
+      final matchingGroup = collectGroups.firstWhere(
+        (group) =>
+            group.nameSpace == namespace ||
+            group.nameSpace.startsWith(namespace),
+        orElse: () => const CollectGroup.empty(),
+      );
+
+      if (matchingGroup.nameSpace.isEmpty) {
+        return const ForYouDiscoveryResult.failure(
+          ForYouDiscoveryFailure.notFound,
+        );
+      }
+
+      if (!matchingGroup.isActive) {
+        return ForYouDiscoveryResult.failure(
+          ForYouDiscoveryFailure.inactiveCollectGroup,
+          collectGroup: matchingGroup,
+        );
+      }
+
+      QrCode? selectedQrCode;
+      for (final qrCode in matchingGroup.qrCodes) {
+        if (qrCode.isActive && qrCode.name.trim().isEmpty) {
+          selectedQrCode = qrCode;
+          break;
+        }
+      }
+      selectedQrCode ??= QrCode(
+        name: '',
+        instance: mediumId,
+        isActive: true,
+      );
+
+      return ForYouDiscoveryResult.success(
+        collectGroup: matchingGroup,
+        qrCode: selectedQrCode,
       );
     }
 

--- a/lib/features/give/utils/for_you_discovery_resolvers.dart
+++ b/lib/features/give/utils/for_you_discovery_resolvers.dart
@@ -62,14 +62,25 @@ class _ForYouDiscoveryFailure extends ForYouDiscoveryResult {
 class ForYouDiscoveryResolvers {
   ForYouDiscoveryResolvers._();
 
-  static CollectGroup _findCollectGroupByNamespace(
+  static CollectGroup _findCollectGroupByExactNamespace(
     List<CollectGroup> collectGroups,
     String namespace,
   ) {
-    final exactMatch = collectGroups
-        .where((group) => group.nameSpace == namespace)
-        .firstOrNull;
-    if (exactMatch != null) {
+    return collectGroups
+            .where((group) => group.nameSpace == namespace)
+            .firstOrNull ??
+        const CollectGroup.empty();
+  }
+
+  static CollectGroup _findCollectGroupByNamespacePrefix(
+    List<CollectGroup> collectGroups,
+    String namespace,
+  ) {
+    final exactMatch = _findCollectGroupByExactNamespace(
+      collectGroups,
+      namespace,
+    );
+    if (exactMatch.nameSpace.isNotEmpty) {
       return exactMatch;
     }
 
@@ -79,21 +90,39 @@ class ForYouDiscoveryResolvers {
     );
   }
 
+  static ForYouDiscoveryResult? _failureForInactiveGenericQr(
+    CollectGroup matchingGroup,
+  ) {
+    final inactiveGeneric = matchingGroup.qrCodes
+        .where((qrCode) => !qrCode.isActive && qrCode.isGeneric)
+        .firstOrNull;
+    if (inactiveGeneric == null) {
+      return null;
+    }
+    final hasActiveGeneric = matchingGroup.qrCodes.any(
+      (qrCode) => qrCode.isActive && qrCode.isGeneric,
+    );
+    if (hasActiveGeneric) {
+      return null;
+    }
+    return ForYouDiscoveryResult.failure(
+      ForYouDiscoveryFailure.inactiveQrCode,
+      collectGroup: matchingGroup,
+      qrCode: inactiveGeneric,
+    );
+  }
+
   static QrCode _resolveGenericQrCodeForNamespace(
     CollectGroup matchingGroup,
     String namespace,
   ) {
     for (final qrCode in matchingGroup.qrCodes) {
-      if (qrCode.isActive && qrCode.name.trim().isEmpty) {
+      if (qrCode.isActive && qrCode.isGeneric) {
         return qrCode;
       }
     }
 
-    return QrCode(
-      name: '',
-      instance: namespace,
-      isActive: true,
-    );
+    return QrCode.genericForNamespace(namespace);
   }
 
   static Future<ForYouDiscoveryResult> resolveCollectGroupAndQrFromQrMediumId(
@@ -114,7 +143,7 @@ class ForYouDiscoveryResolvers {
 
     if (!mediumId.contains('.')) {
       final namespace = mediumId;
-      final matchingGroup = _findCollectGroupByNamespace(
+      final matchingGroup = _findCollectGroupByExactNamespace(
         collectGroups,
         namespace,
       );
@@ -130,6 +159,11 @@ class ForYouDiscoveryResolvers {
           ForYouDiscoveryFailure.inactiveCollectGroup,
           collectGroup: matchingGroup,
         );
+      }
+
+      final inactiveGenericFailure = _failureForInactiveGenericQr(matchingGroup);
+      if (inactiveGenericFailure != null) {
+        return inactiveGenericFailure;
       }
 
       return ForYouDiscoveryResult.success(
@@ -225,7 +259,7 @@ class ForYouDiscoveryResolvers {
     if (!beaconId.contains('.')) return null;
 
     final namespace = beaconId.split('.').first;
-    final fallbackMatch = _findCollectGroupByNamespace(
+    final fallbackMatch = _findCollectGroupByNamespacePrefix(
       collectGroups,
       namespace,
     );

--- a/lib/features/give/utils/for_you_discovery_resolvers.dart
+++ b/lib/features/give/utils/for_you_discovery_resolvers.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:givt_app/app/injection/injection.dart';
 import 'package:givt_app/shared/models/models.dart';
@@ -61,6 +62,40 @@ class _ForYouDiscoveryFailure extends ForYouDiscoveryResult {
 class ForYouDiscoveryResolvers {
   ForYouDiscoveryResolvers._();
 
+  static CollectGroup _findCollectGroupByNamespace(
+    List<CollectGroup> collectGroups,
+    String namespace,
+  ) {
+    final exactMatch = collectGroups
+        .where((group) => group.nameSpace == namespace)
+        .firstOrNull;
+    if (exactMatch != null) {
+      return exactMatch;
+    }
+
+    return collectGroups.firstWhere(
+      (group) => group.nameSpace.startsWith(namespace),
+      orElse: () => const CollectGroup.empty(),
+    );
+  }
+
+  static QrCode _resolveGenericQrCodeForNamespace(
+    CollectGroup matchingGroup,
+    String namespace,
+  ) {
+    for (final qrCode in matchingGroup.qrCodes) {
+      if (qrCode.isActive && qrCode.name.trim().isEmpty) {
+        return qrCode;
+      }
+    }
+
+    return QrCode(
+      name: '',
+      instance: namespace,
+      isActive: true,
+    );
+  }
+
   static Future<ForYouDiscoveryResult> resolveCollectGroupAndQrFromQrMediumId(
     String mediumId, {
     CollectGroupRepository? collectGroupRepository,
@@ -79,11 +114,9 @@ class ForYouDiscoveryResolvers {
 
     if (!mediumId.contains('.')) {
       final namespace = mediumId;
-      final matchingGroup = collectGroups.firstWhere(
-        (group) =>
-            group.nameSpace == namespace ||
-            group.nameSpace.startsWith(namespace),
-        orElse: () => const CollectGroup.empty(),
+      final matchingGroup = _findCollectGroupByNamespace(
+        collectGroups,
+        namespace,
       );
 
       if (matchingGroup.nameSpace.isEmpty) {
@@ -99,22 +132,9 @@ class ForYouDiscoveryResolvers {
         );
       }
 
-      QrCode? selectedQrCode;
-      for (final qrCode in matchingGroup.qrCodes) {
-        if (qrCode.isActive && qrCode.name.trim().isEmpty) {
-          selectedQrCode = qrCode;
-          break;
-        }
-      }
-      selectedQrCode ??= QrCode(
-        name: '',
-        instance: mediumId,
-        isActive: true,
-      );
-
       return ForYouDiscoveryResult.success(
         collectGroup: matchingGroup,
-        qrCode: selectedQrCode,
+        qrCode: _resolveGenericQrCodeForNamespace(matchingGroup, namespace),
       );
     }
 
@@ -205,10 +225,9 @@ class ForYouDiscoveryResolvers {
     if (!beaconId.contains('.')) return null;
 
     final namespace = beaconId.split('.').first;
-    final fallbackMatch = collectGroups.firstWhere(
-      (group) =>
-          group.nameSpace == namespace || group.nameSpace.startsWith(namespace),
-      orElse: () => const CollectGroup.empty(),
+    final fallbackMatch = _findCollectGroupByNamespace(
+      collectGroups,
+      namespace,
     );
 
     return fallbackMatch.nameSpace.isEmpty ? null : fallbackMatch;

--- a/lib/shared/models/qr_code.dart
+++ b/lib/shared/models/qr_code.dart
@@ -29,6 +29,15 @@ class QrCode extends Equatable {
   /// True when this QR has no goal-specific name from the backend (`N` empty).
   bool get isGeneric => name.trim().isEmpty;
 
+  /// Org-level entry when the backend has no generic QR row (namespace-only medium).
+  factory QrCode.genericForNamespace(String namespace) {
+    return QrCode(
+      name: '',
+      instance: namespace,
+      isActive: true,
+    );
+  }
+
   Map<String, dynamic> toJson() {
     return {
       'N': name,

--- a/test/features/give/utils/for_you_discovery_resolvers_test.dart
+++ b/test/features/give/utils/for_you_discovery_resolvers_test.dart
@@ -22,31 +22,35 @@ class FakeCollectGroupRepository with CollectGroupRepository {
 
 void main() {
   group('ForYouDiscoveryResolvers', () {
-    test('resolveCollectGroupFromQrMediumId returns active matching group', () async {
-      final group = CollectGroup(
-        nameSpace: 'abc',
-        orgName: 'Org A',
-        hasCelebration: false,
-        type: CollectGroupType.church,
-        qrCodes: [
-          QrCode(
-            name: 'Instance name',
-            instance: 'abc.def',
-            isActive: true,
-          ),
-        ],
-      );
+    test(
+      'resolveCollectGroupFromQrMediumId returns active matching group',
+      () async {
+        final group = CollectGroup(
+          nameSpace: 'abc',
+          orgName: 'Org A',
+          hasCelebration: false,
+          type: CollectGroupType.church,
+          qrCodes: [
+            QrCode(
+              name: 'Instance name',
+              instance: 'abc.def',
+              isActive: true,
+            ),
+          ],
+        );
 
-      final repo = FakeCollectGroupRepository([group]);
-      final result = await ForYouDiscoveryResolvers.resolveCollectGroupFromQrMediumId(
-        'abc.def',
-        collectGroupRepository: repo,
-      );
+        final repo = FakeCollectGroupRepository([group]);
+        final result =
+            await ForYouDiscoveryResolvers.resolveCollectGroupFromQrMediumId(
+              'abc.def',
+              collectGroupRepository: repo,
+            );
 
-      expect(result, isNotNull);
-      expect(result?.nameSpace, equals('abc'));
-      expect(result?.orgName, equals('Org A'));
-    });
+        expect(result, isNotNull);
+        expect(result?.nameSpace, equals('abc'));
+        expect(result?.orgName, equals('Org A'));
+      },
+    );
 
     test(
       'resolveCollectGroupAndQrFromQrMediumId resolves namespace-only mediumId',
@@ -75,6 +79,41 @@ void main() {
         expect(result.isSuccess, isTrue);
         expect(result.collectGroup?.nameSpace, equals('61f7ed014e4c0621d000'));
         expect(result.qrCode?.isGeneric, isTrue);
+      },
+    );
+
+    test(
+      'resolveCollectGroupAndQrFromQrMediumId prefers exact namespace match',
+      () async {
+        final prefixGroup = CollectGroup(
+          nameSpace: '61f7ed014e4c0621d000',
+          orgName: 'Prefix Org',
+          hasCelebration: false,
+          type: CollectGroupType.church,
+        );
+        final exactGroup = CollectGroup(
+          nameSpace: '61f7ed014e4c0621d0009',
+          orgName: 'Exact Org',
+          hasCelebration: false,
+          type: CollectGroupType.church,
+          qrCodes: [
+            QrCode(
+              name: '',
+              instance: '61f7ed014e4c0621d0009.generic',
+              isActive: true,
+            ),
+          ],
+        );
+
+        final repo = FakeCollectGroupRepository([prefixGroup, exactGroup]);
+        final result =
+            await ForYouDiscoveryResolvers.resolveCollectGroupAndQrFromQrMediumId(
+              '61f7ed014e4c0621d0009',
+              collectGroupRepository: repo,
+            );
+
+        expect(result.isSuccess, isTrue);
+        expect(result.collectGroup?.orgName, equals('Exact Org'));
       },
     );
 
@@ -130,136 +169,147 @@ void main() {
       },
     );
 
-    test('resolveCollectGroupFromQrMediumId returns null for inactive QR', () async {
-      final group = CollectGroup(
-        nameSpace: 'abc',
-        orgName: 'Org A',
-        hasCelebration: false,
-        type: CollectGroupType.church,
-        qrCodes: [
-          QrCode(
-            name: 'Instance name',
-            instance: 'abc.def',
-            isActive: false,
-          ),
-        ],
-      );
+    test(
+      'resolveCollectGroupFromQrMediumId returns null for inactive QR',
+      () async {
+        final group = CollectGroup(
+          nameSpace: 'abc',
+          orgName: 'Org A',
+          hasCelebration: false,
+          type: CollectGroupType.church,
+          qrCodes: [
+            QrCode(
+              name: 'Instance name',
+              instance: 'abc.def',
+              isActive: false,
+            ),
+          ],
+        );
 
-      final repo = FakeCollectGroupRepository([group]);
-      final result = await ForYouDiscoveryResolvers.resolveCollectGroupFromQrMediumId(
-        'abc.def',
-        collectGroupRepository: repo,
-      );
+        final repo = FakeCollectGroupRepository([group]);
+        final result =
+            await ForYouDiscoveryResolvers.resolveCollectGroupFromQrMediumId(
+              'abc.def',
+              collectGroupRepository: repo,
+            );
 
-      expect(result, isNull);
-    });
+        expect(result, isNull);
+      },
+    );
 
-    test('resolveCollectGroupFromBeaconId matches by namespace presence', () async {
-      const group = CollectGroup(
-        nameSpace: 'abc',
-        orgName: 'Org A',
-        hasCelebration: false,
-        type: CollectGroupType.charities,
-      );
+    test(
+      'resolveCollectGroupFromBeaconId matches by namespace presence',
+      () async {
+        const group = CollectGroup(
+          nameSpace: 'abc',
+          orgName: 'Org A',
+          hasCelebration: false,
+          type: CollectGroupType.charities,
+        );
 
-      final repo = FakeCollectGroupRepository([group]);
-      final result = await ForYouDiscoveryResolvers.resolveCollectGroupFromBeaconId(
-        'abc.1234',
-        collectGroupRepository: repo,
-      );
+        final repo = FakeCollectGroupRepository([group]);
+        final result =
+            await ForYouDiscoveryResolvers.resolveCollectGroupFromBeaconId(
+              'abc.1234',
+              collectGroupRepository: repo,
+            );
 
-      expect(result, isNotNull);
-      expect(result!.nameSpace, equals('abc'));
-    });
+        expect(result, isNotNull);
+        expect(result!.nameSpace, equals('abc'));
+      },
+    );
 
-    test('resolveNearbyCollectGroups returns nearest location within radius', () async {
-      final now = DateTime.now();
+    test(
+      'resolveNearbyCollectGroups returns nearest location within radius',
+      () async {
+        final now = DateTime.now();
 
-      final groupA = CollectGroup(
-        nameSpace: 'a',
-        orgName: 'Org A',
-        hasCelebration: false,
-        type: CollectGroupType.church,
-        locations: [
-          Location(
-            name: 'Loc A',
-            latitude: 0,
-            longitude: 0,
-            radius: 200,
-            beaconId: 'a.1',
-            begin: now,
-            end: null, // should be skipped
-          ),
-          Location(
-            name: 'Loc A2',
-            latitude: 0,
-            longitude: 0,
-            radius: 5000,
-            beaconId: 'a.2',
-            begin: now,
-            end: null, // should be skipped
-          ),
-        ],
-      );
+        final groupA = CollectGroup(
+          nameSpace: 'a',
+          orgName: 'Org A',
+          hasCelebration: false,
+          type: CollectGroupType.church,
+          locations: [
+            Location(
+              name: 'Loc A',
+              latitude: 0,
+              longitude: 0,
+              radius: 200,
+              beaconId: 'a.1',
+              begin: now,
+              end: null, // should be skipped
+            ),
+            Location(
+              name: 'Loc A2',
+              latitude: 0,
+              longitude: 0,
+              radius: 5000,
+              beaconId: 'a.2',
+              begin: now,
+              end: null, // should be skipped
+            ),
+          ],
+        );
 
-      // We need begin/end set for candidates.
-      final groupB = CollectGroup(
-        nameSpace: 'b',
-        orgName: 'Org B',
-        hasCelebration: false,
-        type: CollectGroupType.church,
-        locations: [
-          Location(
-            name: 'Loc B1',
-            latitude: 0,
-            longitude: 0,
-            radius: 5000,
-            beaconId: 'b.1',
-            begin: now,
-            end: now.add(const Duration(days: 1)),
-          ),
-          Location(
-            name: 'Loc B2',
-            latitude: 0.01,
-            longitude: 0,
-            radius: 5000,
-            beaconId: 'b.2',
-            begin: now,
-            end: now.add(const Duration(days: 1)),
-          ),
-        ],
-      );
+        // We need begin/end set for candidates.
+        final groupB = CollectGroup(
+          nameSpace: 'b',
+          orgName: 'Org B',
+          hasCelebration: false,
+          type: CollectGroupType.church,
+          locations: [
+            Location(
+              name: 'Loc B1',
+              latitude: 0,
+              longitude: 0,
+              radius: 5000,
+              beaconId: 'b.1',
+              begin: now,
+              end: now.add(const Duration(days: 1)),
+            ),
+            Location(
+              name: 'Loc B2',
+              latitude: 0.01,
+              longitude: 0,
+              radius: 5000,
+              beaconId: 'b.2',
+              begin: now,
+              end: now.add(const Duration(days: 1)),
+            ),
+          ],
+        );
 
-      // Target is closer to B1 than B2.
-      final targetLat = 0.001;
-      final targetLng = 0.0;
-      final repo = FakeCollectGroupRepository([groupA, groupB]);
+        // Target is closer to B1 than B2.
+        final targetLat = 0.001;
+        final targetLng = 0.0;
+        final repo = FakeCollectGroupRepository([groupA, groupB]);
 
-      final distanceToB1 = Geolocator.distanceBetween(
-        groupB.locations[0].latitude,
-        groupB.locations[0].longitude,
-        targetLat,
-        targetLng,
-      );
-      final distanceToB2 = Geolocator.distanceBetween(
-        groupB.locations[1].latitude,
-        groupB.locations[1].longitude,
-        targetLat,
-        targetLng,
-      );
+        final distanceToB1 = Geolocator.distanceBetween(
+          groupB.locations[0].latitude,
+          groupB.locations[0].longitude,
+          targetLat,
+          targetLng,
+        );
+        final distanceToB2 = Geolocator.distanceBetween(
+          groupB.locations[1].latitude,
+          groupB.locations[1].longitude,
+          targetLat,
+          targetLng,
+        );
 
-      expect(distanceToB1, lessThan(distanceToB2));
+        expect(distanceToB1, lessThan(distanceToB2));
 
-      final result = await ForYouDiscoveryResolvers.resolveNearbyCollectGroups(
-        targetLat,
-        targetLng,
-        collectGroupRepository: repo,
-      );
+        final result =
+            await ForYouDiscoveryResolvers.resolveNearbyCollectGroups(
+              targetLat,
+              targetLng,
+              collectGroupRepository: repo,
+            );
 
-      expect(result, isNotEmpty);
-      expect(result.first.nameSpace, equals('b'));
-      expect(result.first.orgName, equals('Org B'));
-    });
+        expect(result, isNotEmpty);
+        expect(result.first.nameSpace, equals('b'));
+        expect(result.first.orgName, equals('Org B'));
+      },
+    );
   });
 }
-

--- a/test/features/give/utils/for_you_discovery_resolvers_test.dart
+++ b/test/features/give/utils/for_you_discovery_resolvers_test.dart
@@ -48,6 +48,88 @@ void main() {
       expect(result?.orgName, equals('Org A'));
     });
 
+    test(
+      'resolveCollectGroupAndQrFromQrMediumId resolves namespace-only mediumId',
+      () async {
+        final group = CollectGroup(
+          nameSpace: '61f7ed014e4c0621d000',
+          orgName: 'Namespace Org',
+          hasCelebration: false,
+          type: CollectGroupType.church,
+          qrCodes: [
+            QrCode(
+              name: '',
+              instance: '61f7ed014e4c0621d000.generic',
+              isActive: true,
+            ),
+          ],
+        );
+
+        final repo = FakeCollectGroupRepository([group]);
+        final result =
+            await ForYouDiscoveryResolvers.resolveCollectGroupAndQrFromQrMediumId(
+              '61f7ed014e4c0621d000',
+              collectGroupRepository: repo,
+            );
+
+        expect(result.isSuccess, isTrue);
+        expect(result.collectGroup?.nameSpace, equals('61f7ed014e4c0621d000'));
+        expect(result.qrCode?.isGeneric, isTrue);
+      },
+    );
+
+    test(
+      'resolveCollectGroupAndQrFromQrMediumId resolves dotted mediumId',
+      () async {
+        final group = CollectGroup(
+          nameSpace: '61f7ed014e4c0424c000',
+          orgName: 'Dotted Org',
+          hasCelebration: false,
+          type: CollectGroupType.church,
+          qrCodes: [
+            QrCode(
+              name: 'Goal',
+              instance: '61f7ed014e4c0424c000.c00000000001',
+              isActive: true,
+            ),
+          ],
+        );
+
+        final repo = FakeCollectGroupRepository([group]);
+        final result =
+            await ForYouDiscoveryResolvers.resolveCollectGroupAndQrFromQrMediumId(
+              '61f7ed014e4c0424c000.c00000000001',
+              collectGroupRepository: repo,
+            );
+
+        expect(result.isSuccess, isTrue);
+        expect(result.collectGroup?.nameSpace, equals('61f7ed014e4c0424c000'));
+        expect(result.qrCode?.instance, endsWith('c00000000001'));
+      },
+    );
+
+    test(
+      'resolveCollectGroupAndQrFromQrMediumId returns notFound for unknown mediumId',
+      () async {
+        final group = CollectGroup(
+          nameSpace: 'known',
+          orgName: 'Known Org',
+          hasCelebration: false,
+          type: CollectGroupType.church,
+        );
+
+        final repo = FakeCollectGroupRepository([group]);
+        final result =
+            await ForYouDiscoveryResolvers.resolveCollectGroupAndQrFromQrMediumId(
+              'unknown-medium-id',
+              collectGroupRepository: repo,
+            );
+
+        expect(result.isSuccess, isFalse);
+        expect(result.failure, equals(ForYouDiscoveryFailure.notFound));
+      },
+    );
+
     test('resolveCollectGroupFromQrMediumId returns null for inactive QR', () async {
       final group = CollectGroup(
         nameSpace: 'abc',

--- a/test/features/give/utils/for_you_discovery_resolvers_test.dart
+++ b/test/features/give/utils/for_you_discovery_resolvers_test.dart
@@ -83,6 +83,35 @@ void main() {
     );
 
     test(
+      'resolveCollectGroupAndQrFromQrMediumId does not match longer namespace by prefix',
+      () async {
+        final longerNamespaceGroup = CollectGroup(
+          nameSpace: '61f7ed014e4c0621d0009',
+          orgName: 'Longer Org',
+          hasCelebration: false,
+          type: CollectGroupType.church,
+          qrCodes: [
+            QrCode(
+              name: '',
+              instance: '61f7ed014e4c0621d0009.generic',
+              isActive: true,
+            ),
+          ],
+        );
+
+        final repo = FakeCollectGroupRepository([longerNamespaceGroup]);
+        final result =
+            await ForYouDiscoveryResolvers.resolveCollectGroupAndQrFromQrMediumId(
+              '61f7ed014e4c0621d000',
+              collectGroupRepository: repo,
+            );
+
+        expect(result.isSuccess, isFalse);
+        expect(result.failure, equals(ForYouDiscoveryFailure.notFound));
+      },
+    );
+
+    test(
       'resolveCollectGroupAndQrFromQrMediumId prefers exact namespace match',
       () async {
         final prefixGroup = CollectGroup(
@@ -114,6 +143,35 @@ void main() {
 
         expect(result.isSuccess, isTrue);
         expect(result.collectGroup?.orgName, equals('Exact Org'));
+      },
+    );
+
+    test(
+      'resolveCollectGroupAndQrFromQrMediumId returns inactiveQrCode for inactive generic QR',
+      () async {
+        final group = CollectGroup(
+          nameSpace: '61f7ed014e4c0621d000',
+          orgName: 'Namespace Org',
+          hasCelebration: false,
+          type: CollectGroupType.church,
+          qrCodes: [
+            QrCode(
+              name: '',
+              instance: '61f7ed014e4c0621d000.generic',
+              isActive: false,
+            ),
+          ],
+        );
+
+        final repo = FakeCollectGroupRepository([group]);
+        final result =
+            await ForYouDiscoveryResolvers.resolveCollectGroupAndQrFromQrMediumId(
+              '61f7ed014e4c0621d000',
+              collectGroupRepository: repo,
+            );
+
+        expect(result.isSuccess, isFalse);
+        expect(result.failure, equals(ForYouDiscoveryFailure.inactiveQrCode));
       },
     );
 


### PR DESCRIPTION
## Summary
- Fix retry flow for cancelled donations when `mediumId` is namespace-only (no dot), resolving the org via For You discovery and prefilling the donation amount on the giving screen.
- Address Bugbot review findings: prefer exact namespace matches over prefix matches, sync decimal separator before goal initialization, and add namespace-only handling in the legacy `GiveBloc` resolver.
- Add resolver test coverage for namespace-only, dotted, unknown, inactive, and exact-match-priority cases.

## Test plan
- [ ] Retry a cancelled donation with namespace-only `mediumId` → org resolves, amount prefilled, donation submits
- [ ] Retry a cancelled donation with dotted `mediumId` (specific QR goal) → still works, goal restriction unchanged
- [ ] Retry while unauthenticated → resolves after login
- [ ] US/UK locale → verify prefilled decimal separator on For You giving screen


Made with [Cursor](https://cursor.com)