### PR TITLE
ENG-1286: Sort personal summary categories by donation amount

### DIFF
--- a/lib/features/personal_summary/domain/personal_summary_aggregation.dart
+++ b/lib/features/personal_summary/domain/personal_summary_aggregation.dart
@@ -186,11 +186,24 @@ PersonalSummaryUIModel buildPersonalSummaryUIModel({
   );
 }
 
+int compareCategorySegments(ChartSegment a, ChartSegment b) {
+  if (a.hasData != b.hasData) {
+    return a.hasData ? -1 : 1;
+  }
+  if (a.hasData) {
+    final byAmount = b.amount.compareTo(a.amount);
+    if (byAmount != 0) {
+      return byAmount;
+    }
+  }
+  return a.category.name.compareTo(b.category.name);
+}
+
 List<ChartSegment> _buildCategorySegments(
   Map<GivingCategory, double> totals,
   double yearTotal,
 ) {
-  return GivingCategoryX.ordered.map((category) {
+  final segments = GivingCategoryX.ordered.map((category) {
     final amount = totals[category] ?? 0;
     final fraction = yearTotal > 0 ? amount / yearTotal : 0.0;
     return ChartSegment(
@@ -198,7 +211,9 @@ List<ChartSegment> _buildCategorySegments(
       amount: amount,
       fraction: fraction,
     );
-  }).toList();
+  }).toList()
+    ..sort(compareCategorySegments);
+  return segments;
 }
 
 List<MonthlyCategoryRow> _buildMonthlyRows(

--- a/lib/features/personal_summary/domain/personal_summary_aggregation.dart
+++ b/lib/features/personal_summary/domain/personal_summary_aggregation.dart
@@ -186,7 +186,7 @@ PersonalSummaryUIModel buildPersonalSummaryUIModel({
   );
 }
 
-int compareCategorySegments(ChartSegment a, ChartSegment b) {
+int _compareCategorySegments(ChartSegment a, ChartSegment b) {
   if (a.hasData != b.hasData) {
     return a.hasData ? -1 : 1;
   }
@@ -199,6 +199,8 @@ int compareCategorySegments(ChartSegment a, ChartSegment b) {
   return a.category.name.compareTo(b.category.name);
 }
 
+/// Donut and legend order: descending by amount, then alphabetical for ties/zeros.
+/// Monthly bar stacks keep a fixed Figma order in the widget layer.
 List<ChartSegment> _buildCategorySegments(
   Map<GivingCategory, double> totals,
   double yearTotal,
@@ -212,7 +214,7 @@ List<ChartSegment> _buildCategorySegments(
       fraction: fraction,
     );
   }).toList()
-    ..sort(compareCategorySegments);
+    ..sort(_compareCategorySegments);
   return segments;
 }
 

--- a/test/features/personal_summary/personal_summary_aggregation_test.dart
+++ b/test/features/personal_summary/personal_summary_aggregation_test.dart
@@ -99,6 +99,15 @@ void main() {
       expect(uiModel.categorySegments.firstWhere((s) => s.category == GivingCategory.church).amount, 20);
       expect(uiModel.categorySegments.firstWhere((s) => s.category == GivingCategory.charity).amount, 30);
       expect(uiModel.categorySegments.firstWhere((s) => s.category == GivingCategory.other).amount, 10);
+      expect(
+        uiModel.categorySegments.map((segment) => segment.category).toList(),
+        [
+          GivingCategory.charity,
+          GivingCategory.church,
+          GivingCategory.other,
+          GivingCategory.campaign,
+        ],
+      );
       expect(uiModel.monthlyRows[0].total, 20);
       expect(uiModel.monthlyRows[1].total, 30);
       expect(uiModel.monthlyRows[2].total, 10);
@@ -162,6 +171,175 @@ void main() {
 
       expect(uiModel.yearTotal, 0);
       expect(uiModel.hasDonationsInYear, isFalse);
+    });
+
+    test('orders category segments descending by amount', () {
+      final collectGroupsWithCampaign = [
+        ...collectGroups,
+        const CollectGroup(
+          nameSpace: 'campaign-ns',
+          orgName: 'My Campaign',
+          hasCelebration: false,
+          type: CollectGroupType.campaign,
+        ),
+      ];
+
+      final givts = [
+        Givt(
+          id: 1,
+          amount: 10,
+          collectGroupId: 'guid-1',
+          organisationName: 'My Campaign',
+          organisationTaxDeductible: true,
+          collectId: 1,
+          isGiftAidEnabled: false,
+          status: 3,
+          timeStamp: DateTime(2025, 1, 10),
+          mediumId: 'campaign-ns.location',
+          taxYear: 0,
+        ),
+        Givt(
+          id: 2,
+          amount: 30,
+          collectGroupId: 'guid-2',
+          organisationName: 'My Church',
+          organisationTaxDeductible: true,
+          collectId: 2,
+          isGiftAidEnabled: false,
+          status: 3,
+          timeStamp: DateTime(2025, 2, 5),
+          mediumId: 'church-ns.location',
+          taxYear: 0,
+        ),
+        Givt(
+          id: 3,
+          amount: 40,
+          collectGroupId: 'guid-3',
+          organisationName: 'My Charity',
+          organisationTaxDeductible: true,
+          collectId: 3,
+          isGiftAidEnabled: false,
+          status: 3,
+          timeStamp: DateTime(2025, 3, 5),
+          mediumId: 'charity-ns.location',
+          taxYear: 0,
+        ),
+      ];
+
+      final external = [
+        const ExternalDonation(
+          id: 'ext-1',
+          amount: 20,
+          description: 'External',
+          frequencyString: 'Once',
+          creationDate: '2025-04-01T00:00:00',
+          taxDeductible: false,
+          startDate: '2025-04-01T00:00:00',
+        ),
+      ];
+
+      final uiModel = buildPersonalSummaryUIModel(
+        allGivts: givts,
+        allExternalDonations: external,
+        collectGroups: collectGroupsWithCampaign,
+        givingGoal: const GivingGoal.empty(),
+        selectedYear: 2025,
+      );
+
+      expect(
+        uiModel.categorySegments.map((segment) => segment.category).toList(),
+        [
+          GivingCategory.charity,
+          GivingCategory.church,
+          GivingCategory.other,
+          GivingCategory.campaign,
+        ],
+      );
+    });
+
+    test('lists zero-donation categories below active categories alphabetically', () {
+      final uiModel = buildPersonalSummaryUIModel(
+        allGivts: const [],
+        allExternalDonations: const [],
+        collectGroups: collectGroups,
+        givingGoal: const GivingGoal.empty(),
+        selectedYear: 2025,
+      );
+
+      expect(
+        uiModel.categorySegments.map((segment) => segment.category).toList(),
+        [
+          GivingCategory.campaign,
+          GivingCategory.charity,
+          GivingCategory.church,
+          GivingCategory.other,
+        ],
+      );
+    });
+
+    test('uses alphabetical order for tied non-zero amounts', () {
+      final givts = [
+        Givt(
+          id: 1,
+          amount: 50,
+          collectGroupId: 'guid-1',
+          organisationName: 'My Church',
+          organisationTaxDeductible: true,
+          collectId: 1,
+          isGiftAidEnabled: false,
+          status: 3,
+          timeStamp: DateTime(2025, 1, 10),
+          mediumId: 'church-ns.location',
+          taxYear: 0,
+        ),
+        Givt(
+          id: 2,
+          amount: 50,
+          collectGroupId: 'guid-2',
+          organisationName: 'My Charity',
+          organisationTaxDeductible: true,
+          collectId: 2,
+          isGiftAidEnabled: false,
+          status: 3,
+          timeStamp: DateTime(2025, 2, 5),
+          mediumId: 'charity-ns.location',
+          taxYear: 0,
+        ),
+      ];
+
+      final uiModel = buildPersonalSummaryUIModel(
+        allGivts: givts,
+        allExternalDonations: const [],
+        collectGroups: collectGroups,
+        givingGoal: const GivingGoal.empty(),
+        selectedYear: 2025,
+      );
+
+      expect(
+        uiModel.categorySegments.map((segment) => segment.category).toList(),
+        [
+          GivingCategory.charity,
+          GivingCategory.church,
+          GivingCategory.campaign,
+          GivingCategory.other,
+        ],
+      );
+    });
+
+    test('compareCategorySegments sorts active before zero amounts', () {
+      const active = ChartSegment(
+        category: GivingCategory.charity,
+        amount: 10,
+        fraction: 1,
+      );
+      const zero = ChartSegment(
+        category: GivingCategory.campaign,
+        amount: 0,
+        fraction: 0,
+      );
+
+      expect(compareCategorySegments(active, zero), lessThan(0));
+      expect(compareCategorySegments(zero, active), greaterThan(0));
     });
   });
 }

--- a/test/features/personal_summary/personal_summary_aggregation_test.dart
+++ b/test/features/personal_summary/personal_summary_aggregation_test.dart
@@ -326,20 +326,42 @@ void main() {
       );
     });
 
-    test('compareCategorySegments sorts active before zero amounts', () {
-      const active = ChartSegment(
-        category: GivingCategory.charity,
-        amount: 10,
-        fraction: 1,
-      );
-      const zero = ChartSegment(
-        category: GivingCategory.campaign,
-        amount: 0,
-        fraction: 0,
+    test('places zero-donation categories below active categories', () {
+      final givts = [
+        Givt(
+          id: 1,
+          amount: 10,
+          collectGroupId: 'guid-2',
+          organisationName: 'My Charity',
+          organisationTaxDeductible: true,
+          collectId: 2,
+          isGiftAidEnabled: false,
+          status: 3,
+          timeStamp: DateTime(2025, 2, 5),
+          mediumId: 'charity-ns.location',
+          taxYear: 0,
+        ),
+      ];
+
+      final uiModel = buildPersonalSummaryUIModel(
+        allGivts: givts,
+        allExternalDonations: const [],
+        collectGroups: collectGroups,
+        givingGoal: const GivingGoal.empty(),
+        selectedYear: 2025,
       );
 
-      expect(compareCategorySegments(active, zero), lessThan(0));
-      expect(compareCategorySegments(zero, active), greaterThan(0));
+      final categories =
+          uiModel.categorySegments.map((segment) => segment.category).toList();
+      expect(categories.first, GivingCategory.charity);
+      expect(
+        categories.sublist(1),
+        [
+          GivingCategory.campaign,
+          GivingCategory.church,
+          GivingCategory.other,
+        ],
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- Sort personal summary "By cause" donut and legend categories descending by total donation amount.
- Categories with zero donations appear below active categories, sorted alphabetically by enum name.
- Monthly bar chart stack order remains the fixed Figma layout (intentionally unchanged).

## Test plan
- [x] `flutter test test/features/personal_summary/`
- [x] `flutter analyze` (no new issues in changed files)
- [ ] Manual: open Personal Summary with mixed category amounts and confirm donut + legend order matches amounts

Linear: https://linear.app/givt/issue/ENG-1286/sort-personal-summary-categories-by-total-amount-donated

Made with [Cursor](https://cursor.com)