### PR TITLE
Fix pledge overview card date off by one day (ENG-1161)

### DIFF
--- a/lib/features/pledges/shared/models/pledge.dart
+++ b/lib/features/pledges/shared/models/pledge.dart
@@ -284,8 +284,13 @@ class PledgeGoal extends Equatable {
   DateTime? get nextExecutionDateTime =>
       _earliestUpcomingTransaction()?.executionDateTime;
 
+  /// Original API string for the next upcoming transaction date.
+  ///
+  /// Must not be re-encoded via [DateTime.toUtc]; [ApiDateTime.parseLocal]
+  /// treats ISO values as wall-clock calendar dates, so a UTC round-trip
+  /// shifts the calendar day east of UTC (ENG-1161).
   String? get nextExecutionDate =>
-      nextExecutionDateTime?.toUtc().toIso8601String();
+      _earliestUpcomingTransaction()?.executionDate;
 
   double get scheduledGivenAmount => transactions
       .where((transaction) => transaction.isProcessed)

--- a/test/features/pledges/pledge_test.dart
+++ b/test/features/pledges/pledge_test.dart
@@ -108,6 +108,54 @@ void main() {
       expect(pledges.first.endDate, '2026-12-31T00:00:00Z');
       expect(pledges.last.goalName, 'Youth Ministry');
     });
+
+    test('toPledges keeps next execution as original wall-clock API date', () {
+      const executionDate = '2026-08-31T00:00:00Z';
+      final group = PledgeGroup.fromJson({
+        'pledgeGroupId': 'pg-1',
+        'pledgeGroupName': 'Campaign',
+        'collectGroupId': 'cg-1',
+        'collectGroupNamespace': 'org',
+        'collectGroupName': 'Church',
+        'startDate': '2026-01-01T00:00:00Z',
+        'endDate': '2026-12-31T00:00:00Z',
+        'goals': [
+          {
+            'id': 'goal-row-1',
+            'goalId': 'goal-1',
+            'goalName': 'Building Fund',
+            'totalAmount': 1598,
+            'type': 'DirectDebit',
+            'frequency': 'Monthly',
+            'transactions': [
+              {
+                'id': 'tx-1',
+                'amount': 266.32,
+                'executionDate': executionDate,
+                'state': 'Entered',
+              },
+            ],
+          },
+        ],
+      });
+
+      final pledges = group.toPledges();
+      expect(pledges, hasLength(1));
+
+      final pledge = pledges.first;
+      expect(pledge.nextExecutionDate, executionDate);
+      expect(pledge.nextExecutionDateTime, isNotNull);
+      expect(pledge.nextExecutionDateTime!.year, 2026);
+      expect(pledge.nextExecutionDateTime!.month, 8);
+      expect(pledge.nextExecutionDateTime!.day, 31);
+
+      final card = PledgeOverviewCard.fromPledges(pledges);
+      final cardDate = card.earliestNextExecution;
+      expect(cardDate, isNotNull);
+      expect(cardDate!.year, 2026);
+      expect(cardDate.month, 8);
+      expect(cardDate.day, 31);
+    });
   });
 
   group('Pledge', () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [ENG-1161](https://linear.app/givt/issue/ENG-1161/pledge-overview-the-date-in-the-card-is-incorrect): the pledge overview card showed the next execution date one day early (e.g. Aug 30 instead of Aug 31).

## Cause

`ApiDateTime.parseLocal` treats API ISO strings as wall-clock calendar dates and ignores `Z` / offsets. When flattening a pledge group for the list, `PledgeGoal.nextExecutionDate` re-encoded that local `DateTime` with `toUtc().toIso8601String()`. East of UTC that shifts midnight to the previous calendar day, so the card displayed Aug 30 while detail (which uses the original API string) showed Aug 31.

## Change

- Keep the original transaction `executionDate` string when flattening pledges.
- Add a regression test that `2026-08-31T00:00:00Z` stays Aug 31 on the overview card path.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cf43a0c-6345-40fd-bc8d-ae6755fbffb5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cf43a0c-6345-40fd-bc8d-ae6755fbffb5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

