### PR TITLE
Rename pledge detail Transactions label to Donations (ENG-1169)

### DIFF
--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -942,7 +942,7 @@
   },
   "pledgesDetailEditButton": "Zusage bearbeiten",
   "pledgesDetailEndsLabel": "Endet",
-  "pledgesDetailTransactionsLabel": "Transaktionen",
+  "pledgesDetailTransactionsLabel": "Spenden",
   "pledgesEditRequestTitle": "Zusageänderung anfragen",
   "pledgesEditRequestBody": "Du kannst deine Zusage noch nicht selbst ändern. Sag uns, was du ändern möchtest, und wir melden uns bei dir.",
   "pledgesEditRequestPrefilledText": "Ich möchte meine Zusage ändern:",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -941,7 +941,7 @@
   },
   "pledgesDetailEditButton": "Edit pledge",
   "pledgesDetailEndsLabel": "Ends",
-  "pledgesDetailTransactionsLabel": "Transactions",
+  "pledgesDetailTransactionsLabel": "Donations",
   "pledgesEditRequestTitle": "Request a pledge change",
   "pledgesEditRequestBody": "You can't change your pledge yourself yet. Tell us what you'd like to change and we'll get back to you.",
   "pledgesEditRequestPrefilledText": "I'd like to change my pledge:",

--- a/lib/l10n/arb/app_en_US.arb
+++ b/lib/l10n/arb/app_en_US.arb
@@ -937,7 +937,7 @@
   },
   "pledgesDetailEditButton": "Edit pledge",
   "pledgesDetailEndsLabel": "Ends",
-  "pledgesDetailTransactionsLabel": "Transactions",
+  "pledgesDetailTransactionsLabel": "Donations",
   "pledgesEditRequestTitle": "Request a pledge change",
   "pledgesEditRequestBody": "You can't change your pledge yourself yet. Tell us what you'd like to change and we'll get back to you.",
   "pledgesEditRequestPrefilledText": "I'd like to change my pledge:",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -942,7 +942,7 @@
   },
   "pledgesDetailEditButton": "Editar compromiso",
   "pledgesDetailEndsLabel": "Finaliza",
-  "pledgesDetailTransactionsLabel": "Transacciones",
+  "pledgesDetailTransactionsLabel": "Donaciones",
   "pledgesEditRequestTitle": "Solicitar un cambio de compromiso",
   "pledgesEditRequestBody": "Aún no puedes cambiar tu compromiso tú mismo. Cuéntanos qué te gustaría cambiar y nos pondremos en contacto contigo.",
   "pledgesEditRequestPrefilledText": "Me gustaría cambiar mi compromiso:",

--- a/lib/l10n/arb/app_es_419.arb
+++ b/lib/l10n/arb/app_es_419.arb
@@ -937,7 +937,7 @@
   },
   "pledgesDetailEditButton": "Editar compromiso",
   "pledgesDetailEndsLabel": "Finaliza",
-  "pledgesDetailTransactionsLabel": "Transacciones",
+  "pledgesDetailTransactionsLabel": "Donaciones",
   "pledgesEditRequestTitle": "Solicitar un cambio de compromiso",
   "pledgesEditRequestBody": "Aún no puedes cambiar tu compromiso tú mismo. Cuéntanos qué te gustaría cambiar y nos pondremos en contacto contigo.",
   "pledgesEditRequestPrefilledText": "Me gustaría cambiar mi compromiso:",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -2316,7 +2316,7 @@ abstract class AppLocalizations {
   /// No description provided for @pledgesDetailTransactionsLabel.
   ///
   /// In en, this message translates to:
-  /// **'Transactions'**
+  /// **'Donations'**
   String get pledgesDetailTransactionsLabel;
 
   /// No description provided for @pledgesEditRequestTitle.

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -1276,7 +1276,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get pledgesDetailEndsLabel => 'Endet';
 
   @override
-  String get pledgesDetailTransactionsLabel => 'Transaktionen';
+  String get pledgesDetailTransactionsLabel => 'Spenden';
 
   @override
   String get pledgesEditRequestTitle => 'Zusageänderung anfragen';

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -1267,7 +1267,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pledgesDetailEndsLabel => 'Ends';
 
   @override
-  String get pledgesDetailTransactionsLabel => 'Transactions';
+  String get pledgesDetailTransactionsLabel => 'Donations';
 
   @override
   String get pledgesEditRequestTitle => 'Request a pledge change';
@@ -4821,7 +4821,7 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
   String get pledgesDetailEndsLabel => 'Ends';
 
   @override
-  String get pledgesDetailTransactionsLabel => 'Transactions';
+  String get pledgesDetailTransactionsLabel => 'Donations';
 
   @override
   String get pledgesEditRequestTitle => 'Request a pledge change';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -1267,7 +1267,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get pledgesDetailEndsLabel => 'Finaliza';
 
   @override
-  String get pledgesDetailTransactionsLabel => 'Transacciones';
+  String get pledgesDetailTransactionsLabel => 'Donaciones';
 
   @override
   String get pledgesEditRequestTitle => 'Solicitar un cambio de compromiso';
@@ -4842,7 +4842,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get pledgesDetailEndsLabel => 'Finaliza';
 
   @override
-  String get pledgesDetailTransactionsLabel => 'Transacciones';
+  String get pledgesDetailTransactionsLabel => 'Donaciones';
 
   @override
   String get pledgesEditRequestTitle => 'Solicitar un cambio de compromiso';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -1271,7 +1271,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get pledgesDetailEndsLabel => 'Eindigt';
 
   @override
-  String get pledgesDetailTransactionsLabel => 'Transacties';
+  String get pledgesDetailTransactionsLabel => 'Donaties';
 
   @override
   String get pledgesEditRequestTitle => 'Toezegging wijzigen aanvragen';

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -942,7 +942,7 @@
   },
   "pledgesDetailEditButton": "Toezegging bewerken",
   "pledgesDetailEndsLabel": "Eindigt",
-  "pledgesDetailTransactionsLabel": "Transacties",
+  "pledgesDetailTransactionsLabel": "Donaties",
   "pledgesEditRequestTitle": "Toezegging wijzigen aanvragen",
   "pledgesEditRequestBody": "Je kunt je toezegging nog niet zelf wijzigen. Laat ons weten wat je wilt veranderen, dan nemen we contact met je op.",
   "pledgesEditRequestPrefilledText": "Ik wil mijn toezegging wijzigen:",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Changes the pledge detail summary tile subtitle from **Transactions** to **Donations** (Dutch **Donaties**).
- Scope is the existing `pledgesDetailTransactionsLabel` key only. Dart identifiers, API fields, overview, history, and other pledge copy are unchanged.

## Linear
[ENG-1169](https://linear.app/givt/issue/ENG-1169/adjust-the-word-transactions-in-the-pledge-detail-screen)

## Test plan
- [x] `flutter gen-l10n`
- [x] `flutter analyze` on l10n + `pledge_detail_summary_tiles.dart`
- [x] `flutter test test/features/pledges/` (29 passed)
- Browser / device screenshot skipped (Flutter native, copy-only i18n, no layout change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d75ab47-ae4f-4d30-a690-0396ce2c86de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d75ab47-ae4f-4d30-a690-0396ce2c86de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

