### PR TITLE
ENG-1233: Update FunAccordion typography to title/small and body/small

### DIFF
--- a/lib/shared/design_system/components/content/fun_accordion.dart
+++ b/lib/shared/design_system/components/content/fun_accordion.dart
@@ -17,7 +17,6 @@ class FunAccordion extends StatelessWidget {
     required this.onHeaderTap,
     this.subtitle,
     this.content,
-    this.size = FunAccordionSize.medium,
     this.state = FunAccordionState.collapsed,
     this.leadingIcon,
     super.key,
@@ -26,7 +25,6 @@ class FunAccordion extends StatelessWidget {
   final String title;
   final String? subtitle;
   final Widget? content;
-  final FunAccordionSize size;
   final FunAccordionState state;
   final bool isExpanded;
   final VoidCallback onHeaderTap;
@@ -171,11 +169,6 @@ class FunAccordion extends StatelessWidget {
       color: iconColor,
     );
   }
-}
-
-enum FunAccordionSize {
-  medium,
-  small,
 }
 
 enum FunAccordionState {

--- a/lib/shared/design_system/components/content/fun_accordion.dart
+++ b/lib/shared/design_system/components/content/fun_accordion.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:givt_app/shared/design_system/theme/fun_app_theme.dart';
-import 'package:givt_app/shared/design_system/theme/fun_theme.dart';
 import 'package:givt_app/features/family/shared/widgets/texts/texts.dart';
+import 'package:givt_app/shared/design_system/design_system.dart';
 
 /// FUN Accordion
 ///
@@ -69,13 +68,13 @@ class FunAccordion extends StatelessWidget {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          TitleMediumText(
+                          TitleSmallText(
                             title,
                             color: _titleColor(theme),
                           ),
                           if (subtitle != null) ...[
                             const SizedBox(height: 4),
-                            BodyMediumText(
+                            BodySmallText(
                               subtitle!,
                               color: _subtitleColor(theme),
                             ),
@@ -163,10 +162,9 @@ class FunAccordion extends StatelessWidget {
     }
 
     // Use white icon when header has dark background (active and expanded)
-    final iconColor =
-        (state == FunAccordionState.active && isExpanded)
-            ? Colors.white
-            : _titleColor(theme);
+    final iconColor = (state == FunAccordionState.active && isExpanded)
+        ? Colors.white
+        : _titleColor(theme);
 
     return Icon(
       isExpanded ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,

--- a/test/shared/design_system/fun_accordion_test.dart
+++ b/test/shared/design_system/fun_accordion_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/texts.dart';
+import 'package:givt_app/shared/design_system/components/content/fun_accordion.dart';
+import 'package:givt_app/shared/design_system/theme/fun_givt_theme.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: FunGivtTheme().toThemeData(),
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  testWidgets(
+    'renders TitleSmallText and BodySmallText for title and subtitle',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          FunAccordion(
+            title: 'My title',
+            subtitle: 'More info',
+            isExpanded: false,
+            onHeaderTap: () {},
+          ),
+        ),
+      );
+
+      expect(find.byType(TitleSmallText), findsOneWidget);
+      expect(find.byType(BodySmallText), findsOneWidget);
+      expect(find.byType(TitleMediumText), findsNothing);
+      expect(find.byType(BodyMediumText), findsNothing);
+      expect(find.text('My title'), findsOneWidget);
+      expect(find.text('More info'), findsOneWidget);
+    },
+  );
+
+  testWidgets('omits BodySmallText when subtitle is null', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        FunAccordion(
+          title: 'My title',
+          isExpanded: false,
+          onHeaderTap: () {},
+        ),
+      ),
+    );
+
+    expect(find.byType(TitleSmallText), findsOneWidget);
+    expect(find.byType(BodySmallText), findsNothing);
+  });
+
+  testWidgets('shows content when expanded and hides when collapsed', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        FunAccordion(
+          title: 'My title',
+          isExpanded: true,
+          onHeaderTap: () {},
+          content: const Text('Expanded content'),
+        ),
+      ),
+    );
+
+    expect(find.text('Expanded content'), findsOneWidget);
+
+    await tester.pumpWidget(
+      _wrap(
+        FunAccordion(
+          title: 'My title',
+          isExpanded: false,
+          onHeaderTap: () {},
+          content: const Text('Expanded content'),
+        ),
+      ),
+    );
+
+    expect(find.text('Expanded content'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- Update `FunAccordion` header title from `TitleMediumText` to `TitleSmallText` (18px) and subtitle from `BodyMediumText` to `BodySmallText` (15px) per FUN Design System spec.
- Add widget tests asserting typography widgets and expand/collapse behavior.
- Remove unused `FunAccordionSize` enum and `size` parameter (never wired to layout or typography).

## Test plan
- [x] `flutter test test/shared/design_system/fun_accordion_test.dart`
- [x] `flutter analyze` on changed accordion files
- [ ] Manual: For You giving flow — accordion titles/subtitles at collapsed and expanded states
- [ ] Manual: Gift Aid registration — example accordion expand/collapse
- [ ] Manual: Manage Gift Aid — teal impact accordion header

Linear: https://linear.app/givt/issue/ENG-1233/update-accordion-component-in-givt-app

Made with [Cursor](https://cursor.com)