### PR TITLE
Allow offline giving without login (old Give + For You)

### DIFF
--- a/lib/features/auth/cubit/auth_cubit.dart
+++ b/lib/features/auth/cubit/auth_cubit.dart
@@ -452,8 +452,14 @@ class AuthCubit extends Cubit<AuthState> {
     return false;
   }
 
-  // returns whether the session was succesfully refreshed
-  Future<bool> refreshSession({bool emitAuthentication = true}) async {
+  /// Refreshes the OAuth session.
+  ///
+  /// Returns [RefreshSessionResult.success] when a new session is stored,
+  /// [RefreshSessionResult.offline] when the request fails due to no network,
+  /// and [RefreshSessionResult.failure] for auth or other errors.
+  Future<RefreshSessionResult> refreshSession({
+    bool emitAuthentication = true,
+  }) async {
     if (emitAuthentication) emit(state.copyWith(status: AuthStatus.loading));
     try {
       LoggingInfo.instance.info('Refreshing session');
@@ -467,13 +473,13 @@ class AuthCubit extends Cubit<AuthState> {
           needsReauthentication: false,
         ),
       );
-      return true;
+      return RefreshSessionResult.success;
     } on SocketException {
       log('No internet connection');
       if (emitAuthentication) {
         emit(state.copyWith(status: AuthStatus.noInternet));
       }
-      return false;
+      return RefreshSessionResult.offline;
     } catch (e, stackTrace) {
       LoggingInfo.instance.error(
         e.toString(),
@@ -482,7 +488,7 @@ class AuthCubit extends Cubit<AuthState> {
       if (emitAuthentication) {
         emit(state.copyWith(status: AuthStatus.failure));
       }
-      return false;
+      return RefreshSessionResult.failure;
     }
   }
 

--- a/lib/features/auth/cubit/auth_state.dart
+++ b/lib/features/auth/cubit/auth_state.dart
@@ -1,5 +1,11 @@
 part of 'auth_cubit.dart';
 
+enum RefreshSessionResult {
+  success,
+  offline,
+  failure,
+}
+
 enum AuthStatus {
   loading,
   unknown,

--- a/lib/features/give/pages/for_you_giving_page.dart
+++ b/lib/features/give/pages/for_you_giving_page.dart
@@ -491,11 +491,11 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
     );
   }
 
-  void _submit(
+  Future<void> _submit(
     BuildContext context,
     String namespace, {
     required int amountLimit,
-  }) {
+  }) async {
     if (!_hasValidAmounts ||
         DonationAmountValidation.anyExceedsUserAmountLimit(
           values: _controllers.map((controller) => controller.text),
@@ -516,11 +516,19 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
     if (donations.isEmpty) {
       return;
     }
-    context.read<GiveBloc>().add(
-      GiveForYouSubmitDonations(
-        nameSpace: namespace,
-        userGUID: userGuid,
-        donations: donations,
+    await AuthUtils.checkToken(
+      context,
+      checkAuthRequest: CheckAuthRequest(
+        allowWhenOffline: true,
+        navigate: (context) async {
+          context.read<GiveBloc>().add(
+            GiveForYouSubmitDonations(
+              nameSpace: namespace,
+              userGUID: userGuid,
+              donations: donations,
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/features/give/pages/home_page_qr_flow_handler.dart
+++ b/lib/features/give/pages/home_page_qr_flow_handler.dart
@@ -250,6 +250,17 @@ class HomePageQRFlowHandler {
 
       if (!mounted()) return;
 
+      if (finalState.status == GiveStatus.noInternetConnection) {
+        LoggingInfo.instance.info('QR flow: Navigating to offline success');
+        context.goNamed(
+          Pages.giveSucess.name,
+          extra: {
+            'orgName': finalState.organisation.organisationName,
+          },
+        );
+        return;
+      }
+
       // Navigate to giving page if we have transactionIds OR if we have transactions and organisation
       // (transactions will be submitted on the giving page if needed)
       final hasTransactionIds = finalState.transactionIds.isNotEmpty;

--- a/lib/features/give/pages/home_page_view.dart
+++ b/lib/features/give/pages/home_page_view.dart
@@ -128,6 +128,7 @@ class _HomePageViewState extends State<HomePageView> {
                       await AuthUtils.checkToken(
                         context,
                         checkAuthRequest: CheckAuthRequest(
+                          allowWhenOffline: true,
                           navigate: (context) async {
                             await HomePageQRFlowHandler.handleQRFlow(
                               context,

--- a/lib/features/give/pages/select_giving_way_page.dart
+++ b/lib/features/give/pages/select_giving_way_page.dart
@@ -204,6 +204,7 @@ class _SelectGivingWayPageState extends State<SelectGivingWayPage> {
     await AuthUtils.checkToken(
       context,
       checkAuthRequest: CheckAuthRequest(
+        allowWhenOffline: true,
         navigate: (context) async => onAuthenticated(),
       ),
     );

--- a/lib/features/give/widgets/enter_amount_bottom_sheet.dart
+++ b/lib/features/give/widgets/enter_amount_bottom_sheet.dart
@@ -63,10 +63,11 @@ class _EnterAmountBottomSheetState extends State<EnterAmountBottomSheet> {
           presets: auth.presets.presets,
           showAddCollectionButton: false,
           onAmountChanged:
-              (firstCollection, secondCollection, thirdCollection) {
-            AuthUtils.checkToken(
+              (firstCollection, secondCollection, thirdCollection) async {
+            await AuthUtils.checkToken(
               context,
               checkAuthRequest: CheckAuthRequest(
+                allowWhenOffline: true,
                 navigate: (context) async {
                   GiveLoadingDialog.showGiveLoadingDialog(context);
                   context.read<GiveBloc>().add(

--- a/lib/utils/auth_utils.dart
+++ b/lib/utils/auth_utils.dart
@@ -3,8 +3,10 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:givt_app/app/injection/injection.dart';
 import 'package:givt_app/core/auth/local_auth_info.dart';
 import 'package:givt_app/core/logging/logging.dart';
+import 'package:givt_app/core/network/network_info.dart';
 import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/features/auth/pages/login_page.dart';
 
@@ -13,11 +15,17 @@ class CheckAuthRequest {
     required this.navigate,
     this.email = '',
     this.forceLogin = false,
+    this.allowWhenOffline = false,
   });
 
   final Future<void> Function(BuildContext context) navigate;
   final String email;
   final bool forceLogin;
+
+  /// When true (giving flows only), continue with the local session if the
+  /// device is offline instead of prompting for login. Other destinations
+  /// must leave this false so they never navigate without a refreshed token.
+  final bool allowWhenOffline;
 }
 
 class AuthUtils {
@@ -40,24 +48,76 @@ class AuthUtils {
       return;
     }
 
-    // Refresh first so an expired access token is renewed without biometrics.
-    final didTokenRefresh = await context.read<AuthCubit>().refreshSession(
-          emitAuthentication: false,
-        );
-    if (!context.mounted) {
-      return;
-    }
-    if (didTokenRefresh) {
-      await checkAuthRequest.navigate(
-        context,
+    if (_canSkipRefreshForOfflineGiving(
+      context,
+      checkAuthRequest: checkAuthRequest,
+    )) {
+      LoggingInfo.instance.info(
+        'Offline giving: skipping session refresh, continuing with local session.',
       );
+      await checkAuthRequest.navigate(context);
       return;
     }
 
-    await _promptBiometricsOrLogin(
+    // Refresh first so an expired access token is renewed without biometrics.
+    final refreshResult = await context.read<AuthCubit>().refreshSession(
+      emitAuthentication: false,
+    );
+    if (!context.mounted) {
+      return;
+    }
+    if (await _tryNavigateAfterRefresh(
       context,
       checkAuthRequest: checkAuthRequest,
-    );
+      refreshResult: refreshResult,
+    )) {
+      return;
+    }
+
+    await _promptBiometricsOrLogin(context, checkAuthRequest: checkAuthRequest);
+  }
+
+  static bool _canSkipRefreshForOfflineGiving(
+    BuildContext context, {
+    required CheckAuthRequest checkAuthRequest,
+  }) {
+    if (!checkAuthRequest.allowWhenOffline) {
+      return false;
+    }
+    if (getIt<NetworkInfo>().isConnected) {
+      return false;
+    }
+    return _hasLocalAuthenticatedSession(context.read<AuthCubit>().state);
+  }
+
+  static bool _hasLocalAuthenticatedSession(AuthState auth) {
+    return auth.user.guid.isNotEmpty &&
+        auth.status != AuthStatus.unauthenticated;
+  }
+
+  /// Returns true when [navigate] was invoked and the caller should stop.
+  static Future<bool> _tryNavigateAfterRefresh(
+    BuildContext context, {
+    required CheckAuthRequest checkAuthRequest,
+    required RefreshSessionResult refreshResult,
+  }) async {
+    switch (refreshResult) {
+      case RefreshSessionResult.success:
+        await checkAuthRequest.navigate(context);
+        return true;
+      case RefreshSessionResult.offline:
+        if (checkAuthRequest.allowWhenOffline &&
+            _hasLocalAuthenticatedSession(context.read<AuthCubit>().state)) {
+          LoggingInfo.instance.info(
+            'Offline giving: session refresh failed due to no network, continuing with local session.',
+          );
+          await checkAuthRequest.navigate(context);
+          return true;
+        }
+        return false;
+      case RefreshSessionResult.failure:
+        return false;
+    }
   }
 
   static Future<void> _promptBiometricsOrLogin(
@@ -92,22 +152,23 @@ class AuthUtils {
       if (!context.mounted) {
         return;
       }
-      final didTokenRefresh = await context.read<AuthCubit>().refreshSession(
-            emitAuthentication: false,
-          );
+      final refreshResult = await context.read<AuthCubit>().refreshSession(
+        emitAuthentication: false,
+      );
       if (!context.mounted) {
         return;
       }
-      if (didTokenRefresh) {
-        await checkAuthRequest.navigate(
-          context,
-        );
-      } else {
-        await displayLoginBottomSheet(
-          context,
-          checkAuthRequest: checkAuthRequest,
-        );
+      if (await _tryNavigateAfterRefresh(
+        context,
+        checkAuthRequest: checkAuthRequest,
+        refreshResult: refreshResult,
+      )) {
+        return;
       }
+      await displayLoginBottomSheet(
+        context,
+        checkAuthRequest: checkAuthRequest,
+      );
     } on PlatformException catch (e) {
       LoggingInfo.instance.info(
         'Error while authenticating with biometrics: ${e.message}',

--- a/lib/utils/auth_utils.dart
+++ b/lib/utils/auth_utils.dart
@@ -53,7 +53,8 @@ class AuthUtils {
       checkAuthRequest: checkAuthRequest,
     )) {
       LoggingInfo.instance.info(
-        'Offline giving: skipping session refresh, continuing with local session.',
+        'Offline giving: skipping session refresh, '
+        'continuing with local session.',
       );
       await checkAuthRequest.navigate(context);
       return;
@@ -109,7 +110,8 @@ class AuthUtils {
         if (checkAuthRequest.allowWhenOffline &&
             _hasLocalAuthenticatedSession(context.read<AuthCubit>().state)) {
           LoggingInfo.instance.info(
-            'Offline giving: session refresh failed due to no network, continuing with local session.',
+            'Offline giving: session refresh failed due to no network, '
+            'continuing with local session.',
           );
           await checkAuthRequest.navigate(context);
           return true;
@@ -163,6 +165,9 @@ class AuthUtils {
         checkAuthRequest: checkAuthRequest,
         refreshResult: refreshResult,
       )) {
+        return;
+      }
+      if (!context.mounted) {
         return;
       }
       await displayLoginBottomSheet(

--- a/test/features/auth/cubit/auth_cubit_refresh_session_test.dart
+++ b/test/features/auth/cubit/auth_cubit_refresh_session_test.dart
@@ -62,9 +62,9 @@ void main() {
         ),
       );
 
-      final didRefresh = await cubit.refreshSession(emitAuthentication: false);
+      final result = await cubit.refreshSession(emitAuthentication: false);
 
-      expect(didRefresh, isTrue);
+      expect(result, RefreshSessionResult.success);
       expect(cubit.state.status, AuthStatus.authenticated);
       expect(cubit.state.session.accessToken, 'new-access');
     });
@@ -78,9 +78,9 @@ void main() {
         ),
       );
 
-      final didRefresh = await cubit.refreshSession(emitAuthentication: false);
+      final result = await cubit.refreshSession(emitAuthentication: false);
 
-      expect(didRefresh, isFalse);
+      expect(result, RefreshSessionResult.failure);
       expect(cubit.state.status, AuthStatus.authenticated);
     });
 
@@ -88,19 +88,34 @@ void main() {
         () async {
       repository.refreshError = Exception('refresh failed');
 
-      final didRefresh = await cubit.refreshSession();
+      final result = await cubit.refreshSession();
 
-      expect(didRefresh, isFalse);
+      expect(result, RefreshSessionResult.failure);
       expect(cubit.state.status, AuthStatus.failure);
     });
 
     test('sets noInternet when emitAuthentication is true and offline', () async {
       repository.refreshError = const SocketException('offline');
 
-      final didRefresh = await cubit.refreshSession();
+      final result = await cubit.refreshSession();
 
-      expect(didRefresh, isFalse);
+      expect(result, RefreshSessionResult.offline);
       expect(cubit.state.status, AuthStatus.noInternet);
+    });
+
+    test('returns offline without changing status when emitAuthentication is false',
+        () async {
+      repository.refreshError = const SocketException('offline');
+      cubit.emit(
+        cubit.state.copyWith(
+          status: AuthStatus.authenticated,
+        ),
+      );
+
+      final result = await cubit.refreshSession(emitAuthentication: false);
+
+      expect(result, RefreshSessionResult.offline);
+      expect(cubit.state.status, AuthStatus.authenticated);
     });
   });
 }

--- a/test/utils/auth_utils_offline_giving_test.dart
+++ b/test/utils/auth_utils_offline_giving_test.dart
@@ -1,0 +1,272 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/app/injection/injection.dart';
+import 'package:givt_app/core/network/network_info.dart';
+import 'package:givt_app/features/amount_presets/models/models.dart';
+import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
+import 'package:givt_app/features/auth/models/session.dart';
+import 'package:givt_app/features/auth/repositories/auth_repository.dart';
+import 'package:givt_app/l10n/arb/app_localizations.dart';
+import 'package:givt_app/shared/models/stripe_response.dart';
+import 'package:givt_app/shared/models/temp_user.dart';
+import 'package:givt_app/shared/models/user_ext.dart';
+import 'package:givt_app/utils/auth_utils.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _FakeAuthRepository repository;
+  late _RecordingAuthCubit cubit;
+  late _FakeNetworkInfo networkInfo;
+  var navigateCount = 0;
+
+  const user = UserExt(
+    email: 'user@givt.app',
+    guid: 'guid-1',
+    amountLimit: 499,
+  );
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    repository = _FakeAuthRepository();
+    cubit = _RecordingAuthCubit(repository);
+    cubit.emit(
+      cubit.state.copyWith(status: AuthStatus.authenticated, user: user),
+    );
+    networkInfo = _FakeNetworkInfo(isConnected: true);
+    if (getIt.isRegistered<NetworkInfo>()) {
+      await getIt.unregister<NetworkInfo>();
+    }
+    getIt.registerSingleton<NetworkInfo>(networkInfo);
+    navigateCount = 0;
+  });
+
+  tearDown(() async {
+    await cubit.close();
+    repository.dispose();
+    if (getIt.isRegistered<NetworkInfo>()) {
+      await getIt.unregister<NetworkInfo>();
+    }
+  });
+
+  Future<void> runCheckToken(
+    WidgetTester tester, {
+    required bool allowWhenOffline,
+  }) async {
+    await tester.pumpWidget(
+      BlocProvider<AuthCubit>.value(
+        value: cubit,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) {
+              return TextButton(
+                onPressed: () {
+                  unawaited(
+                    AuthUtils.checkToken(
+                      context,
+                      checkAuthRequest: CheckAuthRequest(
+                        allowWhenOffline: allowWhenOffline,
+                        navigate: (_) async {
+                          navigateCount++;
+                        },
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('Continue'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Continue'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+
+  group('AuthUtils.checkToken offline giving', () {
+    testWidgets(
+      'skips refresh and navigates when allowWhenOffline and checker is disconnected',
+      (tester) async {
+        networkInfo.isConnected = false;
+
+        await runCheckToken(tester, allowWhenOffline: true);
+
+        expect(cubit.refreshCallCount, 0);
+        expect(navigateCount, 1);
+      },
+    );
+
+    testWidgets(
+      'navigates without login when allowWhenOffline and refresh is offline',
+      (tester) async {
+        cubit.refreshResult = RefreshSessionResult.offline;
+
+        await runCheckToken(tester, allowWhenOffline: true);
+
+        expect(cubit.refreshCallCount, 1);
+        expect(navigateCount, 1);
+      },
+    );
+
+    testWidgets(
+      'does not navigate when offline and allowWhenOffline is false',
+      (tester) async {
+        networkInfo.isConnected = false;
+        cubit.refreshResult = RefreshSessionResult.offline;
+
+        await runCheckToken(tester, allowWhenOffline: false);
+
+        expect(cubit.refreshCallCount, 1);
+        expect(navigateCount, 0);
+      },
+    );
+
+    testWidgets(
+      'does not skip refresh for non-giving when checker is disconnected',
+      (tester) async {
+        networkInfo.isConnected = false;
+        cubit.refreshResult = RefreshSessionResult.success;
+
+        await runCheckToken(tester, allowWhenOffline: false);
+
+        expect(cubit.refreshCallCount, 1);
+        expect(navigateCount, 1);
+      },
+    );
+  });
+}
+
+class _FakeNetworkInfo with NetworkInfo {
+  _FakeNetworkInfo({required this.isConnected});
+
+  @override
+  bool isConnected;
+
+  final _controller = StreamController<bool>.broadcast();
+
+  @override
+  Stream<bool> hasInternetConnectionStream() => _controller.stream.distinct();
+}
+
+class _RecordingAuthCubit extends AuthCubit {
+  _RecordingAuthCubit(super.repository);
+
+  int refreshCallCount = 0;
+  RefreshSessionResult refreshResult = RefreshSessionResult.success;
+
+  @override
+  Future<RefreshSessionResult> refreshSession({
+    bool emitAuthentication = true,
+  }) async {
+    refreshCallCount++;
+    return refreshResult;
+  }
+}
+
+class _FakeAuthRepository with AuthRepository {
+  final _sessionController = StreamController<bool>.broadcast();
+
+  void dispose() {
+    _sessionController.close();
+  }
+
+  @override
+  Future<Session> refreshToken({bool refreshUserExt = false}) async =>
+      const Session.empty();
+
+  @override
+  Future<Session> login(String email, String password) async =>
+      const Session.empty();
+
+  @override
+  Future<UserExt> fetchUserExtension(String guid) async =>
+      const UserExt(email: '', guid: '', amountLimit: 0);
+
+  @override
+  Future<(UserExt, Session, UserPresets)?> isAuthenticated() async => null;
+
+  @override
+  Future<bool> logout() async => true;
+
+  @override
+  Future<bool> checkTld(String email) async => true;
+
+  @override
+  Future<String> checkEmail(String email) async => '';
+
+  @override
+  Future<bool> resetPassword(String email) async => true;
+
+  @override
+  Future<String> signSepaMandate({
+    required String guid,
+    required String appLanguage,
+  }) async => '';
+
+  @override
+  Future<StripeResponse> fetchStripeSetupIntent() async =>
+      const StripeResponse.empty();
+
+  @override
+  Future<UserExt> registerUser({
+    required TempUser tempUser,
+    required bool isNewUser,
+  }) async => const UserExt(email: '', guid: '', amountLimit: 0);
+
+  @override
+  Future<bool> changeGiftAid({
+    required String guid,
+    required bool giftAid,
+  }) async => true;
+
+  @override
+  Future<bool> unregisterUser({required String email}) async => true;
+
+  @override
+  Future<bool> updateUser({
+    required String guid,
+    required Map<String, dynamic> newUserExt,
+  }) async => true;
+
+  @override
+  Future<bool> updateUserExt(Map<String, dynamic> newUserExt) async => true;
+
+  @override
+  Future<bool> updateLocalUserPresets({
+    required UserPresets newUserPresets,
+  }) async => true;
+
+  @override
+  Future<void> checkUserExt({required String email}) async {}
+
+  @override
+  Future<bool> updateNotificationId({
+    required String guid,
+    required String notificationId,
+    required bool notificationPermissionStatus,
+  }) async => true;
+
+  @override
+  void updateSessionStream(bool hasSession) {
+    if (!_sessionController.isClosed) {
+      _sessionController.add(hasSession);
+    }
+  }
+
+  @override
+  Stream<bool> hasSessionStream() => _sessionController.stream;
+
+  @override
+  void setHasSessionInitialValue(bool hasSession) {}
+
+  @override
+  Future<Session> getStoredSession() async => const Session.empty();
+}

--- a/test/utils/auth_utils_offline_giving_test.dart
+++ b/test/utils/auth_utils_offline_giving_test.dart
@@ -57,6 +57,17 @@ void main() {
     WidgetTester tester, {
     required bool allowWhenOffline,
   }) async {
+    final previousOnError = FlutterError.onError;
+    FlutterError.onError = (details) {
+      if (details.toString().contains('overflowed')) {
+        return;
+      }
+      previousOnError?.call(details);
+    };
+    addTearDown(() {
+      FlutterError.onError = previousOnError;
+    });
+
     await tester.pumpWidget(
       BlocProvider<AuthCubit>.value(
         value: cubit,
@@ -93,7 +104,8 @@ void main() {
 
   group('AuthUtils.checkToken offline giving', () {
     testWidgets(
-      'skips refresh and navigates when allowWhenOffline and checker is disconnected',
+      'skips refresh and navigates when allowWhenOffline '
+      'and checker is disconnected',
       (tester) async {
         networkInfo.isConnected = false;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Tine’s [ENG-1171](https://linear.app/givt/issue/ENG-1171) finding that the **old Give flow** cannot continue offline (login/FaceID), while **For You** can. Root cause is [ENG-1143](https://linear.app/givt/issue/ENG-1143): `AuthUtils.checkToken` always calls `refreshSession()`, treats `SocketException` like an invalid token, and never reaches queued giving.

Offline continue-without-login is **opt-in and giving-only**. Drawer destinations such as donation overview still require login and **never navigate** when offline.

## Changes

- `RefreshSessionResult` (`success` / `offline` / `failure`) so a network failure is distinct from an invalid refresh token
- `CheckAuthRequest.allowWhenOffline` (default `false`)
  - Giving + checker already disconnected + local session → skip `refreshSession` and continue
  - Giving + checker still connected + `SocketException` → continue and queue
  - Default (menu items) → do not navigate when refresh is offline
- Set `allowWhenOffline: true` on old Give (select way, enter amount, home QR) and For You submit
- Home QR flow routes `GiveStatus.noInternetConnection` to the offline success screen

## Verification

- `flutter test test/utils/auth_utils_offline_giving_test.dart test/features/auth/cubit/auth_cubit_refresh_session_test.dart` — 9 passed
- `flutter test test/features/auth/auth_cubit_startup_reauth_test.dart` — 5 passed
- `flutter analyze` on changed files — exit 0 (pre-existing infos only)
- Version kept at `6.5.0`

## Test plan

- [ ] Airplane mode: old Give (list / collection) completes without login and shows “Got it”
- [ ] Airplane mode: For You (favorite) still completes without login
- [ ] Airplane mode: Donation overview still asks for login and does not open
- [ ] Online giving still silent-refreshes; invalid token still prompts biometrics/login
- [ ] Queued donations sync when back online; offline banner still updates

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f72723cd-6f94-40a0-b3e0-4f8c57ae5f46?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f72723cd-6f94-40a0-b3e0-4f8c57ae5f46&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

