### PR TITLE
ENG-1171: Fix offline banner on cold start and For You giving spinner

### DIFF
--- a/lib/core/network/network_info.dart
+++ b/lib/core/network/network_info.dart
@@ -11,15 +11,11 @@ mixin NetworkInfo {
 class NetworkInfoImpl implements NetworkInfo {
   NetworkInfoImpl(this.connectionChecker) {
     // First check if there is an internet connection
-    connectionChecker.hasInternetAccess.then((value) {
-      isConnected = value;
-      _hasInternetConnectionStream.add(value);
-    });
+    connectionChecker.hasInternetAccess.then(_setConnected);
 
     // Listen for changes in the internet connection status
     connectionChecker.onStatusChange.listen((status) {
-      isConnected = status == InternetStatus.connected;
-      _hasInternetConnectionStream.add(isConnected);
+      _setConnected(status == InternetStatus.connected);
     });
   }
 
@@ -27,12 +23,39 @@ class NetworkInfoImpl implements NetworkInfo {
   final StreamController<bool> _hasInternetConnectionStream =
       StreamController<bool>.broadcast();
 
+  bool _hasCompletedInitialCheck = false;
+
   @override
   bool isConnected = true;
 
   final InternetConnection connectionChecker;
 
+  void _setConnected(bool connected) {
+    isConnected = connected;
+    _hasCompletedInitialCheck = true;
+    _hasInternetConnectionStream.add(connected);
+  }
+
+  /// Replays the last known value to late subscribers.
+  ///
+  /// The underlying controller is broadcast without replay, so listeners
+  /// created after the first check (for example the home offline banner) would
+  /// otherwise miss the initial offline reading.
   @override
-  Stream<bool> hasInternetConnectionStream() =>
-      _hasInternetConnectionStream.stream.distinct();
+  Stream<bool> hasInternetConnectionStream() {
+    return Stream<bool>.multi((controller) {
+      if (_hasCompletedInitialCheck) {
+        controller.add(isConnected);
+      }
+      final subscription = _hasInternetConnectionStream.stream.listen(
+        controller.add,
+        onError: controller.addError,
+        onDone: controller.close,
+      );
+      controller
+        ..onPause = subscription.pause
+        ..onResume = subscription.resume
+        ..onCancel = subscription.cancel;
+    }).distinct();
+  }
 }

--- a/lib/features/give/cubit/offline_queue_cubit.dart
+++ b/lib/features/give/cubit/offline_queue_cubit.dart
@@ -13,6 +13,12 @@ class OfflineQueueCubit extends Cubit<OfflineQueueState> {
     this._networkInfo,
   ) : super(OfflineQueueState.initial(isOffline: !_networkInfo.isConnected)) {
     _wasOffline = !_networkInfo.isConnected;
+    // [NetworkInfo.isConnected] defaults to true until the first real check.
+    // false therefore means we already know the device is offline, so show
+    // the banner without waiting for a stream event that may have been missed.
+    if (!_networkInfo.isConnected) {
+      _hasResolvedConnectivity = true;
+    }
     _refreshFromCache(isOffline: !_networkInfo.isConnected);
     if (_networkInfo.isConnected && _hasPendingDonations()) {
       unawaited(_syncAndRefresh());

--- a/lib/features/give/pages/for_you_giving_page.dart
+++ b/lib/features/give/pages/for_you_giving_page.dart
@@ -6,6 +6,7 @@ import 'package:givt_app/app/routes/routes.dart';
 import 'package:givt_app/core/enums/analytics_event_name.dart';
 import 'package:givt_app/core/enums/collect_group_type.dart';
 import 'package:givt_app/core/enums/country.dart';
+import 'package:givt_app/core/network/network_info.dart';
 import 'package:givt_app/features/amount_presets/models/models.dart';
 import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/shared/design_system/design_system.dart';
@@ -16,6 +17,7 @@ import 'package:givt_app/features/give/dialogs/donation_submission_timeout_dialo
 import 'package:givt_app/features/give/models/models.dart';
 import 'package:givt_app/features/give/utils/for_you_donation_transactions.dart';
 import 'package:givt_app/features/give/utils/for_you_giving_analytics.dart';
+import 'package:givt_app/features/give/utils/offline_aware_organisation_goals_loader.dart';
 import 'package:givt_app/shared/models/analytics_event.dart';
 import 'package:givt_app/features/give/widgets/for_you_more_general_goals_sheet.dart';
 import 'package:givt_app/features/give/widgets/numeric_keyboard.dart';
@@ -631,32 +633,32 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
       return;
     }
 
-    try {
-      final repository = getIt<OrganisationGoalsRepository>();
-      final response = await repository.fetchGoals(organisation.nameSpace);
-      if (!mounted) {
-        return;
-      }
-      _goalsResponse = response;
-      final restrict = widget.flowContext.restrictToEntryQrGoal;
-      final entryMediumId = widget.flowContext.entryMediumId?.trim() ?? '';
-      if (restrict && entryMediumId.isNotEmpty) {
-        final match = response.qrCodes
-            .where((q) => q.mediumId.trim() == entryMediumId)
-            .toList();
-        if (match.isNotEmpty) {
-          _applyLines([ForYouGeneralGoalLine(match.first)]);
-          return;
-        }
-      }
-      _setupCollectionLinesFromResponse(response);
-    } on Exception {
-      if (!mounted) {
-        return;
-      }
+    final response = await OfflineAwareOrganisationGoalsLoader(
+      repository: getIt<OrganisationGoalsRepository>(),
+      networkInfo: getIt<NetworkInfo>(),
+    ).load(organisation.nameSpace);
+    if (!mounted) {
+      return;
+    }
+    if (response == null) {
       _goalsResponse = const OrganisationGoalsResponse();
       _setupFallbackLines();
+      return;
     }
+
+    _goalsResponse = response;
+    final restrict = widget.flowContext.restrictToEntryQrGoal;
+    final entryMediumId = widget.flowContext.entryMediumId?.trim() ?? '';
+    if (restrict && entryMediumId.isNotEmpty) {
+      final match = response.qrCodes
+          .where((q) => q.mediumId.trim() == entryMediumId)
+          .toList();
+      if (match.isNotEmpty) {
+        _applyLines([ForYouGeneralGoalLine(match.first)]);
+        return;
+      }
+    }
+    _setupCollectionLinesFromResponse(response);
   }
 
   void _setupCollectionLinesFromResponse(OrganisationGoalsResponse response) {

--- a/lib/features/give/utils/offline_aware_organisation_goals_loader.dart
+++ b/lib/features/give/utils/offline_aware_organisation_goals_loader.dart
@@ -1,0 +1,40 @@
+import 'package:givt_app/core/network/network_info.dart';
+import 'package:givt_app/shared/models/organisation_goals.dart';
+import 'package:givt_app/shared/repositories/organisation_goals_repository.dart';
+
+/// Loads organisation goals for giving, without blocking on a dead network.
+///
+/// The HTTP client waits 30s for a response. When the user has just gone
+/// offline, [NetworkInfo.isConnected] can still be true for a moment, so a
+/// short timeout is used as a fallback.
+class OfflineAwareOrganisationGoalsLoader {
+  const OfflineAwareOrganisationGoalsLoader({
+    required OrganisationGoalsRepository repository,
+    required NetworkInfo networkInfo,
+    this.requestTimeout = const Duration(seconds: 3),
+  }) : _repository = repository,
+       _networkInfo = networkInfo;
+
+  final OrganisationGoalsRepository _repository;
+  final NetworkInfo _networkInfo;
+  final Duration requestTimeout;
+
+  /// Returns goals when they can be fetched quickly while online.
+  /// Returns null when offline or the request fails/times out so callers
+  /// can show fallback collection lines immediately.
+  Future<OrganisationGoalsResponse?> load(String collectGroupId) async {
+    if (!_networkInfo.isConnected) {
+      return null;
+    }
+
+    try {
+      return await _repository
+          .fetchGoals(collectGroupId)
+          .timeout(
+            requestTimeout,
+          );
+    } on Object {
+      return null;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: givt_app
 description: Givt App
-version: 6.5.0
+version: 6.5.1
 publish_to: none
 
 environment:

--- a/test/features/give/cubit/offline_queue_cubit_test.dart
+++ b/test/features/give/cubit/offline_queue_cubit_test.dart
@@ -175,6 +175,16 @@ void main() {
       await networkInfo.dispose();
     });
 
+    test('shows offline banner on cold start without a stream event', () {
+      networkInfo = _FakeNetworkInfo(isConnected: false);
+      repository = _FakeGivtRepository();
+      cubit = OfflineQueueCubit(repository, networkInfo);
+
+      expect(cubit.state.hasResolvedConnectivity, isTrue);
+      expect(cubit.state.isOffline, isTrue);
+      expect(cubit.state.shouldShowBanner, isTrue);
+    });
+
     test('marks connectivity resolved and shows offline banner', () async {
       networkInfo = _FakeNetworkInfo(isConnected: true);
       repository = _FakeGivtRepository();

--- a/test/features/give/utils/offline_aware_organisation_goals_loader_test.dart
+++ b/test/features/give/utils/offline_aware_organisation_goals_loader_test.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/core/network/network_info.dart';
+import 'package:givt_app/features/give/utils/offline_aware_organisation_goals_loader.dart';
+import 'package:givt_app/shared/models/organisation_goals.dart';
+import 'package:givt_app/shared/repositories/organisation_goals_repository.dart';
+
+class _FakeNetworkInfo with NetworkInfo {
+  _FakeNetworkInfo({required this.isConnected});
+
+  @override
+  bool isConnected;
+
+  @override
+  Stream<bool> hasInternetConnectionStream() => const Stream.empty();
+}
+
+class _FakeOrganisationGoalsRepository with OrganisationGoalsRepository {
+  _FakeOrganisationGoalsRepository({required this.onFetch});
+
+  final Future<OrganisationGoalsResponse> Function() onFetch;
+  int fetchCount = 0;
+
+  @override
+  Future<OrganisationGoalsSummary> fetchGoalsSummary(
+    String collectGroupId,
+  ) async => const OrganisationGoalsSummary.empty();
+
+  @override
+  Future<OrganisationGoalsResponse> fetchGoals(String collectGroupId) async {
+    fetchCount++;
+    return onFetch();
+  }
+
+  @override
+  void clearCache() {}
+}
+
+void main() {
+  group('OfflineAwareOrganisationGoalsLoader', () {
+    test('skips the request when already offline', () async {
+      final repository = _FakeOrganisationGoalsRepository(
+        onFetch: () async => const OrganisationGoalsResponse(),
+      );
+      final loader = OfflineAwareOrganisationGoalsLoader(
+        repository: repository,
+        networkInfo: _FakeNetworkInfo(isConnected: false),
+      );
+
+      final result = await loader.load('org-1');
+
+      expect(result, isNull);
+      expect(repository.fetchCount, 0);
+    });
+
+    test('returns goals when the request succeeds while online', () async {
+      const response = OrganisationGoalsResponse();
+      final repository = _FakeOrganisationGoalsRepository(
+        onFetch: () async => response,
+      );
+      final loader = OfflineAwareOrganisationGoalsLoader(
+        repository: repository,
+        networkInfo: _FakeNetworkInfo(isConnected: true),
+      );
+
+      final result = await loader.load('org-1');
+
+      expect(result, same(response));
+      expect(repository.fetchCount, 1);
+    });
+
+    test('returns null when the request exceeds the timeout', () async {
+      final repository = _FakeOrganisationGoalsRepository(
+        onFetch: () => Completer<OrganisationGoalsResponse>().future,
+      );
+      final loader = OfflineAwareOrganisationGoalsLoader(
+        repository: repository,
+        networkInfo: _FakeNetworkInfo(isConnected: true),
+        requestTimeout: const Duration(milliseconds: 20),
+      );
+
+      final result = await loader.load('org-1');
+
+      expect(result, isNull);
+      expect(repository.fetchCount, 1);
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Test feedback on [ENG-1171](https://linear.app/givt/issue/ENG-1171/implement-offline-giving-flow-states-and-queued-donation-messaging):

1. **Banner missing on cold start** — Kill the app while offline, reopen with no queued donations: the “You’re offline — You can still give…” banner does not appear until a donation is queued.
2. **For You giving spinner** — Start the app online, turn off internet, then donate from For You: the amount screen stays on a spinner for ~30s.

## Causes

- `NetworkInfo.isConnected` defaults to `true`, and `hasInternetConnectionStream()` is a broadcast stream **without replay**. `OfflineQueueCubit` is created on Home *after* splash, so it often misses the first offline reading. The no-pending banner also required `hasResolvedConnectivity`, which only flipped on a stream event.
- For You giving always called `fetchGoals()`. The HTTP client uses a **30s** `requestTimeout`. That matches Donna’s wait. PostHog is **not** the cause: `AnalyticsHelper.logEvent` is fired with `unawaited` from `ActionContainer` and from the favorite-card tap.

## Fixes

- Replay the last connectivity value to late subscribers once the initial check has completed.
- If the cubit is constructed while already offline, treat connectivity as resolved immediately so the banner shows with zero pending donations.
- Load organisation goals through `OfflineAwareOrganisationGoalsLoader`: skip the request when offline, otherwise time out after 3s and fall back to collection lines.

## How to test

1. Kill the app, disable network, reopen → home banner shows without making a donation.
2. Open the app online, disable network, tap a For You favorite → amount screen appears without a long spinner (fallback collection goals).
3. Queue a donation offline → pending banner copy still updates.

## Tests

`flutter test` on cubit/state/loader tests: 11 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a83df2f9-efb9-4b8a-b4fe-74199585a894?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a83df2f9-efb9-4b8a-b4fe-74199585a894&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

