### PR TITLE
Fix recurring icon on one-off external donation badges (ENG-1284)

### DIFF
--- a/lib/features/external_donations/create/models/external_donation_create_preview_row.dart
+++ b/lib/features/external_donations/create/models/external_donation_create_preview_row.dart
@@ -12,6 +12,7 @@ class ExternalDonationCreatePreviewRow extends Equatable {
     this.isUpcoming = false,
     this.isCompleted = false,
     this.isFaded = false,
+    this.isRecurring = false,
   });
 
   final String organisationName;
@@ -27,6 +28,8 @@ class ExternalDonationCreatePreviewRow extends Equatable {
   final bool isCompleted;
   /// Oldest visible past row when three preview cards are shown.
   final bool isFaded;
+  /// Whether the Ext. donation tag should show the recurring icon.
+  final bool isRecurring;
 
   @override
   List<Object?> get props => [
@@ -39,5 +42,6 @@ class ExternalDonationCreatePreviewRow extends Equatable {
         isUpcoming,
         isCompleted,
         isFaded,
+        isRecurring,
       ];
 }

--- a/lib/features/external_donations/create/models/external_donation_create_ui_model.dart
+++ b/lib/features/external_donations/create/models/external_donation_create_ui_model.dart
@@ -158,6 +158,7 @@ class ExternalDonationCreateUIModel extends Equatable {
       typeTagLabel: _previewTypeTag(locals),
       amountLabel: amount != null ? '$currencySymbol${formatAmount(amount)}' : null,
       primarySubtitle: _donationTypeSubtitle(locals),
+      isRecurring: draft.isOneOff == false,
     );
   }
 
@@ -175,6 +176,7 @@ class ExternalDonationCreateUIModel extends Equatable {
       amountLabel: amount != null ? '$currencySymbol${formatAmount(amount)}' : null,
       primarySubtitle: locals.externalDonationsCreateFrequencyOneOff,
       dateLabel: date != null ? _formatShortDate(date, locale) : null,
+      isRecurring: false,
     );
   }
 
@@ -271,6 +273,7 @@ class ExternalDonationCreateUIModel extends Equatable {
       isUpcoming: isUpcoming,
       isCompleted: isCompleted,
       isFaded: isFaded,
+      isRecurring: true,
     );
   }
 

--- a/lib/features/external_donations/create/widgets/external_donation_create_preview_panel.dart
+++ b/lib/features/external_donations/create/widgets/external_donation_create_preview_panel.dart
@@ -130,7 +130,9 @@ class _PreviewHistoryItem extends StatelessWidget {
                     FunTag(
                       text: row.typeTagLabel!,
                       variant: FunTagVariant.accent,
-                      iconData: FontAwesomeIcons.arrowsRotate,
+                      iconData: row.isRecurring
+                          ? FontAwesomeIcons.arrowsRotate
+                          : null,
                       iconSize: 12,
                       margin: EdgeInsets.zero,
                     ),

--- a/lib/features/external_donations/detail/pages/external_donation_detail_page.dart
+++ b/lib/features/external_donations/detail/pages/external_donation_detail_page.dart
@@ -200,7 +200,11 @@ class _ExternalDonationDetailPageState extends State<ExternalDonationDetailPage>
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      _buildOrganizationHeader(context, uiModel.donation.description),
+                      _buildOrganizationHeader(
+                        context,
+                        uiModel.donation.description,
+                        isRecurring: uiModel.isRecurring,
+                      ),
                       const SizedBox(height: 24),
                       if (uiModel.isRecurring) ...[
                         _buildSummaryCards(uiModel, currency, context),
@@ -258,8 +262,9 @@ class _ExternalDonationDetailPageState extends State<ExternalDonationDetailPage>
 
   Widget _buildOrganizationHeader(
     BuildContext context,
-    String organizationName,
-  ) {
+    String organizationName, {
+    required bool isRecurring,
+  }) {
     return SizedBox(
       width: double.infinity,
       child: Column(
@@ -278,7 +283,8 @@ class _ExternalDonationDetailPageState extends State<ExternalDonationDetailPage>
           FunTag(
             text: context.l10n.externalDonationsCreatePreviewTypeTag,
             variant: FunTagVariant.accent,
-            iconData: FontAwesomeIcons.arrowsRotate,
+            iconData:
+                isRecurring ? FontAwesomeIcons.arrowsRotate : null,
             iconSize: 12,
             margin: EdgeInsets.zero,
           ),

--- a/test/features/external_donations/create/external_donation_create_ui_model_test.dart
+++ b/test/features/external_donations/create/external_donation_create_ui_model_test.dart
@@ -60,6 +60,50 @@ void main() {
       expect(rows.first.amountLabel, '€10.00');
       expect(rows.first.isCompleted, isFalse);
       expect(rows.first.secondarySubtitle, isNull);
+      expect(rows.first.isRecurring, isFalse);
+    });
+
+    test('donation type step sets isRecurring true for recurring draft', () {
+      const model = ExternalDonationCreateUIModel(
+        draft: ExternalDonationCreateDraft(
+          organisationName: 'World Vision',
+          amountInput: '10',
+          isOneOff: false,
+          frequency: ExternalDonationFrequency.monthly,
+        ),
+      );
+
+      final rows = model.previewRowsForStep(
+        ExternalDonationCreateFlowStep.donationType,
+        currencySymbol: '€',
+        formatAmount: (a) => a.toStringAsFixed(2),
+        locals: en,
+        locale: 'en',
+      );
+
+      expect(rows, hasLength(1));
+      expect(rows.first.isRecurring, isTrue);
+    });
+
+    test('donation type step sets isRecurring false when isOneOff is null',
+        () {
+      const model = ExternalDonationCreateUIModel(
+        draft: ExternalDonationCreateDraft(
+          organisationName: 'World Vision',
+          amountInput: '10',
+        ),
+      );
+
+      final rows = model.previewRowsForStep(
+        ExternalDonationCreateFlowStep.donationType,
+        currencySymbol: '€',
+        formatAmount: (a) => a.toStringAsFixed(2),
+        locals: en,
+        locale: 'en',
+      );
+
+      expect(rows, hasLength(1));
+      expect(rows.first.isRecurring, isFalse);
     });
 
     test('one-off date step shows date on third line without completed', () {
@@ -83,6 +127,7 @@ void main() {
       expect(rows, hasLength(1));
       expect(rows.first.dateLabel, '10 Mar 2024');
       expect(rows.first.isCompleted, isFalse);
+      expect(rows.first.isRecurring, isFalse);
     });
 
     test('stepCount is 3 for one-off and recurring', () {
@@ -132,6 +177,7 @@ void main() {
       expect(rows.length, lessThanOrEqualTo(3));
       expect(rows.first.isUpcoming, isTrue);
       expect(rows.any((row) => row.isCompleted), isTrue);
+      expect(rows.every((row) => row.isRecurring), isTrue);
       if (DateTime.now().isAfter(DateTime(2026, 4, 4))) {
         expect(rows.length, 3);
         expect(model.previewMoreRecordsLabel(en, 'en'), isNotNull);

--- a/test/features/external_donations/create/widgets/external_donation_create_preview_panel_test.dart
+++ b/test/features/external_donations/create/widgets/external_donation_create_preview_panel_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:givt_app/features/external_donations/create/models/external_donation_create_preview_row.dart';
+import 'package:givt_app/features/external_donations/create/widgets/external_donation_create_preview_panel.dart';
+import 'package:givt_app/l10n/arb/app_localizations.dart';
+import 'package:givt_app/shared/design_system/components/content/fun_tag.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  testWidgets('one-off preview row renders FunTag without recurring icon',
+      (tester) async {
+    const panel = ExternalDonationCreatePreviewPanel(
+      rows: [
+        ExternalDonationCreatePreviewRow(
+          organisationName: 'World Vision',
+          typeTagLabel: 'Ext. donation',
+          amountLabel: '€20.00',
+          primarySubtitle: 'One-off',
+          isRecurring: false,
+        ),
+      ],
+      showSectionTitle: false,
+    );
+
+    await tester.pumpWidget(_wrap(panel));
+    await tester.pumpAndSettle();
+
+    final tag = tester.widget<FunTag>(find.byType(FunTag));
+    expect(tag.iconData, isNull);
+  });
+
+  testWidgets('recurring preview row renders FunTag with recurring icon',
+      (tester) async {
+    const panel = ExternalDonationCreatePreviewPanel(
+      rows: [
+        ExternalDonationCreatePreviewRow(
+          organisationName: 'World Vision',
+          typeTagLabel: 'Ext. donation',
+          amountLabel: '€20.00',
+          primarySubtitle: 'Monthly',
+          isRecurring: true,
+        ),
+      ],
+      showSectionTitle: false,
+    );
+
+    await tester.pumpWidget(_wrap(panel));
+    await tester.pumpAndSettle();
+
+    final tag = tester.widget<FunTag>(find.byType(FunTag));
+    expect(tag.iconData, FontAwesomeIcons.arrowsRotate);
+    expect(tag.iconSize, 12);
+    expect(tag.variant, FunTagVariant.accent);
+  });
+}

--- a/test/features/external_donations/detail/external_donation_detail_page_test.dart
+++ b/test/features/external_donations/detail/external_donation_detail_page_test.dart
@@ -1,0 +1,214 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:givt_app/app/injection/injection.dart';
+import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
+import 'package:givt_app/features/auth/repositories/auth_repository.dart';
+import 'package:givt_app/features/external_donations/detail/cubit/external_donation_detail_cubit.dart';
+import 'package:givt_app/features/external_donations/detail/models/external_donation_history_item.dart';
+import 'package:givt_app/features/external_donations/detail/models/external_donation_update_scope.dart';
+import 'package:givt_app/features/external_donations/detail/pages/external_donation_detail_page.dart';
+import 'package:givt_app/features/external_donations/detail/repositories/external_donation_detail_repository.dart';
+import 'package:givt_app/features/external_donations/shared/external_donation_schedule.dart';
+import 'package:givt_app/features/external_donations/shared/models/external_donation.dart';
+import 'package:givt_app/features/external_donations/shared/models/external_donation_frequency.dart';
+import 'package:givt_app/l10n/arb/app_localizations.dart';
+import 'package:givt_app/shared/design_system/components/content/fun_tag.dart';
+import 'package:givt_app/shared/models/user_ext.dart';
+
+class _FakeAuthRepository with AuthRepository {
+  final _sessionController = StreamController<bool>.broadcast();
+
+  @override
+  Stream<bool> hasSessionStream() => _sessionController.stream;
+
+  void dispose() {
+    _sessionController.close();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeExternalDonationDetailRepository
+    with ExternalDonationDetailRepository {
+  ExternalDonation? _donation;
+
+  @override
+  bool isLoading() => false;
+
+  @override
+  String? getError() => null;
+
+  @override
+  ExternalDonation? getDonation() => _donation;
+
+  @override
+  double getTotalDonated() => _donation?.amount ?? 0;
+
+  @override
+  GivingDuration? getGivingDuration() =>
+      const GivingDuration(1, GivingDurationUnit.days);
+
+  @override
+  List<ExternalDonationHistoryItem> getHistory() => const [];
+
+  void setDonation(ExternalDonation donation) {
+    _donation = donation;
+  }
+
+  @override
+  Future<void> loadDetail(ExternalDonation donation) async {
+    _donation = donation;
+  }
+
+  @override
+  Future<bool> stopDonation(String externalDonationId) async => true;
+
+  @override
+  Future<bool> updateAmount({
+    required String externalDonationId,
+    required double amount,
+    ExternalDonationUpdateScope? scope,
+  }) async =>
+      true;
+
+  @override
+  Future<bool> updateFrequency({
+    required String externalDonationId,
+    required ExternalDonationFrequency frequency,
+    required DateTime anchorDate,
+    ExternalDonationUpdateScope? scope,
+  }) async =>
+      true;
+
+  @override
+  Future<bool> updateStartDate({
+    required String externalDonationId,
+    required DateTime startDate,
+  }) async =>
+      true;
+
+  @override
+  Future<bool> updateOneOff({
+    required String externalDonationId,
+    double? amount,
+    DateTime? date,
+  }) async =>
+      true;
+
+  @override
+  Future<bool> deleteDonation(String externalDonationId) async => true;
+
+  @override
+  Future<bool> bulkUpdateTransactions({
+    required List<String> transactionIds,
+    required double newAmount,
+  }) async =>
+      true;
+
+  @override
+  Future<bool> bulkDeleteTransactions({
+    required List<String> transactionIds,
+  }) async =>
+      true;
+}
+
+void main() {
+  late _FakeExternalDonationDetailRepository repository;
+  late _FakeAuthRepository authRepository;
+  late AuthCubit authCubit;
+
+  setUp(() {
+    repository = _FakeExternalDonationDetailRepository();
+
+    if (getIt.isRegistered<ExternalDonationDetailCubit>()) {
+      getIt.unregister<ExternalDonationDetailCubit>();
+    }
+    getIt.registerFactory<ExternalDonationDetailCubit>(
+      () => ExternalDonationDetailCubit(repository),
+    );
+
+    authRepository = _FakeAuthRepository();
+    authCubit = AuthCubit(authRepository);
+    authCubit.emit(
+      authCubit.state.copyWith(
+        status: AuthStatus.authenticated,
+        user: const UserExt(
+          email: 'test@givt.app',
+          guid: 'guid',
+          amountLimit: 499,
+          country: 'NL',
+        ),
+      ),
+    );
+  });
+
+  tearDown(() async {
+    await authCubit.close();
+    authRepository.dispose();
+    if (getIt.isRegistered<ExternalDonationDetailCubit>()) {
+      await getIt.unregister<ExternalDonationDetailCubit>();
+    }
+  });
+
+  Future<void> pumpDetailPage(
+    WidgetTester tester,
+    ExternalDonation donation,
+  ) async {
+    await tester.pumpWidget(
+      BlocProvider<AuthCubit>.value(
+        value: authCubit,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ExternalDonationDetailPage(donation: donation),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('one-off detail page renders FunTag without recurring icon',
+      (tester) async {
+    const donation = ExternalDonation(
+      id: 'donation-one-off',
+      amount: 20,
+      description: 'World Vision',
+      frequencyString: 'Once',
+      creationDate: '2024-01-01T00:00:00.000Z',
+      taxDeductible: false,
+      startDate: '2024-06-15T00:00:00.000Z',
+    );
+    repository.setDonation(donation);
+
+    await pumpDetailPage(tester, donation);
+
+    final tag = tester.widget<FunTag>(find.byType(FunTag));
+    expect(tag.iconData, isNull);
+  });
+
+  testWidgets('recurring detail page renders FunTag with recurring icon',
+      (tester) async {
+    const donation = ExternalDonation(
+      id: 'donation-recurring',
+      amount: 20,
+      description: 'World Vision',
+      frequencyString: 'Monthly',
+      creationDate: '2024-01-01T00:00:00.000Z',
+      taxDeductible: false,
+      startDate: '2024-06-15T00:00:00.000Z',
+    );
+    repository.setDonation(donation);
+
+    await pumpDetailPage(tester, donation);
+
+    final tag = tester.widget<FunTag>(find.byType(FunTag));
+    expect(tag.iconData, FontAwesomeIcons.arrowsRotate);
+    expect(tag.iconSize, 12);
+    expect(tag.variant, FunTagVariant.accent);
+  });
+}


### PR DESCRIPTION
## Summary
- Show the recurring rotate icon on the purple "Ext. donation" `FunTag` only when the donation is recurring, not for one-off donations.
- Gate icon display in the create-flow preview panel and external donation detail page header via `isRecurring`.
- Add widget tests for both surfaces (create preview panel and detail page header).

## Test plan
- [x] `flutter test test/features/external_donations/`
- [x] `flutter analyze` (repo-wide; pre-existing infos only)
- [ ] Manual: one-off external donation detail → tag without rotate icon
- [ ] Manual: recurring external donation detail → tag with rotate icon
- [ ] Manual: create flow one-off path → preview tag without icon
- [ ] Manual: create flow recurring path → preview tag with icon from donation-type step


Made with [Cursor](https://cursor.com)