### PR TITLE
Stop attaching deactivated QR on For You continue (ENG-718)

### DIFF
--- a/lib/features/give/models/for_you_flow_context.dart
+++ b/lib/features/give/models/for_you_flow_context.dart
@@ -16,40 +16,9 @@ class ForYouFlowContext extends Equatable {
     this.selectedOrganisation,
     this.entryMediumId,
     this.restrictToEntryQrGoal = false,
+    this.giveViaListOnly = false,
     this.initialAmount,
   });
-
-  final ForYouEntrySource source;
-  final CollectGroup? selectedOrganisation;
-  final String? entryMediumId;
-  final bool restrictToEntryQrGoal;
-  final double? initialAmount;
-
-  ForYouFlowContext copyWith({
-    ForYouEntrySource? source,
-    CollectGroup? selectedOrganisation,
-    String? entryMediumId,
-    bool? restrictToEntryQrGoal,
-    double? initialAmount,
-  }) {
-    return ForYouFlowContext(
-      source: source ?? this.source,
-      selectedOrganisation: selectedOrganisation ?? this.selectedOrganisation,
-      entryMediumId: entryMediumId ?? this.entryMediumId,
-      restrictToEntryQrGoal: restrictToEntryQrGoal ?? this.restrictToEntryQrGoal,
-      initialAmount: initialAmount ?? this.initialAmount,
-    );
-  }
-
-  Map<String, dynamic> toMap() {
-    return <String, dynamic>{
-      'source': source.name,
-      'selectedOrganisation': selectedOrganisation?.toJson(),
-      'entryMediumId': entryMediumId,
-      'restrictToEntryQrGoal': restrictToEntryQrGoal,
-      'initialAmount': initialAmount,
-    };
-  }
 
   factory ForYouFlowContext.fromMap(Map<String, dynamic> map) {
     final sourceName = map['source'] as String?;
@@ -64,7 +33,9 @@ class ForYouFlowContext extends Equatable {
         : null;
 
     final entryMediumId = map['entryMediumId'] as String?;
-    final restrictToEntryQrGoal = map['restrictToEntryQrGoal'] as bool? ?? false;
+    final restrictToEntryQrGoal =
+        map['restrictToEntryQrGoal'] as bool? ?? false;
+    final giveViaListOnly = map['giveViaListOnly'] as bool? ?? false;
     final initialAmountRaw = map['initialAmount'];
     final initialAmount = initialAmountRaw is num
         ? initialAmountRaw.toDouble()
@@ -75,8 +46,59 @@ class ForYouFlowContext extends Equatable {
       selectedOrganisation: selectedOrganisation,
       entryMediumId: entryMediumId,
       restrictToEntryQrGoal: restrictToEntryQrGoal,
+      giveViaListOnly: giveViaListOnly,
       initialAmount: initialAmount,
     );
+  }
+
+  final ForYouEntrySource source;
+  final CollectGroup? selectedOrganisation;
+  final String? entryMediumId;
+  final bool restrictToEntryQrGoal;
+
+  /// When true, giving continues via list (namespace beacon only) and the
+  /// named/active QR goal picker is hidden. Used after an inactive QR scan.
+  final bool giveViaListOnly;
+  final double? initialAmount;
+
+  /// Continue after a deactivated QR: organisation namespace only, no named QR.
+  ForYouFlowContext forGiveViaListAfterInactiveQr(CollectGroup collectGroup) {
+    return copyWith(
+      selectedOrganisation: collectGroup,
+      entryMediumId: collectGroup.nameSpace,
+      restrictToEntryQrGoal: false,
+      giveViaListOnly: true,
+    );
+  }
+
+  ForYouFlowContext copyWith({
+    ForYouEntrySource? source,
+    CollectGroup? selectedOrganisation,
+    String? entryMediumId,
+    bool? restrictToEntryQrGoal,
+    bool? giveViaListOnly,
+    double? initialAmount,
+  }) {
+    return ForYouFlowContext(
+      source: source ?? this.source,
+      selectedOrganisation: selectedOrganisation ?? this.selectedOrganisation,
+      entryMediumId: entryMediumId ?? this.entryMediumId,
+      restrictToEntryQrGoal:
+          restrictToEntryQrGoal ?? this.restrictToEntryQrGoal,
+      giveViaListOnly: giveViaListOnly ?? this.giveViaListOnly,
+      initialAmount: initialAmount ?? this.initialAmount,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'source': source.name,
+      'selectedOrganisation': selectedOrganisation?.toJson(),
+      'entryMediumId': entryMediumId,
+      'restrictToEntryQrGoal': restrictToEntryQrGoal,
+      'giveViaListOnly': giveViaListOnly,
+      'initialAmount': initialAmount,
+    };
   }
 
   @override
@@ -85,6 +107,7 @@ class ForYouFlowContext extends Equatable {
     selectedOrganisation,
     entryMediumId,
     restrictToEntryQrGoal,
+    giveViaListOnly,
     initialAmount,
   ];
 }

--- a/lib/features/give/pages/for_you_giving_page.dart
+++ b/lib/features/give/pages/for_you_giving_page.dart
@@ -83,7 +83,8 @@ class _ForYouGivingPageState extends State<ForYouGivingPage> {
       _goalsResponse != null &&
       _goalsResponse!.qrCodes.isNotEmpty &&
       _sheetAvailableQrCodes.isNotEmpty &&
-      !widget.flowContext.restrictToEntryQrGoal;
+      !widget.flowContext.restrictToEntryQrGoal &&
+      !widget.flowContext.giveViaListOnly;
 
   @override
   void initState() {

--- a/lib/features/give/pages/for_you_qr_discovery_page.dart
+++ b/lib/features/give/pages/for_you_qr_discovery_page.dart
@@ -105,7 +105,8 @@ class _ForYouQrDiscoveryPageState extends State<ForYouQrDiscoveryPage> {
           children: [
             MobileScanner(
               controller: _controller,
-              errorBuilder: (context, error) => ScannerErrorWidget(error: error),
+              errorBuilder: (context, error) =>
+                  ScannerErrorWidget(error: error),
               onDetect: (capture) => _processBarcode(barcodeCapture: capture),
             ),
             const Positioned.fill(child: QrCodeTarget()),
@@ -168,10 +169,7 @@ class _ForYouQrDiscoveryPageState extends State<ForYouQrDiscoveryPage> {
       if (!mounted) return;
 
       if (!resolved.isSuccess) {
-        await _handleDiscoveryFailure(
-          resolved,
-          mediumId: mediumId,
-        );
+        await _handleDiscoveryFailure(resolved);
         return;
       }
 
@@ -198,7 +196,6 @@ class _ForYouQrDiscoveryPageState extends State<ForYouQrDiscoveryPage> {
       if (!mounted) return;
       await _handleDiscoveryFailure(
         const ForYouDiscoveryResult.failure(ForYouDiscoveryFailure.notFound),
-        mediumId: '',
       );
     } finally {
       if (mounted) setState(() => _isProcessing = false);
@@ -206,9 +203,8 @@ class _ForYouQrDiscoveryPageState extends State<ForYouQrDiscoveryPage> {
   }
 
   Future<void> _handleDiscoveryFailure(
-    ForYouDiscoveryResult resolved, {
-    required String mediumId,
-  }) async {
+    ForYouDiscoveryResult resolved,
+  ) async {
     final failure = resolved.failure ?? ForYouDiscoveryFailure.notFound;
 
     switch (failure) {
@@ -230,11 +226,7 @@ class _ForYouQrDiscoveryPageState extends State<ForYouQrDiscoveryPage> {
           context.goNamed(
             Pages.forYouOrganisationConfirm.name,
             extra: widget.flowContext
-                .copyWith(selectedOrganisation: collectGroup)
-                .copyWith(
-                  entryMediumId: mediumId,
-                  restrictToEntryQrGoal: false,
-                )
+                .forGiveViaListAfterInactiveQr(collectGroup)
                 .toMap(),
           );
         } else {

--- a/lib/features/give/pages/home_page_with_qr_code.dart
+++ b/lib/features/give/pages/home_page_with_qr_code.dart
@@ -123,10 +123,7 @@ class _HomePageWithQRCodeState extends State<HomePageWithQRCode> {
       }
 
       if (!resolved.isSuccess) {
-        await _handleDiscoveryFailure(
-          resolved,
-          mediumId: mediumId,
-        );
+        await _handleDiscoveryFailure(resolved);
         return;
       }
 
@@ -161,9 +158,8 @@ class _HomePageWithQRCodeState extends State<HomePageWithQRCode> {
   }
 
   Future<void> _handleDiscoveryFailure(
-    ForYouDiscoveryResult resolved, {
-    required String mediumId,
-  }) async {
+    ForYouDiscoveryResult resolved,
+  ) async {
     final failure = resolved.failure ?? ForYouDiscoveryFailure.notFound;
 
     switch (failure) {
@@ -182,10 +178,13 @@ class _HomePageWithQRCodeState extends State<HomePageWithQRCode> {
           return;
         }
         if (choice ?? false) {
-          _openForYouGiving(
-            collectGroup: collectGroup,
-            mediumId: mediumId,
-            restrictToEntryQrGoal: false,
+          _hasEnteredGivingFlow = true;
+          context.goNamed(
+            Pages.forYouGiving.name,
+            extra: ForYouFlowContext(
+              source: ForYouEntrySource.qrCode,
+              initialAmount: widget.initialAmount,
+            ).forGiveViaListAfterInactiveQr(collectGroup).toMap(),
           );
         }
       case ForYouDiscoveryFailure.inactiveCollectGroup:
@@ -294,7 +293,8 @@ class _HomePageWithQRCodeState extends State<HomePageWithQRCode> {
 
     try {
       final collectGroupRepository = getIt<CollectGroupRepository>();
-      final collectGroupList = await collectGroupRepository.getCollectGroupList();
+      final collectGroupList = await collectGroupRepository
+          .getCollectGroupList();
 
       if (collectGroupList.isEmpty) {
         return FontAwesomeIcons.church;
@@ -302,7 +302,8 @@ class _HomePageWithQRCodeState extends State<HomePageWithQRCode> {
 
       final collectGroup = collectGroupList.firstWhere(
         (group) =>
-            group.nameSpace == namespace || group.nameSpace.startsWith(namespace),
+            group.nameSpace == namespace ||
+            group.nameSpace.startsWith(namespace),
         orElse: CollectGroup.empty,
       );
 

--- a/test/features/give/models/for_you_flow_context_test.dart
+++ b/test/features/give/models/for_you_flow_context_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/core/enums/collect_group_type.dart';
+import 'package:givt_app/features/give/models/for_you_flow_context.dart';
+import 'package:givt_app/shared/models/collect_group.dart';
+
+void main() {
+  const collectGroup = CollectGroup(
+    nameSpace: '61f7ed014e4c0620d000',
+    orgName: 'Test org',
+    hasCelebration: false,
+    type: CollectGroupType.church,
+  );
+
+  group('ForYouFlowContext.forGiveViaListAfterInactiveQr', () {
+    test(
+      'uses organisation namespace and list-only giving',
+      () {
+        const scannedInstance = '61f7ed014e4c0620d000.c00000000004';
+        const current = ForYouFlowContext(
+          source: ForYouEntrySource.qrCode,
+          entryMediumId: scannedInstance,
+          restrictToEntryQrGoal: true,
+        );
+
+        final continued = current.forGiveViaListAfterInactiveQr(collectGroup);
+
+        expect(continued.entryMediumId, collectGroup.nameSpace);
+        expect(continued.entryMediumId, isNot(contains('.')));
+        expect(continued.giveViaListOnly, isTrue);
+        expect(continued.restrictToEntryQrGoal, isFalse);
+        expect(continued.selectedOrganisation, collectGroup);
+        expect(continued.source, ForYouEntrySource.qrCode);
+      },
+    );
+
+    test('round-trips giveViaListOnly through toMap/fromMap', () {
+      final original = const ForYouFlowContext(
+        source: ForYouEntrySource.qrCode,
+      ).forGiveViaListAfterInactiveQr(collectGroup);
+
+      final restored = ForYouFlowContext.fromMap(original.toMap());
+
+      expect(restored.giveViaListOnly, isTrue);
+      expect(restored.entryMediumId, collectGroup.nameSpace);
+      expect(restored.restrictToEntryQrGoal, isFalse);
+      expect(restored.selectedOrganisation?.nameSpace, collectGroup.nameSpace);
+    });
+  });
+}

--- a/test/features/give/pages/for_you_qr_discovery_page_test.dart
+++ b/test/features/give/pages/for_you_qr_discovery_page_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/core/enums/collect_group_type.dart';
+import 'package:givt_app/features/give/models/for_you_flow_context.dart';
+import 'package:givt_app/shared/models/collect_group.dart';
+
+void main() {
+  const collectGroup = CollectGroup(
+    nameSpace: '61f7ed014e4c0620d000',
+    orgName: 'Test church',
+    hasCelebration: false,
+    type: CollectGroupType.church,
+  );
+
+  const scannedInstance = '61f7ed014e4c0620d000.c00000000004';
+
+  group('ForYouQrDiscoveryPage inactive QR continue', () {
+    test(
+      'Yes please navigates with namespace-only list giving context',
+      () {
+        const flowContext = ForYouFlowContext(
+          source: ForYouEntrySource.qrCode,
+          entryMediumId: scannedInstance,
+        );
+
+        final extra = flowContext
+            .forGiveViaListAfterInactiveQr(collectGroup)
+            .toMap();
+        final navigated = ForYouFlowContext.fromMap(extra);
+
+        expect(navigated.entryMediumId, collectGroup.nameSpace);
+        expect(navigated.entryMediumId, isNot(equals(scannedInstance)));
+        expect(navigated.giveViaListOnly, isTrue);
+        expect(navigated.restrictToEntryQrGoal, isFalse);
+        expect(
+          navigated.selectedOrganisation?.nameSpace,
+          collectGroup.nameSpace,
+        );
+      },
+    );
+  });
+}

--- a/test/features/give/utils/for_you_donation_transactions_test.dart
+++ b/test/features/give/utils/for_you_donation_transactions_test.dart
@@ -77,6 +77,34 @@ void main() {
       expect(txs[1].collectId, '2');
     });
 
+    test(
+      'collection goal uses namespace-only override as beaconId',
+      () {
+        const namespace = '61f7ed014e4c0620d000';
+        final lines = <ForYouGoalLineKind>[
+          const ForYouCollectionGoalLine(
+            title: 'A',
+            subtitleIndex: 1,
+            allocation: OrganisationAllocation(
+              collectId: '1',
+              allocationName: 'A',
+              collectGroupId: 'g',
+            ),
+          ),
+        ];
+        final txs = buildForYouDonationTransactions(
+          userGuid: 'u1',
+          collectGroupNamespace: namespace,
+          lines: lines,
+          amounts: [10],
+          collectionGoalsMediumIdOverride: namespace,
+        );
+        expect(txs, hasLength(1));
+        expect(txs.single.beaconId, namespace);
+        expect(txs.single.beaconId, isNot(contains('.')));
+      },
+    );
+
     test('general goal uses QR mediumId and collectId 1', () {
       final lines = <ForYouGoalLineKind>[
         ForYouGeneralGoalLine(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes For You giving after scanning a **deactivated QR**: continuing to give to the organisation now uses the collect-group **namespace only** (e.g. `61f7ed014e4c0620d000`) instead of the inactive QR instance (`61f7ed014e4c0620d000.c00000000004`). The named/active QR goal picker is hidden on that step.

Linear: [ENG-718](https://linear.app/givt/issue/ENG-718/giving-to-deactivated-qr-code-should-not-be-possible)

## Changes
- After “Yes, please” on an inactive QR, `ForYouFlowContext.forGiveViaListAfterInactiveQr` sets `entryMediumId` to `collectGroup.nameSpace` and `giveViaListOnly: true`.
- Applied in For You QR discovery and QR deep-link (`HomePageWithQRCode`) continue paths.
- `ForYouGivingPage` hides “More goals” when `giveViaListOnly` is true so another named/active QR cannot be picked.
- Unit tests for context construction, map round-trip, and namespace-only donation `beaconId`.

## Test plan
- [x] `flutter test` on:
  - `test/features/give/models/for_you_flow_context_test.dart`
  - `test/features/give/pages/for_you_qr_discovery_page_test.dart`
  - `test/features/give/utils/for_you_donation_transactions_test.dart`
- [ ] Manual (device): scan a deactivated QR in For You → Yes, please → give to collection → confirm payload/DB `BeaconId` is namespace only.

**Page check:** skip (Flutter/native; no web route).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-165d06af-dea4-4f59-9d79-1d7135a1f11a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-165d06af-dea4-4f59-9d79-1d7135a1f11a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

