### PR TITLE
Separate OAuth refresh from Face ID step-up on menu items

### DIFF
--- a/lib/features/account_details/account_settings_actions.dart
+++ b/lib/features/account_details/account_settings_actions.dart
@@ -22,6 +22,7 @@ abstract final class AccountSettingsActions {
     return AuthUtils.checkToken(
       context,
       checkAuthRequest: CheckAuthRequest(
+        policy: CheckAuthPolicy.stepUp,
         navigate: (context) => showModalBottomSheet<void>(
           context: context,
           isScrollControlled: true,
@@ -48,11 +49,13 @@ abstract final class AccountSettingsActions {
     return AuthUtils.checkToken(
       context,
       checkAuthRequest: CheckAuthRequest(
+        policy: CheckAuthPolicy.stepUp,
         navigate: (context) async {
           context.pushNamed(Pages.platformContribution.name);
           unawaited(
             AnalyticsHelper.logEvent(
-              eventName: AnalyticsEventName.platformContributionNavigationClicked,
+              eventName:
+                  AnalyticsEventName.platformContributionNavigationClicked,
             ),
           );
         },
@@ -67,6 +70,7 @@ abstract final class AccountSettingsActions {
     return AuthUtils.checkToken(
       context,
       checkAuthRequest: CheckAuthRequest(
+        policy: CheckAuthPolicy.stepUp,
         navigate: (context) => showModalBottomSheet<void>(
           context: context,
           isScrollControlled: true,
@@ -90,6 +94,7 @@ abstract final class AccountSettingsActions {
     return AuthUtils.checkToken(
       context,
       checkAuthRequest: CheckAuthRequest(
+        policy: CheckAuthPolicy.stepUp,
         navigate: (context) async => context.pushNamed(Pages.unregister.name),
       ),
     );

--- a/lib/features/auth/cubit/auth_cubit.dart
+++ b/lib/features/auth/cubit/auth_cubit.dart
@@ -23,10 +23,11 @@ class AuthCubit extends Cubit<AuthState> {
   AuthCubit(
     this._authRepositoy, {
     NetworkInfo? networkInfo,
-  })  : _networkInfo = networkInfo,
-        super(const AuthState()) {
-    _sessionSubscription =
-        _authRepositoy.hasSessionStream().listen((hasSession) {
+  }) : _networkInfo = networkInfo,
+       super(const AuthState()) {
+    _sessionSubscription = _authRepositoy.hasSessionStream().listen((
+      hasSession,
+    ) {
       checkAuth(hasSession: hasSession);
     });
   }
@@ -34,6 +35,7 @@ class AuthCubit extends Cubit<AuthState> {
   final AuthRepository _authRepositoy;
   final NetworkInfo? _networkInfo;
   late StreamSubscription<bool> _sessionSubscription;
+  Future<RefreshSessionResult>? _inFlightRefresh;
 
   bool get _isOnline => _networkInfo?.isConnected ?? true;
 
@@ -86,7 +88,8 @@ class AuthCubit extends Cubit<AuthState> {
 
       final biometricSetting = await BiometricsHelper.getBiometricSetting();
 
-      final showBiometricCheck = biometricSetting == BiometricSetting.unknown &&
+      final showBiometricCheck =
+          biometricSetting == BiometricSetting.unknown &&
           userExt.tempUser == false;
 
       emit(
@@ -100,6 +103,7 @@ class AuthCubit extends Cubit<AuthState> {
           needsReauthentication: false,
         ),
       );
+      unawaited(_authRepositoy.markLocalAuthSucceeded());
       _authRepositoy.updateSessionStream(true);
     } catch (e, stackTrace) {
       if (e.toString().contains('invalid_grant')) {
@@ -158,11 +162,11 @@ class AuthCubit extends Cubit<AuthState> {
       emit(state.copyWith(status: AuthStatus.authenticated));
 
   void clearNavigation() => emit(
-        state.copyWith(
-          status: state.status,
-          navigate: AuthState._emptyNavigate,
-        ),
-      );
+    state.copyWith(
+      status: state.status,
+      navigate: AuthState._emptyNavigate,
+    ),
+  );
 
   void clearNeedsReauthentication() {
     if (!state.needsReauthentication) {
@@ -452,13 +456,56 @@ class AuthCubit extends Cubit<AuthState> {
     return false;
   }
 
+  void markLocalAuthSucceeded() {
+    unawaited(_authRepositoy.markLocalAuthSucceeded());
+  }
+
+  bool get isWithinLocalAuthGrace {
+    final lastLocalAuthAt = _authRepositoy.lastLocalAuthAt();
+    if (lastLocalAuthAt == null) {
+      return false;
+    }
+    return DateTime.now().toUtc().difference(lastLocalAuthAt) <
+        AuthGate.localAuthGracePeriod;
+  }
+
   /// Refreshes the OAuth session.
   ///
   /// Returns [RefreshSessionResult.success] when a new session is stored,
   /// [RefreshSessionResult.offline] when the request fails due to no network,
   /// and [RefreshSessionResult.failure] for auth or other errors.
+  ///
+  /// Skips the network call when the access token is still valid unless
+  /// [force] is true or [AuthState.needsReauthentication] is set. Concurrent
+  /// callers share a single in-flight refresh.
   Future<RefreshSessionResult> refreshSession({
     bool emitAuthentication = true,
+    bool force = false,
+  }) async {
+    if (!force &&
+        !state.needsReauthentication &&
+        state.session.isLoggedIn &&
+        state.session.accessToken.isNotEmpty &&
+        !state.session.isExpired) {
+      return RefreshSessionResult.success;
+    }
+
+    final inFlight = _inFlightRefresh;
+    if (inFlight != null) {
+      return inFlight;
+    }
+
+    final refresh = _refreshSession(emitAuthentication: emitAuthentication);
+    _inFlightRefresh = refresh;
+    try {
+      return await refresh;
+    } finally {
+      _inFlightRefresh = null;
+    }
+  }
+
+  Future<RefreshSessionResult> _refreshSession({
+    required bool emitAuthentication,
   }) async {
     if (emitAuthentication) emit(state.copyWith(status: AuthStatus.loading));
     try {
@@ -466,9 +513,7 @@ class AuthCubit extends Cubit<AuthState> {
       final session = await _authRepositoy.refreshToken();
       emit(
         state.copyWith(
-          status: emitAuthentication
-              ? AuthStatus.authenticated
-              : state.status,
+          status: emitAuthentication ? AuthStatus.authenticated : state.status,
           session: session,
           needsReauthentication: false,
         ),
@@ -538,8 +583,10 @@ class AuthCubit extends Cubit<AuthState> {
       final notificationPermissionStatus =
           await Permission.notification.status.isGranted;
 
-      LoggingInfo.instance.info('New FCM token: $notificationId; '
-          'Notification permission status: $notificationPermissionStatus');
+      LoggingInfo.instance.info(
+        'New FCM token: $notificationId; '
+        'Notification permission status: $notificationPermissionStatus',
+      );
 
       if (userExt.notificationId == notificationId &&
           userExt.pushNotificationsEnabled == notificationPermissionStatus) {

--- a/lib/features/auth/models/auth_gate.dart
+++ b/lib/features/auth/models/auth_gate.dart
@@ -1,0 +1,45 @@
+/// Policy for `AuthUtils.checkToken`.
+enum CheckAuthPolicy {
+  /// Giving and app-open: keep a valid OAuth session. Face ID only if refresh
+  /// fails. No local-auth grace period.
+  ensureSession,
+
+  /// Protected menu item taps: Face ID when the local-auth grace period has
+  /// elapsed. OAuth refresh only if the access token is actually near expiry.
+  stepUp,
+}
+
+/// First action `AuthUtils.checkToken` should take for a given policy.
+enum AuthGateAction {
+  navigate,
+  silentRefresh,
+  promptBiometrics,
+}
+
+/// Pure decision helper for OAuth refresh vs Face ID step-up.
+class AuthGate {
+  static const Duration localAuthGracePeriod = Duration(minutes: 15);
+
+  static AuthGateAction decide({
+    required CheckAuthPolicy policy,
+    required bool isAccessTokenExpired,
+    required bool isWithinLocalAuthGrace,
+    bool needsReauthentication = false,
+  }) {
+    switch (policy) {
+      case CheckAuthPolicy.ensureSession:
+        if (needsReauthentication || isAccessTokenExpired) {
+          return AuthGateAction.silentRefresh;
+        }
+        return AuthGateAction.navigate;
+      case CheckAuthPolicy.stepUp:
+        if (needsReauthentication || !isWithinLocalAuthGrace) {
+          return AuthGateAction.promptBiometrics;
+        }
+        if (isAccessTokenExpired) {
+          return AuthGateAction.silentRefresh;
+        }
+        return AuthGateAction.navigate;
+    }
+  }
+}

--- a/lib/features/auth/models/models.dart
+++ b/lib/features/auth/models/models.dart
@@ -1,1 +1,2 @@
+export 'auth_gate.dart';
 export 'session.dart';

--- a/lib/features/auth/models/session.dart
+++ b/lib/features/auth/models/session.dart
@@ -30,33 +30,34 @@ class Session {
   }
 
   factory Session.fromGenerosityJson(Map<String, dynamic> json) => Session(
-        email: json['email'] as String,
-        userGUID: json['userId'] as String,
-        accessToken: json['accessToken'] as String,
-        refreshToken: json['refreshToken'] as String,
-        expires: json['expirationDate'] as String,
-        expiresIn: json['expiresIn'] as int,
-        isLoggedIn: true,
-      );
+    email: json['email'] as String,
+    userGUID: json['userId'] as String,
+    accessToken: json['accessToken'] as String,
+    refreshToken: json['refreshToken'] as String,
+    expires: json['expirationDate'] as String,
+    expiresIn: json['expiresIn'] as int,
+    isLoggedIn: true,
+  );
 
   factory Session.fromJson(Map<String, dynamic> json) => Session(
-        email: json['Email'] as String,
-        userGUID: json['GUID'] as String,
-        accessToken: json['access_token'] as String,
-        refreshToken: json['refresh_token'] as String,
-        expires: json['.expires'] as String,
-        expiresIn: 0,
-        isLoggedIn:
-            json.containsKey('isLoggedIn') ? json['isLoggedIn'] as bool : false,
-      );
+    email: json['Email'] as String,
+    userGUID: json['GUID'] as String,
+    accessToken: json['access_token'] as String,
+    refreshToken: json['refresh_token'] as String,
+    expires: json['.expires'] as String,
+    expiresIn: 0,
+    isLoggedIn: json.containsKey('isLoggedIn')
+        ? json['isLoggedIn'] as bool
+        : false,
+  );
   const Session.empty()
-      : userGUID = '',
-        email = '',
-        accessToken = '',
-        refreshToken = '',
-        expires = '',
-        expiresIn = 0,
-        isLoggedIn = false;
+    : userGUID = '',
+      email = '',
+      accessToken = '',
+      refreshToken = '',
+      expires = '',
+      expiresIn = 0,
+      isLoggedIn = false;
 
   final String userGUID;
   final String email;
@@ -74,16 +75,18 @@ class Session {
     String? expires,
     int? expiresIn,
     bool? isLoggedIn,
-  }) =>
-      Session(
-        email: email ?? this.email,
-        userGUID: userGUID ?? this.userGUID,
-        accessToken: accessToken ?? this.accessToken,
-        refreshToken: refreshToken ?? this.refreshToken,
-        expires: expires ?? this.expires,
-        expiresIn: expiresIn ?? this.expiresIn,
-        isLoggedIn: isLoggedIn ?? this.isLoggedIn,
-      );
+  }) => Session(
+    email: email ?? this.email,
+    userGUID: userGUID ?? this.userGUID,
+    accessToken: accessToken ?? this.accessToken,
+    refreshToken: refreshToken ?? this.refreshToken,
+    expires: expires ?? this.expires,
+    expiresIn: expiresIn ?? this.expiresIn,
+    isLoggedIn: isLoggedIn ?? this.isLoggedIn,
+  );
+
+  /// Refresh the access token this far before actual expiry.
+  static const Duration accessTokenRefreshBuffer = Duration(minutes: 2);
 
   /// True when the access token is near or past expiry (small client-side buffer).
   bool get isExpired {
@@ -92,22 +95,20 @@ class Session {
     /// If the expires date is empty, then ask user to login.
     if (expires.isEmpty) return true;
     final expiresDate = DateTime.parse(expires).subtract(
-      const Duration(
-        minutes: 2,
-      ),
+      accessTokenRefreshBuffer,
     );
     return now.isAfter(expiresDate);
   }
 
   Map<String, dynamic> toJson() => <String, dynamic>{
-        'GUID': userGUID,
-        'Email': email,
-        'access_token': accessToken,
-        'refresh_token': refreshToken,
-        '.expires': expires,
-        'expires_In': expiresIn,
-        'isLoggedIn': isLoggedIn,
-      };
+    'GUID': userGUID,
+    'Email': email,
+    'access_token': accessToken,
+    'refresh_token': refreshToken,
+    '.expires': expires,
+    'expires_In': expiresIn,
+    'isLoggedIn': isLoggedIn,
+  };
 
   @override
   String toString() {

--- a/lib/features/auth/repositories/auth_repository.dart
+++ b/lib/features/auth/repositories/auth_repository.dart
@@ -78,6 +78,12 @@ mixin AuthRepository {
   void setHasSessionInitialValue(bool hasSession);
 
   Future<Session> getStoredSession();
+
+  DateTime? lastLocalAuthAt() => null;
+
+  Future<void> markLocalAuthSucceeded({DateTime? at}) async {}
+
+  Future<void> clearLastLocalAuth() async {}
 }
 
 class AuthRepositoyImpl with AuthRepository {
@@ -144,8 +150,9 @@ class AuthRepositoyImpl with AuthRepository {
       }
       final userExt = UserExt.fromJson(
         jsonDecode(
-          _prefs.getString(UserExt.tag)!,
-        ) as Map<String, dynamic>,
+              _prefs.getString(UserExt.tag)!,
+            )
+            as Map<String, dynamic>,
       );
       final response = await _apiService.getUserExtension(userExt.guid);
       final newUserExt = UserExt.fromJson(response);
@@ -196,8 +203,9 @@ class AuthRepositoyImpl with AuthRepository {
     }
     final userExt = UserExt.fromJson(
       jsonDecode(
-        _prefs.getString(UserExt.tag)!,
-      ) as Map<String, dynamic>,
+            _prefs.getString(UserExt.tag)!,
+          )
+          as Map<String, dynamic>,
     );
     if (userExt.email == email) {
       return;
@@ -290,8 +298,9 @@ class AuthRepositoyImpl with AuthRepository {
 
     final amountPresets = AmountPresets.fromJson(
       jsonDecode(
-        amountPresetsString!,
-      ) as Map<String, dynamic>,
+            amountPresetsString!,
+          )
+          as Map<String, dynamic>,
     );
 
     if (amountPresets.presets.isEmpty) {
@@ -319,6 +328,8 @@ class AuthRepositoyImpl with AuthRepository {
     final sessionString = _prefs.getString(Session.tag);
 
     updateSessionStream(false);
+
+    await clearLastLocalAuth();
 
     // If the data is already gone, just continue :)
     if (sessionString == null) {
@@ -431,14 +442,12 @@ class AuthRepositoyImpl with AuthRepository {
   Future<bool> updateUser({
     required String guid,
     required Map<String, dynamic> newUserExt,
-  }) async =>
-      _apiService.updateUser(guid, newUserExt);
+  }) async => _apiService.updateUser(guid, newUserExt);
 
   @override
   Future<bool> updateUserExt(
     Map<String, dynamic> newUserExt,
-  ) async =>
-      _apiService.updateUserExt(newUserExt);
+  ) async => _apiService.updateUserExt(newUserExt);
 
   @override
   Future<StripeResponse> fetchStripeSetupIntent() async {
@@ -463,8 +472,9 @@ class AuthRepositoyImpl with AuthRepository {
 
     final amountPresets = AmountPresets.fromJson(
       jsonDecode(
-        _prefs.getString(AmountPresets.tag)!,
-      ) as Map<String, dynamic>,
+            _prefs.getString(AmountPresets.tag)!,
+          )
+          as Map<String, dynamic>,
     );
 
     for (final userPreset in amountPresets.presets) {
@@ -491,14 +501,13 @@ class AuthRepositoyImpl with AuthRepository {
     required String guid,
     required String notificationId,
     required bool notificationPermissionStatus,
-  }) =>
-      _apiService.updateNotificationId(
-        guid: guid,
-        body: {
-          'PushNotificationId': notificationId,
-          'PushNotificationsEnabled': notificationPermissionStatus,
-        },
-      );
+  }) => _apiService.updateNotificationId(
+    guid: guid,
+    body: {
+      'PushNotificationId': notificationId,
+      'PushNotificationsEnabled': notificationPermissionStatus,
+    },
+  );
 
   Future<void> setUserProperties(UserExt newUserExt) {
     FirebaseCrashlytics.instance.setUserIdentifier(newUserExt.guid);
@@ -520,5 +529,28 @@ class AuthRepositoyImpl with AuthRepository {
   @override
   void setHasSessionInitialValue(bool hasSession) {
     _hasSession = hasSession;
+  }
+
+  @override
+  DateTime? lastLocalAuthAt() {
+    final value = _prefs.getString(NativeSharedPreferencesKeys.lastLocalAuthAt);
+    if (value == null || value.isEmpty) {
+      return null;
+    }
+    return DateTime.tryParse(value)?.toUtc();
+  }
+
+  @override
+  Future<void> markLocalAuthSucceeded({DateTime? at}) async {
+    final timestamp = (at ?? DateTime.now()).toUtc().toIso8601String();
+    await _prefs.setString(
+      NativeSharedPreferencesKeys.lastLocalAuthAt,
+      timestamp,
+    );
+  }
+
+  @override
+  Future<void> clearLastLocalAuth() async {
+    await _prefs.remove(NativeSharedPreferencesKeys.lastLocalAuthAt);
   }
 }

--- a/lib/shared/widgets/custom_navigation_drawer.dart
+++ b/lib/shared/widgets/custom_navigation_drawer.dart
@@ -47,7 +47,8 @@ class CustomNavigationDrawer extends StatelessWidget {
                         _buildGivtLogo(),
                         _buildDecorativeAvatar(context),
                         DrawerMenuItem(
-                          isVisible: auth.user.needRegistration ||
+                          isVisible:
+                              auth.user.needRegistration ||
                               !auth.user.mandateSigned,
                           showBadge: true,
                           title: locals.finalizeRegistration,
@@ -84,6 +85,7 @@ class CustomNavigationDrawer extends StatelessWidget {
                           onTap: () async => AuthUtils.checkToken(
                             context,
                             checkAuthRequest: CheckAuthRequest(
+                              policy: CheckAuthPolicy.stepUp,
                               navigate: (context) async {
                                 context.goNamed(Pages.personalSummary.name);
                                 unawaited(
@@ -108,11 +110,12 @@ class CustomNavigationDrawer extends StatelessWidget {
                               AnalyticsEventName.menuNavigationHistoryClicked,
                           onTap: () async {
                             context.read<RemoteDataSourceSyncBloc>().add(
-                                  const RemoteDataSourceSyncRequested(),
-                                );
+                              const RemoteDataSourceSyncRequested(),
+                            );
                             await AuthUtils.checkToken(
                               context,
                               checkAuthRequest: CheckAuthRequest(
+                                policy: CheckAuthPolicy.stepUp,
                                 navigate: (context) async => context.goNamed(
                                   Pages.donationOverview.name,
                                 ),
@@ -133,6 +136,7 @@ class CustomNavigationDrawer extends StatelessWidget {
                           onTap: () async => AuthUtils.checkToken(
                             context,
                             checkAuthRequest: CheckAuthRequest(
+                              policy: CheckAuthPolicy.stepUp,
                               navigate: (context) async {
                                 context.goNamed(Pages.recurringDonations.name);
                                 unawaited(
@@ -158,6 +162,7 @@ class CustomNavigationDrawer extends StatelessWidget {
                           onTap: () async => AuthUtils.checkToken(
                             context,
                             checkAuthRequest: CheckAuthRequest(
+                              policy: CheckAuthPolicy.stepUp,
                               navigate: (context) async {
                                 context.goNamed(Pages.externalDonations.name);
                                 unawaited(
@@ -187,6 +192,7 @@ class CustomNavigationDrawer extends StatelessWidget {
                               onTap: () async => AuthUtils.checkToken(
                                 context,
                                 checkAuthRequest: CheckAuthRequest(
+                                  policy: CheckAuthPolicy.stepUp,
                                   navigate: (context) async {
                                     context.goNamed(Pages.pledges.name);
                                   },
@@ -206,11 +212,12 @@ class CustomNavigationDrawer extends StatelessWidget {
                       color: iconColor,
                     ),
                     semanticsIdentifier: 'menuAccountSettings',
-                    analyticsEvent: AnalyticsEventName
-                        .menuNavigationAccountSettingsClicked,
+                    analyticsEvent:
+                        AnalyticsEventName.menuNavigationAccountSettingsClicked,
                     onTap: () async => AuthUtils.checkToken(
                       context,
                       checkAuthRequest: CheckAuthRequest(
+                        policy: CheckAuthPolicy.stepUp,
                         navigate: (context) async => context.goNamed(
                           Pages.personalInfoEdit.name,
                         ),
@@ -285,14 +292,14 @@ class CustomNavigationDrawer extends StatelessWidget {
   }
 
   Widget _buildGivtLogo() => Padding(
-        padding: const EdgeInsets.only(bottom: 8),
-        child: Center(
-          child: SizedBox(
-            height: 24,
-            child: Image.asset(
-              'assets/images/logo.png',
-            ),
-          ),
+    padding: const EdgeInsets.only(bottom: 8),
+    child: Center(
+      child: SizedBox(
+        height: 24,
+        child: Image.asset(
+          'assets/images/logo.png',
         ),
-      );
+      ),
+    ),
+  );
 }

--- a/lib/utils/auth_utils.dart
+++ b/lib/utils/auth_utils.dart
@@ -8,7 +8,10 @@ import 'package:givt_app/core/auth/local_auth_info.dart';
 import 'package:givt_app/core/logging/logging.dart';
 import 'package:givt_app/core/network/network_info.dart';
 import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
+import 'package:givt_app/features/auth/models/auth_gate.dart';
 import 'package:givt_app/features/auth/pages/login_page.dart';
+
+export 'package:givt_app/features/auth/models/auth_gate.dart';
 
 class CheckAuthRequest {
   CheckAuthRequest({
@@ -16,6 +19,7 @@ class CheckAuthRequest {
     this.email = '',
     this.forceLogin = false,
     this.allowWhenOffline = false,
+    this.policy = CheckAuthPolicy.ensureSession,
   });
 
   final Future<void> Function(BuildContext context) navigate;
@@ -26,6 +30,10 @@ class CheckAuthRequest {
   /// device is offline instead of prompting for login. Other destinations
   /// must leave this false so they never navigate without a refreshed token.
   final bool allowWhenOffline;
+
+  /// Giving / app-open use [CheckAuthPolicy.ensureSession]. Protected menu
+  /// item taps use [CheckAuthPolicy.stepUp].
+  final CheckAuthPolicy policy;
 }
 
 class AuthUtils {
@@ -60,22 +68,49 @@ class AuthUtils {
       return;
     }
 
-    // Refresh first so an expired access token is renewed without biometrics.
-    final refreshResult = await context.read<AuthCubit>().refreshSession(
-      emitAuthentication: false,
+    final authCubit = context.read<AuthCubit>();
+    final action = AuthGate.decide(
+      policy: checkAuthRequest.policy,
+      isAccessTokenExpired: authCubit.state.session.isExpired,
+      isWithinLocalAuthGrace: authCubit.isWithinLocalAuthGrace,
+      needsReauthentication: authCubit.state.needsReauthentication,
     );
-    if (!context.mounted) {
-      return;
-    }
-    if (await _tryNavigateAfterRefresh(
-      context,
-      checkAuthRequest: checkAuthRequest,
-      refreshResult: refreshResult,
-    )) {
-      return;
-    }
 
-    await _promptBiometricsOrLogin(context, checkAuthRequest: checkAuthRequest);
+    switch (action) {
+      case AuthGateAction.navigate:
+        await checkAuthRequest.navigate(context);
+        return;
+      case AuthGateAction.silentRefresh:
+        final forceRefresh = authCubit.state.needsReauthentication;
+        final refreshResult = await authCubit.refreshSession(
+          emitAuthentication: false,
+          force: forceRefresh,
+        );
+        if (!context.mounted) {
+          return;
+        }
+        if (await _tryNavigateAfterRefresh(
+          context,
+          checkAuthRequest: checkAuthRequest,
+          refreshResult: refreshResult,
+        )) {
+          return;
+        }
+        if (!context.mounted) {
+          return;
+        }
+        await _promptBiometricsOrLogin(
+          context,
+          checkAuthRequest: checkAuthRequest,
+        );
+        return;
+      case AuthGateAction.promptBiometrics:
+        await _promptBiometricsOrLogin(
+          context,
+          checkAuthRequest: checkAuthRequest,
+        );
+        return;
+    }
   }
 
   static bool _canSkipRefreshForOfflineGiving(
@@ -154,6 +189,7 @@ class AuthUtils {
       if (!context.mounted) {
         return;
       }
+      context.read<AuthCubit>().markLocalAuthSucceeded();
       final refreshResult = await context.read<AuthCubit>().refreshSession(
         emitAuthentication: false,
       );

--- a/lib/utils/shared_preferences_keys.dart
+++ b/lib/utils/shared_preferences_keys.dart
@@ -28,4 +28,5 @@ class NativeSharedPreferencesKeys {
   static const String mandateSigned = 'MandateSigned';
   static const String mandatePopupDismissals = 'MandatePopupDismissals';
   static const String homePageLastTabIndex = 'HomePageLastTabIndex';
+  static const String lastLocalAuthAt = 'LastLocalAuthAt';
 }

--- a/test/features/auth/cubit/auth_cubit_refresh_session_test.dart
+++ b/test/features/auth/cubit/auth_cubit_refresh_session_test.dart
@@ -69,53 +69,112 @@ void main() {
       expect(cubit.state.session.accessToken, 'new-access');
     });
 
-    test('does not change status on failure when emitAuthentication is false',
-        () async {
-      repository.refreshError = Exception('refresh failed');
+    test(
+      'does not change status on failure when emitAuthentication is false',
+      () async {
+        repository.refreshError = Exception('refresh failed');
+        cubit.emit(
+          cubit.state.copyWith(
+            status: AuthStatus.authenticated,
+          ),
+        );
+
+        final result = await cubit.refreshSession(emitAuthentication: false);
+
+        expect(result, RefreshSessionResult.failure);
+        expect(cubit.state.status, AuthStatus.authenticated);
+      },
+    );
+
+    test(
+      'sets failure status when emitAuthentication is true and refresh fails',
+      () async {
+        repository.refreshError = Exception('refresh failed');
+
+        final result = await cubit.refreshSession();
+
+        expect(result, RefreshSessionResult.failure);
+        expect(cubit.state.status, AuthStatus.failure);
+      },
+    );
+
+    test(
+      'sets noInternet when emitAuthentication is true and offline',
+      () async {
+        repository.refreshError = const SocketException('offline');
+
+        final result = await cubit.refreshSession();
+
+        expect(result, RefreshSessionResult.offline);
+        expect(cubit.state.status, AuthStatus.noInternet);
+      },
+    );
+
+    test(
+      'returns offline without changing status when emitAuthentication is false',
+      () async {
+        repository.refreshError = const SocketException('offline');
+        cubit.emit(
+          cubit.state.copyWith(
+            status: AuthStatus.authenticated,
+          ),
+        );
+
+        final result = await cubit.refreshSession(emitAuthentication: false);
+
+        expect(result, RefreshSessionResult.offline);
+        expect(cubit.state.status, AuthStatus.authenticated);
+      },
+    );
+
+    test('skips network refresh when access token is still valid', () async {
+      repository.refreshResult = refreshedSession();
       cubit.emit(
         cubit.state.copyWith(
           status: AuthStatus.authenticated,
+          session: refreshedSession(),
         ),
       );
 
-      final result = await cubit.refreshSession(emitAuthentication: false);
-
-      expect(result, RefreshSessionResult.failure);
-      expect(cubit.state.status, AuthStatus.authenticated);
-    });
-
-    test('sets failure status when emitAuthentication is true and refresh fails',
-        () async {
-      repository.refreshError = Exception('refresh failed');
-
       final result = await cubit.refreshSession();
 
-      expect(result, RefreshSessionResult.failure);
-      expect(cubit.state.status, AuthStatus.failure);
+      expect(result, RefreshSessionResult.success);
+      expect(repository.refreshCallCount, 0);
     });
 
-    test('sets noInternet when emitAuthentication is true and offline', () async {
-      repository.refreshError = const SocketException('offline');
+    test(
+      'does not skip network refresh when reauthentication is needed',
+      () async {
+        repository.refreshResult = refreshedSession();
+        cubit.emit(
+          cubit.state.copyWith(
+            status: AuthStatus.authenticated,
+            session: refreshedSession(),
+            needsReauthentication: true,
+          ),
+        );
 
-      final result = await cubit.refreshSession();
+        final result = await cubit.refreshSession(emitAuthentication: false);
 
-      expect(result, RefreshSessionResult.offline);
-      expect(cubit.state.status, AuthStatus.noInternet);
-    });
+        expect(result, RefreshSessionResult.success);
+        expect(repository.refreshCallCount, 1);
+        expect(cubit.state.needsReauthentication, isFalse);
+      },
+    );
 
-    test('returns offline without changing status when emitAuthentication is false',
-        () async {
-      repository.refreshError = const SocketException('offline');
+    test('refreshes when force is true even if token is still valid', () async {
+      repository.refreshResult = refreshedSession();
       cubit.emit(
         cubit.state.copyWith(
           status: AuthStatus.authenticated,
+          session: refreshedSession(),
         ),
       );
 
-      final result = await cubit.refreshSession(emitAuthentication: false);
+      final result = await cubit.refreshSession(force: true);
 
-      expect(result, RefreshSessionResult.offline);
-      expect(cubit.state.status, AuthStatus.authenticated);
+      expect(result, RefreshSessionResult.success);
+      expect(repository.refreshCallCount, 1);
     });
   });
 }
@@ -125,6 +184,7 @@ class _RefreshTestAuthRepository with AuthRepository {
 
   Session? refreshResult;
   Object? refreshError;
+  int refreshCallCount = 0;
 
   Future<void> dispose() async {
     await _sessionController.close();
@@ -132,6 +192,7 @@ class _RefreshTestAuthRepository with AuthRepository {
 
   @override
   Future<Session> refreshToken({bool refreshUserExt = false}) async {
+    refreshCallCount++;
     if (refreshError != null) {
       throw refreshError!;
     }
@@ -165,8 +226,7 @@ class _RefreshTestAuthRepository with AuthRepository {
   Future<String> signSepaMandate({
     required String guid,
     required String appLanguage,
-  }) async =>
-      '';
+  }) async => '';
 
   @override
   Future<StripeResponse> fetchStripeSetupIntent() async =>
@@ -176,15 +236,13 @@ class _RefreshTestAuthRepository with AuthRepository {
   Future<UserExt> registerUser({
     required TempUser tempUser,
     required bool isNewUser,
-  }) async =>
-      const UserExt(email: '', guid: '', amountLimit: 0);
+  }) async => const UserExt(email: '', guid: '', amountLimit: 0);
 
   @override
   Future<bool> changeGiftAid({
     required String guid,
     required bool giftAid,
-  }) async =>
-      true;
+  }) async => true;
 
   @override
   Future<bool> unregisterUser({required String email}) async => true;
@@ -193,8 +251,7 @@ class _RefreshTestAuthRepository with AuthRepository {
   Future<bool> updateUser({
     required String guid,
     required Map<String, dynamic> newUserExt,
-  }) async =>
-      true;
+  }) async => true;
 
   @override
   Future<bool> updateUserExt(Map<String, dynamic> newUserExt) async => true;
@@ -202,8 +259,7 @@ class _RefreshTestAuthRepository with AuthRepository {
   @override
   Future<bool> updateLocalUserPresets({
     required UserPresets newUserPresets,
-  }) async =>
-      true;
+  }) async => true;
 
   @override
   Future<void> checkUserExt({required String email}) async {}
@@ -213,8 +269,7 @@ class _RefreshTestAuthRepository with AuthRepository {
     required String guid,
     required String notificationId,
     required bool notificationPermissionStatus,
-  }) async =>
-      true;
+  }) async => true;
 
   @override
   void updateSessionStream(bool hasSession) {

--- a/test/features/auth/models/auth_gate_test.dart
+++ b/test/features/auth/models/auth_gate_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/features/auth/models/auth_gate.dart';
+
+void main() {
+  group('AuthGate.decide ensureSession', () {
+    test('navigates when access token is still valid', () {
+      expect(
+        AuthGate.decide(
+          policy: CheckAuthPolicy.ensureSession,
+          isAccessTokenExpired: false,
+          isWithinLocalAuthGrace: false,
+        ),
+        AuthGateAction.navigate,
+      );
+    });
+
+    test('silently refreshes when access token is expired', () {
+      expect(
+        AuthGate.decide(
+          policy: CheckAuthPolicy.ensureSession,
+          isAccessTokenExpired: true,
+          isWithinLocalAuthGrace: true,
+        ),
+        AuthGateAction.silentRefresh,
+      );
+    });
+
+    test('silently refreshes when startup reauth is needed', () {
+      expect(
+        AuthGate.decide(
+          policy: CheckAuthPolicy.ensureSession,
+          isAccessTokenExpired: false,
+          isWithinLocalAuthGrace: true,
+          needsReauthentication: true,
+        ),
+        AuthGateAction.silentRefresh,
+      );
+    });
+  });
+
+  group('AuthGate.decide stepUp', () {
+    test('prompts biometrics when local-auth grace has elapsed', () {
+      expect(
+        AuthGate.decide(
+          policy: CheckAuthPolicy.stepUp,
+          isAccessTokenExpired: false,
+          isWithinLocalAuthGrace: false,
+        ),
+        AuthGateAction.promptBiometrics,
+      );
+    });
+
+    test(
+      'prompts biometrics when reauthentication is needed even within grace',
+      () {
+        expect(
+          AuthGate.decide(
+            policy: CheckAuthPolicy.stepUp,
+            isAccessTokenExpired: false,
+            isWithinLocalAuthGrace: true,
+            needsReauthentication: true,
+          ),
+          AuthGateAction.promptBiometrics,
+        );
+      },
+    );
+
+    test('navigates when within grace and access token is valid', () {
+      expect(
+        AuthGate.decide(
+          policy: CheckAuthPolicy.stepUp,
+          isAccessTokenExpired: false,
+          isWithinLocalAuthGrace: true,
+        ),
+        AuthGateAction.navigate,
+      );
+    });
+
+    test('silently refreshes when within grace and token is expired', () {
+      expect(
+        AuthGate.decide(
+          policy: CheckAuthPolicy.stepUp,
+          isAccessTokenExpired: true,
+          isWithinLocalAuthGrace: true,
+        ),
+        AuthGateAction.silentRefresh,
+      );
+    });
+
+    test('uses a 15 minute local-auth grace period', () {
+      expect(AuthGate.localAuthGracePeriod, const Duration(minutes: 15));
+    });
+  });
+}

--- a/test/features/auth/models/session_test.dart
+++ b/test/features/auth/models/session_test.dart
@@ -28,5 +28,9 @@ void main() {
       final expires = DateTime.now().toUtc().add(const Duration(minutes: 1));
       expect(sessionWithExpiry(expires).isExpired, isTrue);
     });
+
+    test('uses a two minute refresh buffer', () {
+      expect(Session.accessTokenRefreshBuffer, const Duration(minutes: 2));
+    });
   });
 }

--- a/test/utils/auth_utils_auth_gate_test.dart
+++ b/test/utils/auth_utils_auth_gate_test.dart
@@ -30,12 +30,31 @@ void main() {
     amountLimit: 499,
   );
 
+  Session validSession() {
+    return Session(
+      email: user.email,
+      userGUID: user.guid,
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      expires: DateTime.now()
+          .toUtc()
+          .add(const Duration(minutes: 30))
+          .toIso8601String(),
+      expiresIn: 1800,
+      isLoggedIn: true,
+    );
+  }
+
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
     repository = _FakeAuthRepository();
     cubit = _RecordingAuthCubit(repository);
     cubit.emit(
-      cubit.state.copyWith(status: AuthStatus.authenticated, user: user),
+      cubit.state.copyWith(
+        status: AuthStatus.authenticated,
+        user: user,
+        session: validSession(),
+      ),
     );
     networkInfo = _FakeNetworkInfo(isConnected: true);
     if (getIt.isRegistered<NetworkInfo>()) {
@@ -55,7 +74,7 @@ void main() {
 
   Future<void> runCheckToken(
     WidgetTester tester, {
-    required bool allowWhenOffline,
+    CheckAuthPolicy policy = CheckAuthPolicy.ensureSession,
   }) async {
     final previousOnError = FlutterError.onError;
     FlutterError.onError = (details) {
@@ -82,7 +101,7 @@ void main() {
                     AuthUtils.checkToken(
                       context,
                       checkAuthRequest: CheckAuthRequest(
-                        allowWhenOffline: allowWhenOffline,
+                        policy: policy,
                         navigate: (_) async {
                           navigateCount++;
                         },
@@ -102,14 +121,11 @@ void main() {
     await tester.pump(const Duration(milliseconds: 50));
   }
 
-  group('AuthUtils.checkToken offline giving', () {
+  group('AuthUtils.checkToken auth gate', () {
     testWidgets(
-      'skips refresh and navigates when allowWhenOffline '
-      'and checker is disconnected',
+      'ensureSession navigates without refresh when token is valid',
       (tester) async {
-        networkInfo.isConnected = false;
-
-        await runCheckToken(tester, allowWhenOffline: true);
+        await runCheckToken(tester);
 
         expect(cubit.refreshCallCount, 0);
         expect(navigateCount, 1);
@@ -117,40 +133,65 @@ void main() {
     );
 
     testWidgets(
-      'navigates without login when allowWhenOffline and refresh is offline',
+      'stepUp does not navigate when grace has elapsed',
       (tester) async {
-        cubit.refreshResult = RefreshSessionResult.offline;
+        await runCheckToken(tester, policy: CheckAuthPolicy.stepUp);
 
-        await runCheckToken(tester, allowWhenOffline: true);
-
-        expect(cubit.refreshCallCount, 1);
-        expect(navigateCount, 1);
-      },
-    );
-
-    testWidgets(
-      'does not navigate when offline and allowWhenOffline is false',
-      (tester) async {
-        networkInfo.isConnected = false;
-        cubit.refreshResult = RefreshSessionResult.offline;
-
-        await runCheckToken(tester, allowWhenOffline: false);
-
-        expect(cubit.refreshCallCount, 1);
+        expect(cubit.refreshCallCount, 0);
         expect(navigateCount, 0);
       },
     );
 
     testWidgets(
-      'does not skip refresh for non-giving when checker is disconnected',
+      'stepUp navigates without refresh when within grace and token is valid',
       (tester) async {
-        networkInfo.isConnected = false;
-        cubit.refreshResult = RefreshSessionResult.success;
+        await repository.markLocalAuthSucceeded();
 
-        await runCheckToken(tester, allowWhenOffline: false);
+        await runCheckToken(tester, policy: CheckAuthPolicy.stepUp);
+
+        expect(cubit.refreshCallCount, 0);
+        expect(navigateCount, 1);
+      },
+    );
+
+    testWidgets(
+      'ensureSession forces refresh when reauthentication is needed',
+      (tester) async {
+        cubit
+          ..emit(
+            cubit.state.copyWith(
+              status: AuthStatus.authenticated,
+              user: user,
+              session: validSession(),
+              needsReauthentication: true,
+            ),
+          )
+          ..refreshResult = RefreshSessionResult.failure;
+
+        await runCheckToken(tester);
 
         expect(cubit.refreshCallCount, 1);
-        expect(navigateCount, 1);
+        expect(cubit.lastForce, isTrue);
+        expect(navigateCount, 0);
+      },
+    );
+
+    testWidgets(
+      'stepUp does not navigate when reauthentication is needed within grace',
+      (tester) async {
+        await repository.markLocalAuthSucceeded();
+        cubit.emit(
+          cubit.state.copyWith(
+            status: AuthStatus.authenticated,
+            user: user,
+            session: validSession(),
+            needsReauthentication: true,
+          ),
+        );
+
+        await runCheckToken(tester, policy: CheckAuthPolicy.stepUp);
+
+        expect(navigateCount, 0);
       },
     );
   });
@@ -172,6 +213,7 @@ class _RecordingAuthCubit extends AuthCubit {
   _RecordingAuthCubit(super.repository);
 
   int refreshCallCount = 0;
+  bool? lastForce;
   RefreshSessionResult refreshResult = RefreshSessionResult.success;
 
   @override
@@ -180,15 +222,25 @@ class _RecordingAuthCubit extends AuthCubit {
     bool force = false,
   }) async {
     refreshCallCount++;
+    lastForce = force;
     return refreshResult;
   }
 }
 
 class _FakeAuthRepository with AuthRepository {
   final _sessionController = StreamController<bool>.broadcast();
+  DateTime? _lastLocalAuthAt;
 
   void dispose() {
     _sessionController.close();
+  }
+
+  @override
+  DateTime? lastLocalAuthAt() => _lastLocalAuthAt;
+
+  @override
+  Future<void> markLocalAuthSucceeded({DateTime? at}) async {
+    _lastLocalAuthAt = (at ?? DateTime.now()).toUtc();
   }
 
   @override


### PR DESCRIPTION
## Summary
- Split `checkToken` into `ensureSession` (giving / app-open: silent refresh only when the access token is within 2 minutes of expiry) and `stepUp` (protected menu item taps: Face ID with a 15-minute shared grace period).
- Skip redundant `/oauth2/token` calls when the access token is still valid, but still hit the network when `needsReauthentication` is set so a failed startup refresh cannot be cleared without Face ID or login.
- Addresses [ENG-1143](https://linear.app/givt/issue/ENG-1143/require-valid-auth-token-for-giving-flow) test feedback: menu items were asking for auth on every tap, and refresh ran too early.

## Test plan
- [ ] Giving (old amount flow and For You): continue without Face ID while the access token is valid; Face ID/login only if refresh fails
- [ ] Open the drawer: no auth prompt
- [ ] Tap History, then Recurring (or another protected item) within 15 minutes: Face ID once, then skip
- [ ] After 15 minutes, the next protected menu item asks for Face ID again
- [ ] Kill/restart with an invalid refresh token: stay on home and get Face ID/login, not a silent skip
- [ ] Offline giving still continues with the local session


Made with [Cursor](https://cursor.com)