### PR TITLE
Fix Cloud Agent environment install (Flutter bootstrap)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "Givt App",
+  "user": "ubuntu",
+  "install": ".cursor/scripts/cloud-agent-install.sh"
+}

--- a/.cursor/scripts/cloud-agent-install.sh
+++ b/.cursor/scripts/cloud-agent-install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FLUTTER_VERSION="3.41.0"
+FLUTTER_DIR="$HOME/flutter"
+PATH_EXPORT='export PATH="$HOME/flutter/bin:$HOME/.pub-cache/bin:$PATH"'
+
+if [ ! -x "$FLUTTER_DIR/bin/flutter" ]; then
+  git clone https://github.com/flutter/flutter.git -b "$FLUTTER_VERSION" --depth 1 "$FLUTTER_DIR"
+fi
+
+# Keep Flutter on PATH for interactive agent shells.
+if ! grep -q 'flutter/bin' "$HOME/.bashrc" 2>/dev/null; then
+  printf '\n%s\n' "$PATH_EXPORT" >>"$HOME/.bashrc"
+fi
+
+eval "$PATH_EXPORT"
+
+dart pub global activate melos
+melos install


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Environment build [bld-20260813-bb1a5066-9a95-4826-a2e3-5241c32e0d00](https://cursor.com/dashboard/cloud-agents/builds/bld-20260813-bb1a5066-9a95-4826-a2e3-5241c32e0d00) failed during install with:

```
bash: line 2: dart: command not found
bash: line 3: melos: command not found
```

The personal (dashboard-managed) install script was:

```bash
export PATH="$HOME/flutter/bin:$HOME/.pub-cache/bin:$PATH"
dart pub global activate melos
melos install
```

It assumes Flutter is already present at `$HOME/flutter` from a base snapshot, but no snapshot with Flutter was configured. On a fresh build image, `dart` and `melos` are unavailable.

## Solution

Add repository-managed `.cursor/environment.json` (takes precedence over dashboard config) with an idempotent install script that:

1. Clones Flutter **3.41.0** to `$HOME/flutter` when missing (per `AGENTS.md`)
2. Adds Flutter/Melos to `PATH` in `~/.bashrc` for agent shells
3. Activates Melos and runs `melos install`

## Validation

On the failed-build VM, after manually bootstrapping Flutter:

- `melos install` — success
- `flutter analyze` — success (info-level issues only)
- `flutter test --coverage --test-randomize-ordering-seed random` — success
- Re-running `.cursor/scripts/cloud-agent-install.sh` — idempotent success

## Follow-up

After merging, trigger a new environment build from the [environment dashboard](https://cursor.com/dashboard/cloud-agents/environments/e/174a53c1-2e97-486c-9ace-25641d6307d0). The first successful build will snapshot Flutter; subsequent builds will skip the clone step.

Android SDK setup (for APK builds) remains optional and is documented in `AGENTS.md`; it is not required for install or unit tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbdb512e-9ffa-463d-bc80-89c6130da7dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbdb512e-9ffa-463d-bc80-89c6130da7dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

