### PR TITLE
Logout on empty OAuth 400/401 refresh (ENG-1143)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ When a task mentions “EU” or “US” (or “family”), work in the corresp
 Contract lives in code on [`AuthCubit`](lib/features/auth/cubit/auth_cubit.dart), [`AuthGate`](lib/features/auth/models/auth_gate.dart), and [`AuthUtils.checkToken`](lib/utils/auth_utils.dart). Do not regress this:
 
 - **Online app open:** silent OAuth refresh. Success stays on home.
-- **Invalid refresh token** (`invalid_grant`): **logout** (welcome). Never Face ID, never a dismissible login sheet, never `needsReauthentication`.
+- **Invalid refresh token** (`invalid_grant`, or HTTP 400/401 with an empty body from `/oauth2/token`): **logout** (welcome). Never Face ID, never a dismissible login sheet, never `needsReauthentication`. Do not send a Bearer access token to `/oauth2/token`.
 - **Other refresh failure** (server error): stay logged in, set `needsReauthentication`, prompt biometrics/login from Home **init/resume** (not from `build` — drawer open/close rebuilds).
 - **Offline:** keep local session; no popup. Giving may continue with `allowWhenOffline: true`.
 - **Protected menu items** (`CheckAuthPolicy.stepUp`): refresh expired/reauth sessions **before** Face ID so a dead refresh token logs out instead of scanning. Face ID only when the 15-minute local-auth grace has elapsed.

--- a/lib/core/failures/failure.dart
+++ b/lib/core/failures/failure.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: constant_identifier_names
 
+import 'dart:convert';
+
 import 'package:equatable/equatable.dart';
 
 class GivtServerFailure extends Equatable implements Exception {
@@ -7,6 +9,18 @@ class GivtServerFailure extends Equatable implements Exception {
     required this.statusCode,
     this.body,
   });
+
+  /// Builds a failure from an HTTP error response. An empty or non-JSON body
+  /// (common for `/oauth2/token` 400/401) must not throw [FormatException].
+  factory GivtServerFailure.fromHttpResponse({
+    required int statusCode,
+    required String body,
+  }) {
+    return GivtServerFailure(
+      statusCode: statusCode,
+      body: _tryDecodeJsonMap(body),
+    );
+  }
 
   final int statusCode;
   final Map<String, dynamic>? body;
@@ -29,8 +43,33 @@ class GivtServerFailure extends Equatable implements Exception {
     return body?.toString().contains('invalid_grant') ?? false;
   }
 
+  /// Refresh cannot continue: JSON `invalid_grant`, or a 400/401 from the
+  /// token endpoint (often with an empty body). Callers must log the user
+  /// out instead of showing a dismissible login sheet.
+  bool get isRejectedOAuthToken {
+    if (isInvalidGrant) {
+      return true;
+    }
+    return statusCode == 400 || statusCode == 401;
+  }
+
   @override
   List<Object> get props => [statusCode, type];
+}
+
+Map<String, dynamic>? _tryDecodeJsonMap(String body) {
+  if (body.isEmpty) {
+    return null;
+  }
+  try {
+    final decoded = jsonDecode(body);
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+    return {'raw': decoded.toString()};
+  } on FormatException {
+    return {'raw': body};
+  }
 }
 
 enum FailureType {

--- a/lib/core/network/api_service.dart
+++ b/lib/core/network/api_service.dart
@@ -45,9 +45,9 @@ class APIService {
       encoding: Encoding.getByName('utf-8'),
     );
     if (response.statusCode >= 400) {
-      throw GivtServerFailure(
+      throw GivtServerFailure.fromHttpResponse(
         statusCode: response.statusCode,
-        body: jsonDecode(response.body) as Map<String, dynamic>,
+        body: response.body,
       );
     } else {
       return jsonDecode(response.body) as Map<String, dynamic>;
@@ -800,7 +800,9 @@ class APIService {
     return decodedBody['item'] as bool? ?? false;
   }
 
-  Future<ExternalDonation?> addExternalDonation(Map<String, dynamic> body) async {
+  Future<ExternalDonation?> addExternalDonation(
+    Map<String, dynamic> body,
+  ) async {
     final url = Uri.https(_apiURL, '/givtservice/v1/externaldonations');
 
     final response = await client.post(

--- a/lib/core/network/token_interceptor.dart
+++ b/lib/core/network/token_interceptor.dart
@@ -31,7 +31,12 @@ class TokenInterceptor implements InterceptorContract {
         jsonDecode(sessionString) as Map<String, dynamic>,
       );
 
-      if (session.accessToken.isNotEmpty) {
+      // `/oauth2/token` authenticates via grant_type + refresh_token in the
+      // body. A Bearer access token (especially an expired one) makes the
+      // gateway return 401 with an empty body, which used to skip logout
+      // and show a dismissible login sheet instead.
+      final isOAuthTokenRequest = request.url.path.contains('/oauth2/token');
+      if (!isOAuthTokenRequest && session.accessToken.isNotEmpty) {
         request.headers['Authorization'] = 'Bearer ${session.accessToken}';
       }
     } catch (e, stackTrace) {
@@ -55,8 +60,7 @@ class TokenInterceptor implements InterceptorContract {
   @override
   Future<BaseResponse> interceptResponse({
     required BaseResponse response,
-  }) async =>
-      response;
+  }) async => response;
 
   @override
   Future<bool> shouldInterceptRequest() => Future.value(true);

--- a/lib/features/auth/cubit/auth_cubit.dart
+++ b/lib/features/auth/cubit/auth_cubit.dart
@@ -23,7 +23,8 @@ part 'auth_state.dart';
 ///
 /// Expected behaviour (online unless noted):
 /// * **App open:** silent refresh. Success keeps the user on home.
-/// * **Refresh token rejected** (`invalid_grant`): [logout]. Do not keep a
+/// * **Refresh token rejected** (`invalid_grant`, or HTTP 400/401 from
+///   `/oauth2/token` — often an empty body): [logout]. Do not keep a
 ///   local session, do not set [AuthState.needsReauthentication], do not
 ///   prompt Face ID, and do not show a dismissible login sheet.
 /// * **Refresh fails for another reason** (e.g. server error): stay
@@ -54,11 +55,15 @@ class AuthCubit extends Cubit<AuthState> {
 
   bool get _isOnline => _networkInfo?.isConnected ?? true;
 
-  /// True when OAuth `/oauth2/token` rejected the refresh token.
-  /// That is a permanent session failure: the user must log in again.
+  /// True when OAuth `/oauth2/token` rejected the session (expired/revoked
+  /// refresh token). The token endpoint often returns 400/401 with an empty
+  /// body instead of JSON `invalid_grant` — that must still log the user out.
   bool _isInvalidGrant(Object error) {
     if (error is GivtServerFailure) {
-      return error.isInvalidGrant;
+      return error.isRejectedOAuthToken;
+    }
+    if (error is FormatException) {
+      return true;
     }
     return error.toString().contains('invalid_grant');
   }

--- a/test/core/failures/givt_server_failure_test.dart
+++ b/test/core/failures/givt_server_failure_test.dart
@@ -26,5 +26,28 @@ void main() {
 
       expect(failure.isInvalidGrant, isFalse);
     });
+
+    test('fromHttpResponse accepts an empty body', () {
+      final failure = GivtServerFailure.fromHttpResponse(
+        statusCode: 401,
+        body: '',
+      );
+
+      expect(failure.body, isNull);
+      expect(failure.isInvalidGrant, isFalse);
+      expect(failure.isRejectedOAuthToken, isTrue);
+    });
+
+    test('isRejectedOAuthToken is true for 400 without JSON error', () {
+      const failure = GivtServerFailure(statusCode: 400);
+
+      expect(failure.isRejectedOAuthToken, isTrue);
+    });
+
+    test('isRejectedOAuthToken is false for server errors', () {
+      const failure = GivtServerFailure(statusCode: 500);
+
+      expect(failure.isRejectedOAuthToken, isFalse);
+    });
   });
 }

--- a/test/core/network/token_interceptor_test.dart
+++ b/test/core/network/token_interceptor_test.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/core/network/token_interceptor.dart';
+import 'package:givt_app/features/auth/models/session.dart';
+import 'package:http/http.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final sessionJson = jsonEncode({
+    'Email': 'user@givt.app',
+    'GUID': 'guid-1',
+    'access_token': 'access-token',
+    'refresh_token': 'refresh-token',
+    '.expires': DateTime.now().toUtc().toIso8601String(),
+    'isLoggedIn': true,
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({
+      Session.tag: sessionJson,
+    });
+  });
+
+  test('does not attach Bearer to /oauth2/token', () async {
+    final request = Request(
+      'POST',
+      Uri.https('dev-backend.givtapp.net', '/oauth2/token'),
+    );
+
+    final intercepted = await TokenInterceptor().interceptRequest(
+      request: request,
+    );
+
+    expect(intercepted.headers['Authorization'], isNull);
+  });
+
+  test('attaches Bearer to API requests', () async {
+    final request = Request(
+      'GET',
+      Uri.https('dev-backend.givtapp.net', '/api/v2/UsersExtension/guid-1'),
+    );
+
+    final intercepted = await TokenInterceptor().interceptRequest(
+      request: request,
+    );
+
+    expect(intercepted.headers['Authorization'], 'Bearer access-token');
+  });
+}

--- a/test/features/auth/auth_cubit_startup_reauth_test.dart
+++ b/test/features/auth/auth_cubit_startup_reauth_test.dart
@@ -115,6 +115,39 @@ void main() {
       expect(repository.logoutCallCount, 1);
     });
 
+    test('online startup empty 401 body logs the user out', () async {
+      repository.refreshError = const GivtServerFailure(statusCode: 401);
+      cubit = AuthCubit(
+        repository,
+        networkInfo: _FakeNetworkInfo(isConnected: true),
+      );
+
+      await cubit.checkAuth(isAppStartupCheck: true);
+
+      expect(cubit.state.status, AuthStatus.unauthenticated);
+      expect(cubit.state.needsReauthentication, isFalse);
+      expect(repository.logoutCallCount, 1);
+    });
+
+    test(
+      'online startup empty-body FormatException logs the user out',
+      () async {
+        repository.refreshError = const FormatException(
+          'Unexpected end of input',
+        );
+        cubit = AuthCubit(
+          repository,
+          networkInfo: _FakeNetworkInfo(isConnected: true),
+        );
+
+        await cubit.checkAuth(isAppStartupCheck: true);
+
+        expect(cubit.state.status, AuthStatus.unauthenticated);
+        expect(cubit.state.needsReauthentication, isFalse);
+        expect(repository.logoutCallCount, 1);
+      },
+    );
+
     test('offline startup skips refresh and does not require reauth', () async {
       repository.refreshError = Exception('should not be called');
       cubit = AuthCubit(

--- a/test/features/auth/cubit/auth_cubit_refresh_session_test.dart
+++ b/test/features/auth/cubit/auth_cubit_refresh_session_test.dart
@@ -205,6 +205,30 @@ void main() {
       expect(cubit.state.needsReauthentication, isFalse);
       expect(repository.logoutCallCount, 1);
     });
+
+    test('logs the user out when refresh returns empty 401', () async {
+      repository.refreshError = const GivtServerFailure(statusCode: 401);
+      cubit.emit(
+        cubit.state.copyWith(
+          status: AuthStatus.authenticated,
+          session: Session(
+            email: 'user@example.com',
+            userGUID: 'guid',
+            accessToken: 'old-access',
+            refreshToken: 'old-refresh',
+            expires: '2000-01-01T00:00:00.000Z',
+            expiresIn: 0,
+            isLoggedIn: true,
+          ),
+        ),
+      );
+
+      final result = await cubit.refreshSession(emitAuthentication: false);
+
+      expect(result, RefreshSessionResult.invalidRefreshToken);
+      expect(cubit.state.status, AuthStatus.unauthenticated);
+      expect(repository.logoutCallCount, 1);
+    });
   });
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Maikel reproduced Donna’s 15-minute token expiry on 6.5.1 (Pixel, Android). PostHog logs show:

```
Refreshing session on app startup
Session refresh failed on app startup: FormatException: Unexpected end of input
Refreshing session
Session refresh failed, biometrics not available, displaying login bottom sheet.
```

`/oauth2/token` returned 400/401 with an **empty body**. `jsonDecode('')` threw `FormatException`, so we never classified it as `invalid_grant`, stayed “logged in”, and showed the dismissible login sheet.

This PR:
- Parses empty/non-JSON token error bodies without throwing
- Treats HTTP 400/401 on refresh as a dead session → **logout** (welcome), not a sheet
- Stops sending `Authorization: Bearer` to `/oauth2/token` (expired access tokens were likely the empty 401)

## Test plan

- [x] `GivtServerFailure.fromHttpResponse` empty 401
- [x] Startup empty 401 / `FormatException` → logout
- [x] `refreshSession` empty 401 → logout
- [x] Token interceptor does not attach Bearer to `/oauth2/token`
- [x] Auth-related unit tests: **32 passed**
- [ ] Manual: Donna account, wait 15+ min, open app → welcome/login **screen**, not a dismissible sheet
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-933f8b1d-ffc2-42c8-82b7-13977c58000a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-933f8b1d-ffc2-42c8-82b7-13977c58000a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

