### PR TITLE
ENG-1155: Localize month names in personal summary chart

### DIFF
--- a/lib/features/personal_summary/widgets/monthly_category_bar_chart.dart
+++ b/lib/features/personal_summary/widgets/monthly_category_bar_chart.dart
@@ -91,8 +91,13 @@ class _MonthlyRow extends StatelessWidget {
       return Row(
         children: [
           SizedBox(
-            width: 28,
-            child: LabelSmallText(monthLabel, color: theme.neutral50),
+            width: 40,
+            child: LabelSmallText(
+              monthLabel,
+              color: theme.neutral50,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
           const SizedBox(width: 10),
           Expanded(
@@ -105,8 +110,13 @@ class _MonthlyRow extends StatelessWidget {
     return Row(
       children: [
         SizedBox(
-          width: 28,
-          child: LabelSmallText(monthLabel, color: theme.neutral50),
+          width: 40,
+          child: LabelSmallText(
+            monthLabel,
+            color: theme.neutral50,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
         ),
         const SizedBox(width: 10),
         Expanded(

--- a/lib/features/personal_summary/widgets/monthly_category_bar_chart.dart
+++ b/lib/features/personal_summary/widgets/monthly_category_bar_chart.dart
@@ -5,6 +5,7 @@ import 'package:givt_app/features/personal_summary/widgets/personal_summary_cate
 import 'package:givt_app/features/personal_summary/widgets/personal_summary_section_card.dart';
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/shared/design_system/design_system.dart';
+import 'package:givt_app/utils/util.dart';
 import 'package:intl/intl.dart';
 
 class MonthlyCategoryBarChart extends StatelessWidget {
@@ -23,6 +24,7 @@ class MonthlyCategoryBarChart extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = FunTheme.of(context);
     final locals = context.l10n;
+    final locale = Util.getLanguageTageFromLocale(context);
     final maxTotal = rows.fold<double>(
       0,
       (max, row) => row.total > max ? row.total : max,
@@ -53,7 +55,7 @@ class MonthlyCategoryBarChart extends StatelessWidget {
                   row: row,
                   maxTotal: maxTotal,
                   formatAmount: formatAmount,
-                  monthLabel: DateFormat.MMM().format(
+                  monthLabel: DateFormat.MMM(locale).format(
                     DateTime(2024, row.month),
                   ),
                 ),
@@ -120,9 +122,11 @@ class _MonthlyRow extends StatelessWidget {
                   height: 14,
                   child: Stack(
                     children: [
-                      for (var index = 0;
-                          index < monthlyBarCategoryOrder.length;
-                          index++)
+                      for (
+                        var index = 0;
+                        index < monthlyBarCategoryOrder.length;
+                        index++
+                      )
                         _buildSegment(context, index, totalBarWidth),
                     ],
                   ),
@@ -154,7 +158,8 @@ class _MonthlyRow extends StatelessWidget {
     }
 
     final segmentFraction = amount / row.total;
-    final precedingFraction = monthlyBarCategoryOrder
+    final precedingFraction =
+        monthlyBarCategoryOrder
             .take(index)
             .map(row.amountFor)
             .fold<double>(0, (sum, value) => sum + value) /

--- a/test/features/personal_summary/widgets/monthly_category_bar_chart_test.dart
+++ b/test/features/personal_summary/widgets/monthly_category_bar_chart_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/features/personal_summary/models/personal_summary_chart_models.dart';
+import 'package:givt_app/features/personal_summary/widgets/monthly_category_bar_chart.dart';
+import 'package:givt_app/l10n/arb/app_localizations.dart';
+import 'package:intl/intl.dart';
+
+void main() {
+  const sampleRows = [
+    MonthlyCategoryRow(
+      month: 1,
+      amountsByCategory: {GivingCategory.charity: 25},
+      total: 25,
+    ),
+    MonthlyCategoryRow(
+      month: 2,
+      amountsByCategory: {GivingCategory.church: 40},
+      total: 40,
+    ),
+  ];
+
+  Widget wrapChart({required Locale locale}) {
+    return MaterialApp(
+      locale: locale,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: MonthlyCategoryBarChart(
+          rows: sampleRows,
+          formatAmount: (amount) => '€${amount.toStringAsFixed(0)}',
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders month labels using the app locale', (tester) async {
+    const locale = Locale('nl');
+    await tester.pumpWidget(wrapChart(locale: locale));
+    await tester.pumpAndSettle();
+
+    for (final row in sampleRows) {
+      final expectedLabel = DateFormat.MMM('nl').format(
+        DateTime(2024, row.month),
+      );
+      expect(find.text(expectedLabel), findsOneWidget);
+    }
+  });
+}

--- a/test/features/personal_summary/widgets/monthly_category_bar_chart_test.dart
+++ b/test/features/personal_summary/widgets/monthly_category_bar_chart_test.dart
@@ -3,9 +3,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:givt_app/features/personal_summary/models/personal_summary_chart_models.dart';
 import 'package:givt_app/features/personal_summary/widgets/monthly_category_bar_chart.dart';
 import 'package:givt_app/l10n/arb/app_localizations.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 
 void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('nl');
+  });
+
   const sampleRows = [
     MonthlyCategoryRow(
       month: 1,
@@ -39,7 +44,7 @@ void main() {
     await tester.pumpAndSettle();
 
     for (final row in sampleRows) {
-      final expectedLabel = DateFormat.MMM('nl').format(
+      final expectedLabel = DateFormat.MMM(locale.toLanguageTag()).format(
         DateTime(2024, row.month),
       );
       expect(find.text(expectedLabel), findsOneWidget);


### PR DESCRIPTION
## Summary
- Pass the app locale into `DateFormat.MMM()` so month labels in the personal summary monthly chart respect the user's language (e.g. Dutch).
- Widen the month label column (28px → 40px) and add ellipsis overflow so longer locale abbreviations (e.g. German) do not clip.
- Add a widget test asserting Dutch month labels, with `initializeDateFormatting` and `toLanguageTag()` aligned to production.

## Test plan
- [x] `flutter test test/features/personal_summary/widgets/monthly_category_bar_chart_test.dart`
- [x] Full test suite (`make test`)
- [x] `flutter analyze` on changed files
- [ ] Manual: open personal summary with Dutch (and optionally German) locale and confirm month labels are localized and not clipped

Closes ENG-1155

Made with [Cursor](https://cursor.com)