### PR TITLE
Logout on invalid refresh token (ENG-1143 / ENG-1323)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,17 @@ The app has **two main variants**; many features exist in both with different im
 
 When a task mentions “EU” or “US” (or “family”), work in the corresponding feature folder. Do not assume one implementation applies to both.
 
+## EU auth session (main app)
+
+Contract lives in code on [`AuthCubit`](lib/features/auth/cubit/auth_cubit.dart), [`AuthGate`](lib/features/auth/models/auth_gate.dart), and [`AuthUtils.checkToken`](lib/utils/auth_utils.dart). Do not regress this:
+
+- **Online app open:** silent OAuth refresh. Success stays on home.
+- **Invalid refresh token** (`invalid_grant`): **logout** (welcome). Never Face ID, never a dismissible login sheet, never `needsReauthentication`.
+- **Other refresh failure** (server error): stay logged in, set `needsReauthentication`, prompt biometrics/login from Home **init/resume** (not from `build` — drawer open/close rebuilds).
+- **Offline:** keep local session; no popup. Giving may continue with `allowWhenOffline: true`.
+- **Protected menu items** (`CheckAuthPolicy.stepUp`): refresh expired/reauth sessions **before** Face ID so a dead refresh token logs out instead of scanning. Face ID only when the 15-minute local-auth grace has elapsed.
+- **Logout:** persist `isLoggedIn: false` before the session stream; do **not** emit `AuthStatus.loading` (that bounced splash → home on the first tap).
+
 ## Registration mandate flow (EU / UK, main app)
 
 - **Intro**: [`MandateExplanationPage`](lib/features/registration/pages/mandate_explanation_page.dart) — SEPA vs UK Direct Debit intro; continues to sign step.
@@ -126,7 +137,7 @@ When a task mentions “EU” or “US” (or “family”), work in the corresp
 
 ## Where to look
 
-- **Auth / current user**: `AuthCubit` (EU), `FamilyAuthRepository` / family auth (US).
+- **Auth / current user**: `AuthCubit` (EU; see **EU auth session** above), `FamilyAuthRepository` / family auth (US).
 - **Support / infra**: `InfraCubit`, `contactSupportSafely`; used from `lib/shared/bloc/infra/`.
 - **L10n**: `lib/l10n/arb/app_en.arb` (template), then regenerate with `flutter gen-l10n`.
 - **Language & phrasing**: `docs/language.md` for terminology, tone of voice, and translation guidelines.

--- a/lib/core/failures/failure.dart
+++ b/lib/core/failures/failure.dart
@@ -19,6 +19,16 @@ class GivtServerFailure extends Equatable implements Exception {
     return FailureType.UNKNOWN;
   }
 
+  /// OAuth `/oauth2/token` returns `{"error":"invalid_grant"}` when the
+  /// refresh token is expired or revoked.
+  bool get isInvalidGrant {
+    final oauthError = body?['error']?.toString() ?? '';
+    if (oauthError == 'invalid_grant') {
+      return true;
+    }
+    return body?.toString().contains('invalid_grant') ?? false;
+  }
+
   @override
   List<Object> get props => [statusCode, type];
 }
@@ -27,8 +37,7 @@ enum FailureType {
   ALLOWANCE_NOT_SUCCESSFUL,
   TOPUP_NOT_SUCCESSFUL,
   VPC_NOT_SUCCESSFUL,
-  UNKNOWN,
-  ;
+  UNKNOWN;
 
   static FailureType getByErrorMessage(String message) {
     try {

--- a/lib/features/auth/cubit/auth_cubit.dart
+++ b/lib/features/auth/cubit/auth_cubit.dart
@@ -19,6 +19,20 @@ import 'package:givt_app/utils/utils.dart';
 import 'package:permission_handler/permission_handler.dart';
 part 'auth_state.dart';
 
+/// Owns the EU / main-app OAuth session.
+///
+/// Expected behaviour (online unless noted):
+/// * **App open:** silent refresh. Success keeps the user on home.
+/// * **Refresh token rejected** (`invalid_grant`): [logout]. Do not keep a
+///   local session, do not set [AuthState.needsReauthentication], do not
+///   prompt Face ID, and do not show a dismissible login sheet.
+/// * **Refresh fails for another reason** (e.g. server error): stay
+///   authenticated and set [AuthState.needsReauthentication] so Home / give
+///   can prompt biometrics or login.
+/// * **Offline:** keep the local session; no popup.
+/// * **Logout:** persist `isLoggedIn: false` before the session stream
+///   notifies [checkAuth], and never emit [AuthStatus.loading] (that
+///   redirects through splash and can bounce back to home).
 class AuthCubit extends Cubit<AuthState> {
   AuthCubit(
     this._authRepositoy, {
@@ -40,6 +54,8 @@ class AuthCubit extends Cubit<AuthState> {
 
   bool get _isOnline => _networkInfo?.isConnected ?? true;
 
+  /// True when OAuth `/oauth2/token` rejected the refresh token.
+  /// That is a permanent session failure: the user must log in again.
   bool _isInvalidGrant(Object error) {
     if (error is GivtServerFailure) {
       return error.isInvalidGrant;
@@ -188,6 +204,12 @@ class AuthCubit extends Cubit<AuthState> {
     );
   }
 
+  /// Loads the stored session and, when [isAppStartupCheck] and online,
+  /// silently refreshes.
+  ///
+  /// Pass [hasSession] `false` from the session stream after logout. That
+  /// path emits [AuthStatus.unauthenticated] without [AuthStatus.loading]
+  /// so the router does not bounce splash → home while still logged in.
   Future<void> checkAuth({
     bool isAppStartupCheck = false,
     bool? hasSession,
@@ -308,6 +330,12 @@ class AuthCubit extends Cubit<AuthState> {
     }
   }
 
+  /// Clears the local session and emits [AuthStatus.unauthenticated].
+  ///
+  /// Must not emit [AuthStatus.loading]. The repository persists
+  /// `isLoggedIn: false` before notifying the session stream; [checkAuth]
+  /// then treats `hasSession: false` as logged out instead of re-reading
+  /// a still-logged-in cached session.
   Future<void> logout({bool fullReset = false}) async {
     if (_isLoggingOut) {
       return;
@@ -514,6 +542,9 @@ class AuthCubit extends Cubit<AuthState> {
     unawaited(_authRepositoy.markLocalAuthSucceeded());
   }
 
+  /// Face ID / local-auth succeeded within [AuthGate.localAuthGracePeriod]
+  /// (15 minutes). Used only by [CheckAuthPolicy.stepUp] on protected menu
+  /// items — giving and app-open always use [CheckAuthPolicy.ensureSession].
   bool get isWithinLocalAuthGrace {
     final lastLocalAuthAt = _authRepositoy.lastLocalAuthAt();
     if (lastLocalAuthAt == null) {

--- a/lib/features/auth/cubit/auth_cubit.dart
+++ b/lib/features/auth/cubit/auth_cubit.dart
@@ -36,8 +36,16 @@ class AuthCubit extends Cubit<AuthState> {
   final NetworkInfo? _networkInfo;
   late StreamSubscription<bool> _sessionSubscription;
   Future<RefreshSessionResult>? _inFlightRefresh;
+  bool _isLoggingOut = false;
 
   bool get _isOnline => _networkInfo?.isConnected ?? true;
+
+  bool _isInvalidGrant(Object error) {
+    if (error is GivtServerFailure) {
+      return error.isInvalidGrant;
+    }
+    return error.toString().contains('invalid_grant');
+  }
 
   @override
   Future<void> close() async {
@@ -184,6 +192,25 @@ class AuthCubit extends Cubit<AuthState> {
     bool isAppStartupCheck = false,
     bool? hasSession,
   }) async {
+    if (_isLoggingOut) {
+      return;
+    }
+
+    // Logout notifies the session stream with false. Do not re-authenticate
+    // from a still-cached session, and do not emit loading (that redirects
+    // the router to the splash/loading route, then back to home).
+    if (hasSession == false) {
+      emit(
+        state.copyWith(
+          status: AuthStatus.unauthenticated,
+          email: state.user.email,
+          needsReauthentication: false,
+        ),
+      );
+      _authRepositoy.setHasSessionInitialValue(false);
+      return;
+    }
+
     final currentStatus = state.status;
     emit(state.copyWith(status: AuthStatus.loading));
     try {
@@ -213,6 +240,14 @@ class AuthCubit extends Cubit<AuthState> {
             'No internet while refreshing session on startup; continuing offline',
           );
         } on Object catch (e, stackTrace) {
+          if (_isInvalidGrant(e)) {
+            LoggingInfo.instance.warning(
+              'Refresh token invalid on app startup, logging out: $e',
+              methodName: stackTrace.toString(),
+            );
+            await logout();
+            return;
+          }
           LoggingInfo.instance.warning(
             'Session refresh failed on app startup: $e',
             methodName: stackTrace.toString(),
@@ -274,19 +309,38 @@ class AuthCubit extends Cubit<AuthState> {
   }
 
   Future<void> logout({bool fullReset = false}) async {
-    emit(state.copyWith(status: AuthStatus.loading));
+    if (_isLoggingOut) {
+      return;
+    }
+    _isLoggingOut = true;
     LoggingInfo.instance.info('User is logging out');
 
-    await _authRepositoy.logout();
+    try {
+      await _authRepositoy.logout();
 
-    emit(
-      state.copyWith(
-        status: AuthStatus.unauthenticated,
-        email: fullReset ? null : state.user.email,
-        user: fullReset ? const UserExt.empty() : state.user,
-      ),
-    );
-    AnalyticsHelper.clearUserProperties();
+      emit(
+        state.copyWith(
+          status: AuthStatus.unauthenticated,
+          email: fullReset ? null : state.user.email,
+          user: fullReset ? const UserExt.empty() : state.user,
+          session: const Session.empty(),
+          needsReauthentication: false,
+        ),
+      );
+      await _clearAnalyticsUserProperties();
+    } finally {
+      _isLoggingOut = false;
+    }
+  }
+
+  Future<void> _clearAnalyticsUserProperties() async {
+    try {
+      await AnalyticsHelper.clearUserProperties();
+    } on Object catch (e) {
+      LoggingInfo.instance.warning(
+        'Failed to clear analytics user properties: $e',
+      );
+    }
   }
 
   Future<void> register({
@@ -473,7 +527,9 @@ class AuthCubit extends Cubit<AuthState> {
   ///
   /// Returns [RefreshSessionResult.success] when a new session is stored,
   /// [RefreshSessionResult.offline] when the request fails due to no network,
-  /// and [RefreshSessionResult.failure] for auth or other errors.
+  /// [RefreshSessionResult.invalidRefreshToken] when the refresh token is
+  /// rejected (the user is logged out), and [RefreshSessionResult.failure]
+  /// for other errors.
   ///
   /// Skips the network call when the access token is still valid unless
   /// [force] is true or [AuthState.needsReauthentication] is set. Concurrent
@@ -526,6 +582,14 @@ class AuthCubit extends Cubit<AuthState> {
       }
       return RefreshSessionResult.offline;
     } catch (e, stackTrace) {
+      if (_isInvalidGrant(e)) {
+        LoggingInfo.instance.warning(
+          'Refresh token invalid, logging out: $e',
+          methodName: stackTrace.toString(),
+        );
+        await logout();
+        return RefreshSessionResult.invalidRefreshToken;
+      }
       LoggingInfo.instance.error(
         e.toString(),
         methodName: stackTrace.toString(),

--- a/lib/features/auth/cubit/auth_state.dart
+++ b/lib/features/auth/cubit/auth_state.dart
@@ -4,6 +4,7 @@ enum RefreshSessionResult {
   success,
   offline,
   failure,
+  invalidRefreshToken,
 }
 
 enum AuthStatus {
@@ -45,9 +46,9 @@ class AuthState extends Equatable {
   final AuthStatus status;
   final Future<void> Function(BuildContext context) navigate;
 
-  /// True when the user is still treated as logged in locally, but the
-  /// access/refresh tokens could not be renewed and the UI should prompt
-  /// for biometrics or password login.
+  /// True when the user is still treated as logged in locally, but session
+  /// refresh failed for a non-auth reason (e.g. a server error). Invalid
+  /// refresh tokens log the user out instead of setting this flag.
   final bool needsReauthentication;
 
   static Future<void> _emptyNavigate(
@@ -87,15 +88,15 @@ class AuthState extends Equatable {
 
   @override
   List<Object> get props => [
-        user,
-        session,
-        email,
-        message,
-        status,
-        presets,
-        navigate,
-        needsReauthentication,
-      ];
+    user,
+    session,
+    email,
+    message,
+    status,
+    presets,
+    navigate,
+    needsReauthentication,
+  ];
 
   @override
   String toString() {

--- a/lib/features/auth/cubit/auth_state.dart
+++ b/lib/features/auth/cubit/auth_state.dart
@@ -1,9 +1,21 @@
 part of 'auth_cubit.dart';
 
+/// Outcome of [AuthCubit.refreshSession]. Callers must treat
+/// [invalidRefreshToken] as “already logged out” and must not prompt
+/// Face ID or a login sheet.
 enum RefreshSessionResult {
+  /// New tokens stored; [AuthState.needsReauthentication] is cleared.
   success,
+
+  /// No network. Giving may continue with the local session; other
+  /// destinations must not navigate without a refreshed token.
   offline,
+
+  /// Server or other recoverable error. Caller may prompt biometrics/login.
   failure,
+
+  /// Refresh token rejected (`invalid_grant`). [AuthCubit.logout] already
+  /// ran; do not show Face ID or a dismissible login sheet.
   invalidRefreshToken,
 }
 

--- a/lib/features/auth/models/auth_gate.dart
+++ b/lib/features/auth/models/auth_gate.dart
@@ -1,23 +1,37 @@
 /// Policy for `AuthUtils.checkToken`.
 enum CheckAuthPolicy {
-  /// Giving and app-open: keep a valid OAuth session. Face ID only if refresh
-  /// fails. No local-auth grace period.
+  /// Giving and app-open: keep a valid OAuth session. Face ID only if
+  /// refresh fails for a recoverable reason. No local-auth grace period.
+  /// An invalid refresh token logs the user out instead of Face ID/login.
   ensureSession,
 
-  /// Protected menu item taps: Face ID when the local-auth grace period has
-  /// elapsed. If the access token is expired or reauth is needed, refresh
-  /// first so an invalid refresh token can log the user out.
+  /// Protected menu item taps: Face ID when the 15-minute local-auth grace
+  /// has elapsed. If the access token is expired or reauth is needed,
+  /// refresh first so an invalid refresh token logs the user out before
+  /// Face ID (opening the menu must not Face ID-scan a dead session).
   stepUp,
 }
 
 /// First action `AuthUtils.checkToken` should take for a given policy.
 enum AuthGateAction {
+  /// Session is usable; continue without Face ID or login.
   navigate,
+
+  /// Refresh the OAuth session before navigating or prompting Face ID.
   silentRefresh,
+
+  /// Prompt Face ID (then login sheet if biometrics fail). Never used
+  /// when the refresh token is already known to be invalid.
   promptBiometrics,
 }
 
 /// Pure decision helper for OAuth refresh vs Face ID step-up.
+///
+/// Decision order for [CheckAuthPolicy.stepUp]:
+/// 1. Expired access token or `needsReauthentication` → silent refresh
+///    (invalid grant logs out; no Face ID).
+/// 2. Local-auth grace elapsed → Face ID.
+/// 3. Otherwise navigate.
 class AuthGate {
   static const Duration localAuthGracePeriod = Duration(minutes: 15);
 

--- a/lib/features/auth/models/auth_gate.dart
+++ b/lib/features/auth/models/auth_gate.dart
@@ -5,7 +5,8 @@ enum CheckAuthPolicy {
   ensureSession,
 
   /// Protected menu item taps: Face ID when the local-auth grace period has
-  /// elapsed. OAuth refresh only if the access token is actually near expiry.
+  /// elapsed. If the access token is expired or reauth is needed, refresh
+  /// first so an invalid refresh token can log the user out.
   stepUp,
 }
 
@@ -33,11 +34,13 @@ class AuthGate {
         }
         return AuthGateAction.navigate;
       case CheckAuthPolicy.stepUp:
-        if (needsReauthentication || !isWithinLocalAuthGrace) {
-          return AuthGateAction.promptBiometrics;
-        }
-        if (isAccessTokenExpired) {
+        // Refresh first so an invalid refresh token logs the user out
+        // instead of prompting Face ID / a dismissible login sheet.
+        if (needsReauthentication || isAccessTokenExpired) {
           return AuthGateAction.silentRefresh;
+        }
+        if (!isWithinLocalAuthGrace) {
+          return AuthGateAction.promptBiometrics;
         }
         return AuthGateAction.navigate;
     }

--- a/lib/features/auth/repositories/auth_repository.dart
+++ b/lib/features/auth/repositories/auth_repository.dart
@@ -21,6 +21,10 @@ mixin AuthRepository {
 
   Future<(UserExt, Session, UserPresets)?> isAuthenticated();
 
+  /// Persists `isLoggedIn: false` then notifies [hasSessionStream].
+  ///
+  /// Order matters: notifying first lets [AuthCubit.checkAuth] re-read a
+  /// still-logged-in session and bounce the user back to home.
   Future<bool> logout();
 
   Future<bool> checkTld(String email);

--- a/lib/features/auth/repositories/auth_repository.dart
+++ b/lib/features/auth/repositories/auth_repository.dart
@@ -327,28 +327,28 @@ class AuthRepositoyImpl with AuthRepository {
     // _prefs.clear();
     final sessionString = _prefs.getString(Session.tag);
 
-    updateSessionStream(false);
-
     await clearLastLocalAuth();
 
-    // If the data is already gone, just continue :)
-    if (sessionString == null) {
-      return true;
+    // Persist logged-out session before notifying listeners so checkAuth
+    // cannot re-read a still-logged-in session and bounce back to home.
+    if (sessionString != null) {
+      final session = Session.fromJson(
+        jsonDecode(sessionString) as Map<String, dynamic>,
+      );
+      await _prefs.setString(
+        Session.tag,
+        jsonEncode(
+          session
+              .copyWith(
+                isLoggedIn: false,
+              )
+              .toJson(),
+        ),
+      );
     }
 
-    final session = Session.fromJson(
-      jsonDecode(sessionString) as Map<String, dynamic>,
-    );
-    return _prefs.setString(
-      Session.tag,
-      jsonEncode(
-        session
-            .copyWith(
-              isLoggedIn: false,
-            )
-            .toJson(),
-      ),
-    );
+    updateSessionStream(false);
+    return true;
   }
 
   @override

--- a/lib/features/give/pages/home_page.dart
+++ b/lib/features/give/pages/home_page.dart
@@ -295,13 +295,6 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
         _mandatePopupDismissalTracker.shouldForceCompletion &&
         auth.user.needRegistration;
 
-    if (auth.needsReauthentication &&
-        auth.status == AuthStatus.authenticated) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        unawaited(_promptReauthenticationIfNeeded());
-      });
-    }
-
     if (widget.navigateTo.isNotEmpty &&
         auth.status == AuthStatus.authenticated) {
       LoggingInfo.instance.info('Navigating to ${widget.navigateTo}');

--- a/lib/features/give/pages/home_page.dart
+++ b/lib/features/give/pages/home_page.dart
@@ -103,6 +103,12 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
     });
   }
 
+  /// Prompts biometrics/login only for recoverable reauth (server error,
+  /// not an invalid refresh token — that already logged the user out).
+  ///
+  /// Call from [initState] and app resume only. Do not call from [build]:
+  /// opening/closing the drawer rebuilds HomePage and would re-prompt Face
+  /// ID or a dismissible login sheet.
   Future<void> _promptReauthenticationIfNeeded({
     bool requireExpiredSession = false,
   }) async {
@@ -294,6 +300,10 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
     final shouldLockScreen =
         _mandatePopupDismissalTracker.shouldForceCompletion &&
         auth.user.needRegistration;
+
+    // Do not prompt reauth here. [build] also runs when the drawer
+    // opens/closes; initState + resume cover app-open and returning
+    // from background.
 
     if (widget.navigateTo.isNotEmpty &&
         auth.status == AuthStatus.authenticated) {

--- a/lib/utils/auth_utils.dart
+++ b/lib/utils/auth_utils.dart
@@ -89,12 +89,30 @@ class AuthUtils {
         if (!context.mounted) {
           return;
         }
-        if (await _tryNavigateAfterRefresh(
-          context,
-          checkAuthRequest: checkAuthRequest,
-          refreshResult: refreshResult,
-        )) {
-          return;
+        switch (refreshResult) {
+          case RefreshSessionResult.invalidRefreshToken:
+            return;
+          case RefreshSessionResult.success:
+            if (_shouldPromptStepUp(checkAuthRequest, authCubit)) {
+              await _promptBiometricsOrLogin(
+                context,
+                checkAuthRequest: checkAuthRequest,
+              );
+              return;
+            }
+            await checkAuthRequest.navigate(context);
+            return;
+          case RefreshSessionResult.offline:
+            if (await _tryNavigateAfterRefresh(
+              context,
+              checkAuthRequest: checkAuthRequest,
+              refreshResult: refreshResult,
+            )) {
+              return;
+            }
+            break;
+          case RefreshSessionResult.failure:
+            break;
         }
         if (!context.mounted) {
           return;
@@ -111,6 +129,14 @@ class AuthUtils {
         );
         return;
     }
+  }
+
+  static bool _shouldPromptStepUp(
+    CheckAuthRequest checkAuthRequest,
+    AuthCubit authCubit,
+  ) {
+    return checkAuthRequest.policy == CheckAuthPolicy.stepUp &&
+        !authCubit.isWithinLocalAuthGrace;
   }
 
   static bool _canSkipRefreshForOfflineGiving(
@@ -154,6 +180,9 @@ class AuthUtils {
         return false;
       case RefreshSessionResult.failure:
         return false;
+      case RefreshSessionResult.invalidRefreshToken:
+        // Logout already happened; do not fall through to a login sheet.
+        return true;
     }
   }
 

--- a/lib/utils/auth_utils.dart
+++ b/lib/utils/auth_utils.dart
@@ -37,10 +37,13 @@ class CheckAuthRequest {
 }
 
 class AuthUtils {
-  /// Checks if the user is authenticated.
-  /// If the user is authenticated, the [navigate] callback is called.
-  /// If the user is not authenticated, the login bottom sheet is displayed
-  /// or the biometrics are checked.
+  /// Ensures a usable OAuth session for [checkAuthRequest], then calls
+  /// [CheckAuthRequest.navigate].
+  ///
+  /// Recoverable refresh failures may prompt Face ID or a dismissible login
+  /// sheet. [RefreshSessionResult.invalidRefreshToken] means logout already
+  /// ran — return without Face ID or a login sheet so the user lands on
+  /// welcome instead of a popup they can dismiss while still "logged in".
   static Future<void> checkToken(
     BuildContext context, {
     required CheckAuthRequest checkAuthRequest,
@@ -91,6 +94,7 @@ class AuthUtils {
         }
         switch (refreshResult) {
           case RefreshSessionResult.invalidRefreshToken:
+            // Already logged out; do not Face ID or show login.
             return;
           case RefreshSessionResult.success:
             if (_shouldPromptStepUp(checkAuthRequest, authCubit)) {
@@ -131,6 +135,8 @@ class AuthUtils {
     }
   }
 
+  /// After a successful silent refresh on a protected menu item, still
+  /// prompt Face ID when the 15-minute local-auth grace has elapsed.
   static bool _shouldPromptStepUp(
     CheckAuthRequest checkAuthRequest,
     AuthCubit authCubit,
@@ -264,9 +270,11 @@ class AuthUtils {
     }
   }
 
-  /// Displays the login bottom sheet.
-  /// If the user successfully logs in, the [navigate] callback is called.
-  /// If the user cancels the login, nothing happens.
+  /// Displays the dismissible login bottom sheet.
+  ///
+  /// Success calls [CheckAuthRequest.navigate]. Cancel / dismiss does
+  /// nothing — so this must not be used when the refresh token is invalid
+  /// (that path logs the user out instead).
   static Future<void> displayLoginBottomSheet(
     BuildContext context, {
     required CheckAuthRequest checkAuthRequest,

--- a/test/core/failures/givt_server_failure_test.dart
+++ b/test/core/failures/givt_server_failure_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/core/failures/failures.dart';
+
+void main() {
+  group('GivtServerFailure.isInvalidGrant', () {
+    test('is true when OAuth error is invalid_grant', () {
+      const failure = GivtServerFailure(
+        statusCode: 400,
+        body: {'error': 'invalid_grant'},
+      );
+
+      expect(failure.isInvalidGrant, isTrue);
+    });
+
+    test('is false for other OAuth errors', () {
+      const failure = GivtServerFailure(
+        statusCode: 400,
+        body: {'error': 'invalid_client'},
+      );
+
+      expect(failure.isInvalidGrant, isFalse);
+    });
+
+    test('is false when body is missing', () {
+      const failure = GivtServerFailure(statusCode: 500);
+
+      expect(failure.isInvalidGrant, isFalse);
+    });
+  });
+}

--- a/test/features/auth/auth_cubit_startup_reauth_test.dart
+++ b/test/features/auth/auth_cubit_startup_reauth_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/core/failures/failures.dart';
 import 'package:givt_app/core/network/network_info.dart';
 import 'package:givt_app/features/amount_presets/models/models.dart';
 import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
@@ -25,7 +26,10 @@ void main() {
       userGUID: 'guid-1',
       accessToken: 'access',
       refreshToken: 'refresh',
-      expires: DateTime.now().toUtc().add(const Duration(hours: 1)).toIso8601String(),
+      expires: DateTime.now()
+          .toUtc()
+          .add(const Duration(hours: 1))
+          .toIso8601String(),
       expiresIn: 3600,
       isLoggedIn: true,
     );
@@ -35,7 +39,10 @@ void main() {
       userGUID: 'guid-1',
       accessToken: 'new-access',
       refreshToken: 'new-refresh',
-      expires: DateTime.now().toUtc().add(const Duration(hours: 2)).toIso8601String(),
+      expires: DateTime.now()
+          .toUtc()
+          .add(const Duration(hours: 2))
+          .toIso8601String(),
       expiresIn: 7200,
       isLoggedIn: true,
     );
@@ -57,23 +64,26 @@ void main() {
       repository.dispose();
     });
 
-    test('online startup refresh success clears needsReauthentication', () async {
-      repository.refreshResult = refreshedSession;
-      cubit = AuthCubit(
-        repository,
-        networkInfo: _FakeNetworkInfo(isConnected: true),
-      );
+    test(
+      'online startup refresh success clears needsReauthentication',
+      () async {
+        repository.refreshResult = refreshedSession;
+        cubit = AuthCubit(
+          repository,
+          networkInfo: _FakeNetworkInfo(isConnected: true),
+        );
 
-      await cubit.checkAuth(isAppStartupCheck: true);
+        await cubit.checkAuth(isAppStartupCheck: true);
 
-      expect(cubit.state.status, AuthStatus.authenticated);
-      expect(cubit.state.needsReauthentication, isFalse);
-      expect(cubit.state.session.accessToken, 'new-access');
-      expect(repository.refreshCallCount, 1);
-    });
+        expect(cubit.state.status, AuthStatus.authenticated);
+        expect(cubit.state.needsReauthentication, isFalse);
+        expect(cubit.state.session.accessToken, 'new-access');
+        expect(repository.refreshCallCount, 1);
+      },
+    );
 
     test('online startup refresh failure sets needsReauthentication', () async {
-      repository.refreshError = Exception('invalid_grant');
+      repository.refreshError = Exception('server error');
       cubit = AuthCubit(
         repository,
         networkInfo: _FakeNetworkInfo(isConnected: true),
@@ -85,6 +95,24 @@ void main() {
       expect(cubit.state.needsReauthentication, isTrue);
       expect(cubit.state.session.accessToken, 'access');
       expect(repository.refreshCallCount, 1);
+    });
+
+    test('online startup invalid refresh token logs the user out', () async {
+      repository.refreshError = const GivtServerFailure(
+        statusCode: 400,
+        body: {'error': 'invalid_grant'},
+      );
+      cubit = AuthCubit(
+        repository,
+        networkInfo: _FakeNetworkInfo(isConnected: true),
+      );
+
+      await cubit.checkAuth(isAppStartupCheck: true);
+
+      expect(cubit.state.status, AuthStatus.unauthenticated);
+      expect(cubit.state.needsReauthentication, isFalse);
+      expect(repository.refreshCallCount, 1);
+      expect(repository.logoutCallCount, 1);
     });
 
     test('offline startup skips refresh and does not require reauth', () async {
@@ -101,19 +129,22 @@ void main() {
       expect(repository.refreshCallCount, 0);
     });
 
-    test('online startup SocketException keeps session without reauth', () async {
-      repository.refreshError = const SocketException('offline');
-      cubit = AuthCubit(
-        repository,
-        networkInfo: _FakeNetworkInfo(isConnected: true),
-      );
+    test(
+      'online startup SocketException keeps session without reauth',
+      () async {
+        repository.refreshError = const SocketException('offline');
+        cubit = AuthCubit(
+          repository,
+          networkInfo: _FakeNetworkInfo(isConnected: true),
+        );
 
-      await cubit.checkAuth(isAppStartupCheck: true);
+        await cubit.checkAuth(isAppStartupCheck: true);
 
-      expect(cubit.state.status, AuthStatus.authenticated);
-      expect(cubit.state.needsReauthentication, isFalse);
-      expect(repository.refreshCallCount, 1);
-    });
+        expect(cubit.state.status, AuthStatus.authenticated);
+        expect(cubit.state.needsReauthentication, isFalse);
+        expect(repository.refreshCallCount, 1);
+      },
+    );
 
     test('non-startup checkAuth does not refresh', () async {
       cubit = AuthCubit(
@@ -149,6 +180,7 @@ class _FakeAuthRepository with AuthRepository {
   Object? refreshError;
   Session? refreshResult;
   int refreshCallCount = 0;
+  int logoutCallCount = 0;
 
   void dispose() {
     _sessionController.close();
@@ -176,7 +208,10 @@ class _FakeAuthRepository with AuthRepository {
       authenticated;
 
   @override
-  Future<bool> logout() async => true;
+  Future<bool> logout() async {
+    logoutCallCount++;
+    return true;
+  }
 
   @override
   Future<bool> checkTld(String email) async => true;
@@ -191,8 +226,7 @@ class _FakeAuthRepository with AuthRepository {
   Future<String> signSepaMandate({
     required String guid,
     required String appLanguage,
-  }) async =>
-      '';
+  }) async => '';
 
   @override
   Future<StripeResponse> fetchStripeSetupIntent() async =>
@@ -202,15 +236,13 @@ class _FakeAuthRepository with AuthRepository {
   Future<UserExt> registerUser({
     required TempUser tempUser,
     required bool isNewUser,
-  }) async =>
-      const UserExt(email: '', guid: '', amountLimit: 0);
+  }) async => const UserExt(email: '', guid: '', amountLimit: 0);
 
   @override
   Future<bool> changeGiftAid({
     required String guid,
     required bool giftAid,
-  }) async =>
-      true;
+  }) async => true;
 
   @override
   Future<bool> unregisterUser({required String email}) async => true;
@@ -219,8 +251,7 @@ class _FakeAuthRepository with AuthRepository {
   Future<bool> updateUser({
     required String guid,
     required Map<String, dynamic> newUserExt,
-  }) async =>
-      true;
+  }) async => true;
 
   @override
   Future<bool> updateUserExt(Map<String, dynamic> newUserExt) async => true;
@@ -228,8 +259,7 @@ class _FakeAuthRepository with AuthRepository {
   @override
   Future<bool> updateLocalUserPresets({
     required UserPresets newUserPresets,
-  }) async =>
-      true;
+  }) async => true;
 
   @override
   Future<void> checkUserExt({required String email}) async {}
@@ -239,8 +269,7 @@ class _FakeAuthRepository with AuthRepository {
     required String guid,
     required String notificationId,
     required bool notificationPermissionStatus,
-  }) async =>
-      true;
+  }) async => true;
 
   @override
   void updateSessionStream(bool hasSession) {

--- a/test/features/auth/cubit/auth_cubit_logout_test.dart
+++ b/test/features/auth/cubit/auth_cubit_logout_test.dart
@@ -1,0 +1,199 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/features/amount_presets/models/models.dart';
+import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
+import 'package:givt_app/features/auth/models/session.dart';
+import 'package:givt_app/features/auth/repositories/auth_repository.dart';
+import 'package:givt_app/shared/models/stripe_response.dart';
+import 'package:givt_app/shared/models/temp_user.dart';
+import 'package:givt_app/shared/models/user_ext.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferences.setMockInitialValues({});
+
+  group('AuthCubit.logout', () {
+    late _LogoutTestAuthRepository repository;
+    late AuthCubit cubit;
+
+    const user = UserExt(
+      email: 'user@givt.app',
+      guid: 'guid-1',
+      amountLimit: 499,
+    );
+
+    Session loggedInSession() => Session(
+      email: user.email,
+      userGUID: user.guid,
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      expires: DateTime.now()
+          .toUtc()
+          .add(const Duration(hours: 1))
+          .toIso8601String(),
+      expiresIn: 3600,
+      isLoggedIn: true,
+    );
+
+    setUp(() {
+      repository = _LogoutTestAuthRepository(
+        authenticated: (user, loggedInSession(), const UserPresets.empty()),
+      );
+      cubit = AuthCubit(repository);
+      cubit.emit(
+        cubit.state.copyWith(
+          status: AuthStatus.authenticated,
+          user: user,
+          session: loggedInSession(),
+        ),
+      );
+    });
+
+    tearDown(() async {
+      await cubit.close();
+      repository.dispose();
+    });
+
+    test('logs out on the first attempt without returning to home', () async {
+      await cubit.logout();
+
+      expect(cubit.state.status, AuthStatus.unauthenticated);
+      expect(cubit.state.needsReauthentication, isFalse);
+      expect(repository.logoutCallCount, 1);
+    });
+
+    test(
+      'session stream false does not re-authenticate a cached session',
+      () async {
+        repository.emitHasSession(false);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(cubit.state.status, AuthStatus.unauthenticated);
+        expect(cubit.state.needsReauthentication, isFalse);
+      },
+    );
+  });
+}
+
+class _LogoutTestAuthRepository with AuthRepository {
+  _LogoutTestAuthRepository({this.authenticated});
+
+  (UserExt, Session, UserPresets)? authenticated;
+  final _sessionController = StreamController<bool>.broadcast();
+  int logoutCallCount = 0;
+
+  void dispose() {
+    _sessionController.close();
+  }
+
+  void emitHasSession(bool hasSession) {
+    _sessionController.add(hasSession);
+  }
+
+  @override
+  Future<Session> refreshToken({bool refreshUserExt = false}) async =>
+      const Session.empty();
+
+  @override
+  Future<Session> login(String email, String password) async =>
+      const Session.empty();
+
+  @override
+  Future<UserExt> fetchUserExtension(String guid) async =>
+      const UserExt(email: '', guid: '', amountLimit: 0);
+
+  @override
+  Future<(UserExt, Session, UserPresets)?> isAuthenticated() async =>
+      authenticated;
+
+  @override
+  Future<bool> logout() async {
+    logoutCallCount++;
+    final current = authenticated;
+    if (current != null) {
+      authenticated = (
+        current.$1,
+        current.$2.copyWith(isLoggedIn: false),
+        current.$3,
+      );
+    }
+    _sessionController.add(false);
+    return true;
+  }
+
+  @override
+  Future<bool> checkTld(String email) async => true;
+
+  @override
+  Future<String> checkEmail(String email) async => '';
+
+  @override
+  Future<bool> resetPassword(String email) async => true;
+
+  @override
+  Future<String> signSepaMandate({
+    required String guid,
+    required String appLanguage,
+  }) async => '';
+
+  @override
+  Future<StripeResponse> fetchStripeSetupIntent() async =>
+      const StripeResponse.empty();
+
+  @override
+  Future<UserExt> registerUser({
+    required TempUser tempUser,
+    required bool isNewUser,
+  }) async => const UserExt(email: '', guid: '', amountLimit: 0);
+
+  @override
+  Future<bool> changeGiftAid({
+    required String guid,
+    required bool giftAid,
+  }) async => true;
+
+  @override
+  Future<bool> unregisterUser({required String email}) async => true;
+
+  @override
+  Future<bool> updateUser({
+    required String guid,
+    required Map<String, dynamic> newUserExt,
+  }) async => true;
+
+  @override
+  Future<bool> updateUserExt(Map<String, dynamic> newUserExt) async => true;
+
+  @override
+  Future<bool> updateLocalUserPresets({
+    required UserPresets newUserPresets,
+  }) async => true;
+
+  @override
+  Future<void> checkUserExt({required String email}) async {}
+
+  @override
+  Future<bool> updateNotificationId({
+    required String guid,
+    required String notificationId,
+    required bool notificationPermissionStatus,
+  }) async => true;
+
+  @override
+  void updateSessionStream(bool hasSession) {
+    if (!_sessionController.isClosed) {
+      _sessionController.add(hasSession);
+    }
+  }
+
+  @override
+  Stream<bool> hasSessionStream() => _sessionController.stream;
+
+  @override
+  void setHasSessionInitialValue(bool hasSession) {}
+
+  @override
+  Future<Session> getStoredSession() async => const Session.empty();
+}

--- a/test/features/auth/cubit/auth_cubit_refresh_session_test.dart
+++ b/test/features/auth/cubit/auth_cubit_refresh_session_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/core/failures/failures.dart';
 import 'package:givt_app/features/amount_presets/models/models.dart';
 import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/features/auth/models/session.dart';
@@ -176,6 +177,34 @@ void main() {
       expect(result, RefreshSessionResult.success);
       expect(repository.refreshCallCount, 1);
     });
+
+    test('logs the user out when the refresh token is invalid', () async {
+      repository.refreshError = const GivtServerFailure(
+        statusCode: 400,
+        body: {'error': 'invalid_grant'},
+      );
+      cubit.emit(
+        cubit.state.copyWith(
+          status: AuthStatus.authenticated,
+          session: Session(
+            email: 'user@example.com',
+            userGUID: 'guid',
+            accessToken: 'old-access',
+            refreshToken: 'old-refresh',
+            expires: '2000-01-01T00:00:00.000Z',
+            expiresIn: 0,
+            isLoggedIn: true,
+          ),
+        ),
+      );
+
+      final result = await cubit.refreshSession(emitAuthentication: false);
+
+      expect(result, RefreshSessionResult.invalidRefreshToken);
+      expect(cubit.state.status, AuthStatus.unauthenticated);
+      expect(cubit.state.needsReauthentication, isFalse);
+      expect(repository.logoutCallCount, 1);
+    });
   });
 }
 
@@ -185,6 +214,7 @@ class _RefreshTestAuthRepository with AuthRepository {
   Session? refreshResult;
   Object? refreshError;
   int refreshCallCount = 0;
+  int logoutCallCount = 0;
 
   Future<void> dispose() async {
     await _sessionController.close();
@@ -211,7 +241,10 @@ class _RefreshTestAuthRepository with AuthRepository {
   Future<(UserExt, Session, UserPresets)?> isAuthenticated() async => null;
 
   @override
-  Future<bool> logout() async => true;
+  Future<bool> logout() async {
+    logoutCallCount++;
+    return true;
+  }
 
   @override
   Future<bool> checkTld(String email) async => true;

--- a/test/features/auth/models/auth_gate_test.dart
+++ b/test/features/auth/models/auth_gate_test.dart
@@ -51,7 +51,7 @@ void main() {
     });
 
     test(
-      'prompts biometrics when reauthentication is needed even within grace',
+      'silently refreshes when reauthentication is needed even within grace',
       () {
         expect(
           AuthGate.decide(
@@ -60,7 +60,7 @@ void main() {
             isWithinLocalAuthGrace: true,
             needsReauthentication: true,
           ),
-          AuthGateAction.promptBiometrics,
+          AuthGateAction.silentRefresh,
         );
       },
     );

--- a/test/utils/auth_utils_auth_gate_test.dart
+++ b/test/utils/auth_utils_auth_gate_test.dart
@@ -8,6 +8,7 @@ import 'package:givt_app/core/network/network_info.dart';
 import 'package:givt_app/features/amount_presets/models/models.dart';
 import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/features/auth/models/session.dart';
+import 'package:givt_app/features/auth/pages/login_page.dart';
 import 'package:givt_app/features/auth/repositories/auth_repository.dart';
 import 'package:givt_app/l10n/arb/app_localizations.dart';
 import 'package:givt_app/shared/models/stripe_response.dart';
@@ -177,7 +178,7 @@ void main() {
     );
 
     testWidgets(
-      'stepUp does not navigate when reauthentication is needed within grace',
+      'stepUp refreshes then navigates when reauthentication is needed within grace',
       (tester) async {
         await repository.markLocalAuthSucceeded();
         cubit.emit(
@@ -191,7 +192,30 @@ void main() {
 
         await runCheckToken(tester, policy: CheckAuthPolicy.stepUp);
 
+        expect(cubit.refreshCallCount, 1);
+        expect(navigateCount, 1);
+      },
+    );
+
+    testWidgets(
+      'ensureSession does not show login when refresh token is invalid',
+      (tester) async {
+        cubit
+          ..emit(
+            cubit.state.copyWith(
+              status: AuthStatus.authenticated,
+              user: user,
+              session: validSession(),
+              needsReauthentication: true,
+            ),
+          )
+          ..refreshResult = RefreshSessionResult.invalidRefreshToken;
+
+        await runCheckToken(tester);
+
+        expect(cubit.refreshCallCount, 1);
         expect(navigateCount, 0);
+        expect(find.byType(LoginPage), findsNothing);
       },
     );
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses Donna’s ENG-1143 test feedback on the short-lived token account (`donna+hacktoken@givtapp.net`), and the related first-attempt logout bounce in ENG-1323.

When the OAuth refresh token is rejected (`invalid_grant`):
- the user is **logged out** instead of staying “logged in” with `needsReauthentication`
- Face ID / the dismissible login bottom sheet no longer loop when opening or closing the menu
- app-open Face ID no longer fires just to keep a dead session alive

Also fixes logout racing the session stream: persist `isLoggedIn: false` before notifying listeners, and do not emit `loading` during logout (that redirected the router to splash and back to home).

The expected session behaviour is documented on `AuthCubit`, `AuthGate`, `AuthUtils.checkToken`, logout, HomePage, and in `AGENTS.md` (EU auth session) so later changes do not reintroduce Face ID / login-sheet loops or the first-tap logout bounce.

Branched from current `develop` (includes #1910 offline banner). No overlap with those changes.

## Test plan

- [x] Unit tests for `GivtServerFailure.isInvalidGrant`
- [x] Unit tests for startup invalid grant → logout
- [x] Unit tests for `refreshSession` invalid grant → logout
- [x] Unit tests for logout not re-authenticating from a cached session
- [x] AuthGate `stepUp` refreshes before Face ID when the token is expired / reauth is needed
- [x] `AuthUtils.checkToken` does not show login when refresh token is invalid
- [x] Ran the auth-related suite locally: **38 tests passed**
- [ ] Manual: Donna’s test account, Face ID on, wait 15+ min, open app / open menu — should land on welcome, not Face ID + login sheet
- [ ] Manual: logout from the menu on the first tap (ENG-1323)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-933f8b1d-ffc2-42c8-82b7-13977c58000a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-933f8b1d-ffc2-42c8-82b7-13977c58000a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

