### PR TITLE
Restore Bearer on OAuth refresh (ENG-1143)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,8 @@ When a task mentions “EU” or “US” (or “family”), work in the corresp
 
 Contract lives in code on [`AuthCubit`](lib/features/auth/cubit/auth_cubit.dart), [`AuthGate`](lib/features/auth/models/auth_gate.dart), and [`AuthUtils.checkToken`](lib/utils/auth_utils.dart). Do not regress this:
 
-- **Online app open:** silent OAuth refresh. Success stays on home.
-- **Invalid refresh token** (`invalid_grant`, or HTTP 400/401 with an empty body from `/oauth2/token`): **logout** (welcome). Never Face ID, never a dismissible login sheet, never `needsReauthentication`. Do not send a Bearer access token to `/oauth2/token`.
+- **Online app open:** silent OAuth refresh. Success stays on home. After access-token expiry the refresh token can still be valid (short-lived test account: access ~5 min, refresh ~15 min) — stay logged in.
+- **Invalid refresh token** (`invalid_grant`, or HTTP 400/401 with an empty body from `/oauth2/token`): **logout** (welcome). Never Face ID, never a dismissible login sheet, never `needsReauthentication`. Still send `Authorization: Bearer` on `/oauth2/token`; omitting it returns the same empty 400/401 while the refresh token is valid.
 - **Other refresh failure** (server error): stay logged in, set `needsReauthentication`, prompt biometrics/login from Home **init/resume** (not from `build` — drawer open/close rebuilds).
 - **Offline:** keep local session; no popup. Giving may continue with `allowWhenOffline: true`.
 - **Protected menu items** (`CheckAuthPolicy.stepUp`): refresh expired/reauth sessions **before** Face ID so a dead refresh token logs out instead of scanning. Face ID only when the 15-minute local-auth grace has elapsed.

--- a/lib/core/failures/failure.dart
+++ b/lib/core/failures/failure.dart
@@ -44,8 +44,10 @@ class GivtServerFailure extends Equatable implements Exception {
   }
 
   /// Refresh cannot continue: JSON `invalid_grant`, or a 400/401 from the
-  /// token endpoint (often with an empty body). Callers must log the user
-  /// out instead of showing a dismissible login sheet.
+  /// token endpoint (often with an empty body). Reliable only when the
+  /// request sent `Authorization: Bearer` — without it, a still-valid
+  /// refresh token produces the same empty 400/401. Callers must log the
+  /// user out instead of showing a dismissible login sheet.
   bool get isRejectedOAuthToken {
     if (isInvalidGrant) {
       return true;
@@ -55,6 +57,10 @@ class GivtServerFailure extends Equatable implements Exception {
 
   @override
   List<Object> get props => [statusCode, type];
+
+  @override
+  String toString() =>
+      'GivtServerFailure(statusCode: $statusCode, body: $body)';
 }
 
 Map<String, dynamic>? _tryDecodeJsonMap(String body) {

--- a/lib/core/network/token_interceptor.dart
+++ b/lib/core/network/token_interceptor.dart
@@ -31,12 +31,12 @@ class TokenInterceptor implements InterceptorContract {
         jsonDecode(sessionString) as Map<String, dynamic>,
       );
 
-      // `/oauth2/token` authenticates via grant_type + refresh_token in the
-      // body. A Bearer access token (especially an expired one) makes the
-      // gateway return 401 with an empty body, which used to skip logout
-      // and show a dismissible login sheet instead.
-      final isOAuthTokenRequest = request.url.path.contains('/oauth2/token');
-      if (!isOAuthTokenRequest && session.accessToken.isNotEmpty) {
+      // Send Bearer on every authenticated request, including `/oauth2/token`.
+      // The refresh_token grant still requires it: omitting Authorization
+      // returns HTTP 400/401 with an empty body even when the refresh token
+      // is valid. A *dead* refresh token returns the same empty 400/401;
+      // [GivtServerFailure.isRejectedOAuthToken] turns that into logout.
+      if (session.accessToken.isNotEmpty) {
         request.headers['Authorization'] = 'Bearer ${session.accessToken}';
       }
     } catch (e, stackTrace) {

--- a/lib/features/auth/cubit/auth_cubit.dart
+++ b/lib/features/auth/cubit/auth_cubit.dart
@@ -24,9 +24,10 @@ part 'auth_state.dart';
 /// Expected behaviour (online unless noted):
 /// * **App open:** silent refresh. Success keeps the user on home.
 /// * **Refresh token rejected** (`invalid_grant`, or HTTP 400/401 from
-///   `/oauth2/token` — often an empty body): [logout]. Do not keep a
-///   local session, do not set [AuthState.needsReauthentication], do not
-///   prompt Face ID, and do not show a dismissible login sheet.
+///   `/oauth2/token` — often an empty body, with Bearer still sent):
+///   [logout]. Do not keep a local session, do not set
+///   [AuthState.needsReauthentication], do not prompt Face ID, and do
+///   not show a dismissible login sheet.
 /// * **Refresh fails for another reason** (e.g. server error): stay
 ///   authenticated and set [AuthState.needsReauthentication] so Home / give
 ///   can prompt biometrics or login.

--- a/test/core/failures/givt_server_failure_test.dart
+++ b/test/core/failures/givt_server_failure_test.dart
@@ -49,5 +49,17 @@ void main() {
 
       expect(failure.isRejectedOAuthToken, isFalse);
     });
+
+    test('toString includes statusCode and body', () {
+      const failure = GivtServerFailure(
+        statusCode: 401,
+        body: {'error': 'invalid_grant'},
+      );
+
+      expect(
+        failure.toString(),
+        'GivtServerFailure(statusCode: 401, body: {error: invalid_grant})',
+      );
+    });
   });
 }

--- a/test/core/network/token_interceptor_test.dart
+++ b/test/core/network/token_interceptor_test.dart
@@ -24,7 +24,7 @@ void main() {
     });
   });
 
-  test('does not attach Bearer to /oauth2/token', () async {
+  test('attaches Bearer to /oauth2/token', () async {
     final request = Request(
       'POST',
       Uri.https('dev-backend.givtapp.net', '/oauth2/token'),
@@ -34,7 +34,7 @@ void main() {
       request: request,
     );
 
-    expect(intercepted.headers['Authorization'], isNull);
+    expect(intercepted.headers['Authorization'], 'Bearer access-token');
   });
 
   test('attaches Bearer to API requests', () async {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Empty 400/401 from `/oauth2/token` **was** the 15-minute bug (dead refresh → login sheet). That handling stays.

#1912 also stopped sending `Authorization: Bearer` on `/oauth2/token`. That made a **still-valid** refresh token return the same empty 400/401, so the short-lived test account logged out at **5 minutes** (access expiry) and even ~14 seconds after login on resume.

This PR:

- Sends Bearer on `/oauth2/token` again so silent refresh can succeed while the refresh token is valid (~15 min)
- Keeps empty 400/401 and JSON `invalid_grant` as **logout** (welcome screen, not a dismissible sheet)
- Logs `statusCode` and `body` on `GivtServerFailure` so the next PostHog trace is diagnosable

Expected on `donna+hacktoken@givtapp.net`:

| Time | Tokens | UX |
|------|--------|----|
| &lt; 5 min | access + refresh valid | stay in |
| 5–15 min | access expired, refresh valid | silent refresh, stay in |
| ≥ 15 min | refresh dead, empty 400/401 | logout → welcome/login **screen** |

## Test plan

- [x] Interceptor attaches Bearer to `/oauth2/token`
- [x] Empty 401 / `invalid_grant` still logout (existing tests)
- [x] Unit tests on this branch: **27 passed**
- [ ] Manual: hacktoken account — open at ~5 min stays logged in; open at ~15 min goes to welcome, not the login sheet

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-933f8b1d-ffc2-42c8-82b7-13977c58000a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-933f8b1d-ffc2-42c8-82b7-13977c58000a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

