### PR TITLE
Allow editing UK BACS bank details before mandate sign (ENG-1349)

### DIFF
--- a/lib/core/failures/failure.dart
+++ b/lib/core/failures/failure.dart
@@ -55,6 +55,36 @@ class GivtServerFailure extends Equatable implements Exception {
     return statusCode == 400 || statusCode == 401;
   }
 
+  /// Best-effort user-facing text from a BFF/legacy error body.
+  String? get userFacingMessage {
+    if (body == null) {
+      return null;
+    }
+    const keys = ['errorMessage', 'message', 'detail', 'title', 'raw'];
+    for (final key in keys) {
+      final value = body![key];
+      if (value is String && value.trim().isNotEmpty) {
+        return value.trim();
+      }
+    }
+    return null;
+  }
+
+  /// `POST /givtservice/v1/Mandates/bacs` 409 when the latest mandate is
+  /// already signed or active. Message starts with `MANDATE_ALREADY_SIGNED`.
+  bool get isMandateAlreadySigned {
+    if (statusCode != 409) {
+      return false;
+    }
+    final candidates = <String>[
+      if (userFacingMessage != null) userFacingMessage!,
+      if (body != null) body.toString(),
+    ];
+    return candidates.any(
+      (text) => text.contains('MANDATE_ALREADY_SIGNED'),
+    );
+  }
+
   @override
   List<Object> get props => [statusCode, type];
 

--- a/lib/core/network/api_service.dart
+++ b/lib/core/network/api_service.dart
@@ -214,12 +214,52 @@ class APIService {
     final response = await client.post(url);
 
     if (response.statusCode >= 400) {
-      throw GivtServerFailure(
+      throw GivtServerFailure.fromHttpResponse(
         statusCode: response.statusCode,
-        body: jsonDecode(response.body) as Map<String, dynamic>,
+        body: response.body,
       );
     }
     return response.body;
+  }
+
+  /// Updates pending UK BACS sort code / account number before mandate sign.
+  Future<Map<String, dynamic>> updatePendingBacsBankDetails({
+    required String guid,
+    required String sortCode,
+    required String accountNumber,
+  }) async {
+    final url = Uri.https(_apiURL, '/givtservice/v1/Mandates/bacs');
+    final response = await client.post(
+      url,
+      body: jsonEncode({
+        'guid': guid,
+        'sortCode': sortCode,
+        'accountNumber': accountNumber,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    );
+
+    if (response.statusCode >= 400) {
+      throw GivtServerFailure.fromHttpResponse(
+        statusCode: response.statusCode,
+        body: response.body,
+      );
+    }
+
+    if (response.body.isEmpty) {
+      return <String, dynamic>{};
+    }
+    final responseBody = jsonDecode(response.body);
+    if (responseBody is Map<String, dynamic>) {
+      final item = responseBody['item'];
+      if (item is Map<String, dynamic>) {
+        return item;
+      }
+      return responseBody;
+    }
+    return <String, dynamic>{};
   }
 
   Future<Map<String, dynamic>> fetchStripeSetupIntent() async {

--- a/lib/features/account_details/bloc/personal_info_edit_bloc.dart
+++ b/lib/features/account_details/bloc/personal_info_edit_bloc.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:givt_app/core/enums/country.dart';
 import 'package:givt_app/core/failures/failure.dart';
 import 'package:givt_app/core/logging/logging.dart';
 import 'package:givt_app/core/network/network_info.dart';
@@ -19,10 +20,10 @@ class PersonalInfoEditBloc
     required this.authRepository,
     required UserExt loggedInUserExt,
   }) : super(
-          PersonalInfoEditState(
-            loggedInUserExt: loggedInUserExt,
-          ),
-        ) {
+         PersonalInfoEditState(
+           loggedInUserExt: loggedInUserExt,
+         ),
+       ) {
     on<PersonalInfoEditName>(_onNameChanged);
 
     on<PersonalInfoEditEmail>(_onEmailChanged);
@@ -63,10 +64,19 @@ class PersonalInfoEditBloc
       e.toString(),
       methodName: stackTrace.toString(),
     );
+    if (e.isMandateAlreadySigned) {
+      emit(
+        state.copyWith(
+          status: PersonalInfoEditStatus.mandateAlreadySigned,
+          error: e.userFacingMessage ?? '',
+        ),
+      );
+      return;
+    }
     emit(
       state.copyWith(
         status: PersonalInfoEditStatus.error,
-        error: e.body.toString(),
+        error: e.userFacingMessage ?? e.body.toString(),
       ),
     );
   }
@@ -136,10 +146,12 @@ class PersonalInfoEditBloc
 
       final result = await authRepository.checkEmail(event.email);
       if (result.contains('temp') || result.contains('true')) {
-        emit(state.copyWith(
-          status: PersonalInfoEditStatus.emailUsed,
-          requestedNewEmail: event.email,
-        ));
+        emit(
+          state.copyWith(
+            status: PersonalInfoEditStatus.emailUsed,
+            requestedNewEmail: event.email,
+          ),
+        );
         return;
       }
       final stateUser = state.loggedInUserExt.copyWith(email: event.email);
@@ -202,8 +214,9 @@ class PersonalInfoEditBloc
   ) async {
     emit(state.copyWith(status: PersonalInfoEditStatus.loading));
     try {
-      LoggingInfo.instance
-          .info('Changing phone number to ${event.phoneNumber}');
+      LoggingInfo.instance.info(
+        'Changing phone number to ${event.phoneNumber}',
+      );
       final stateUser = state.loggedInUserExt.copyWith(
         phoneNumber: event.phoneNumber,
       );
@@ -237,14 +250,35 @@ class PersonalInfoEditBloc
 
       final cleanedIban = event.iban.replaceAll(' ', '');
 
-      final stateUser = state.loggedInUserExt.copyWith(
+      var stateUser = state.loggedInUserExt.copyWith(
         iban: cleanedIban,
         accountNumber: event.accountNumber,
         sortCode: event.sortCode,
       );
-      await authRepository.updateUserExt(
-        stateUser.toUpdateJsonBankOnly(),
-      );
+
+      final isUnsignedUkBacs =
+          Country.unitedKingdomCodes().contains(stateUser.country) &&
+          !stateUser.mandateSigned;
+
+      if (isUnsignedUkBacs) {
+        final result = await authRepository.updatePendingBacsBankDetails(
+          guid: stateUser.guid,
+          sortCode: event.sortCode,
+          accountNumber: event.accountNumber,
+        );
+        stateUser = stateUser.copyWith(
+          sortCode: result.sortCode.isNotEmpty
+              ? result.sortCode
+              : event.sortCode,
+          accountNumber: result.accountNumber.isNotEmpty
+              ? result.accountNumber
+              : event.accountNumber,
+        );
+      } else {
+        await authRepository.updateUserExt(
+          stateUser.toUpdateJsonBankOnly(),
+        );
+      }
       emit(
         state.copyWith(
           status: PersonalInfoEditStatus.success,
@@ -266,8 +300,9 @@ class PersonalInfoEditBloc
   ) async {
     emit(state.copyWith(status: PersonalInfoEditStatus.loading));
     try {
-      LoggingInfo.instance
-          .info('Changing gift aid to ${event.isGiftAidEnabled}');
+      LoggingInfo.instance.info(
+        'Changing gift aid to ${event.isGiftAidEnabled}',
+      );
 
       final stateUser = state.loggedInUserExt.copyWith(
         isGiftAidEnabled: event.isGiftAidEnabled,
@@ -296,11 +331,13 @@ class PersonalInfoEditBloc
     PersonalInfoEditStatusReset event,
     Emitter<PersonalInfoEditState> emit,
   ) {
-    emit(PersonalInfoEditState(
-      status: PersonalInfoEditStatus.initial,
-      loggedInUserExt: state.loggedInUserExt,
-      error: state.error,
-    ));
+    emit(
+      PersonalInfoEditState(
+        status: PersonalInfoEditStatus.initial,
+        loggedInUserExt: state.loggedInUserExt,
+        error: state.error,
+      ),
+    );
   }
 
   FutureOr<void> _onMaxAmountChanged(
@@ -309,8 +346,9 @@ class PersonalInfoEditBloc
   ) async {
     emit(state.copyWith(status: PersonalInfoEditStatus.loading));
     try {
-      LoggingInfo.instance
-          .info('Changing max amount to ${event.newAmountLimit}');
+      LoggingInfo.instance.info(
+        'Changing max amount to ${event.newAmountLimit}',
+      );
       final stateUser = state.loggedInUserExt.copyWith(
         amountLimit: event.newAmountLimit,
       );

--- a/lib/features/account_details/bloc/personal_info_edit_state.dart
+++ b/lib/features/account_details/bloc/personal_info_edit_state.dart
@@ -9,6 +9,7 @@ enum PersonalInfoEditStatus {
   noInternet,
   invalidEmail,
   emailUsed,
+  mandateAlreadySigned,
 }
 
 class PersonalInfoEditState extends Equatable {
@@ -22,6 +23,7 @@ class PersonalInfoEditState extends Equatable {
   final PersonalInfoEditStatus status;
   final UserExt loggedInUserExt;
   final String error;
+
   /// When status is [PersonalInfoEditStatus.emailUsed], the email the user tried to change to.
   final String? requestedNewEmail;
 
@@ -40,5 +42,10 @@ class PersonalInfoEditState extends Equatable {
   }
 
   @override
-  List<Object?> get props => [status, loggedInUserExt, error, requestedNewEmail];
+  List<Object?> get props => [
+    status,
+    loggedInUserExt,
+    error,
+    requestedNewEmail,
+  ];
 }

--- a/lib/features/account_details/pages/change_bank_details_bottom_sheet.dart
+++ b/lib/features/account_details/pages/change_bank_details_bottom_sheet.dart
@@ -55,8 +55,8 @@ class _ChangeBankDetailsBottomSheetState
   }
 
   String get _submittedSortCode => SortCodeTextFormatter.stripDashes(
-        sortCodeController.text,
-      );
+    sortCodeController.text,
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -83,7 +83,9 @@ class _ChangeBankDetailsBottomSheetState
 
         return FunBottomSheet(
           closeAction: () => Navigator.of(context).pop(),
-          title: _isSepa ? locals.editIbanAccount : locals.changeBankAccountNumberAndSortCode,
+          title: _isSepa
+              ? locals.editIbanAccount
+              : locals.changeBankAccountNumberAndSortCode,
           content: Form(
             key: formKey,
             child: Column(
@@ -127,8 +129,11 @@ class _ChangeBankDetailsBottomSheetState
                     hintText: locals.bankAccountNumberPlaceholder,
                     keyboardType: TextInputType.number,
                     validator: (value) {
-                      if (value == null || value.isEmpty || value.length != 8) {
-                        return '';
+                      if (value == null || value.isEmpty) {
+                        return locals.fieldRequired;
+                      }
+                      if (value.length != 8) {
+                        return locals.accountNumberMustBe8Digits;
                       }
                       return null;
                     },
@@ -156,12 +161,12 @@ class _ChangeBankDetailsBottomSheetState
       return;
     }
     context.read<PersonalInfoEditBloc>().add(
-          PersonalInfoEditBankDetails(
-            iban: ibanController.text.replaceAll(' ', ''),
-            accountNumber: accountNumberController.text,
-            sortCode: _submittedSortCode,
-          ),
-        );
+      PersonalInfoEditBankDetails(
+        iban: ibanController.text.replaceAll(' ', ''),
+        accountNumber: accountNumberController.text,
+        sortCode: _submittedSortCode,
+      ),
+    );
   }
 
   bool get isEnabled {

--- a/lib/features/account_details/personal_info_edit_sheets.dart
+++ b/lib/features/account_details/personal_info_edit_sheets.dart
@@ -65,18 +65,52 @@ Future<void> showChangePhoneSheetForUser(
   ),
 );
 
-Future<void> showChangeBankDetailsSheetForUser(
+enum BankDetailsSheetResult {
+  saved,
+  mandateAlreadySigned,
+  dismissed,
+}
+
+Future<BankDetailsSheetResult> showChangeBankDetailsSheetForUser(
   BuildContext context,
   UserExt user,
-) => _showSheet(
-  context,
-  user,
-  ChangeBankDetailsBottomSheet(
-    sortCode: user.sortCode,
-    accountNumber: user.accountNumber,
-    iban: user.iban,
-  ),
-);
+) async {
+  final authCubit = context.read<AuthCubit>();
+  final bloc = PersonalInfoEditBloc(
+    authRepository: getIt<AuthRepository>(),
+    loggedInUserExt: user,
+  );
+  try {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => BlocProvider.value(
+        value: bloc,
+        child: PersonalInfoEditFeedbackListener(
+          child: ChangeBankDetailsBottomSheet(
+            sortCode: user.sortCode,
+            accountNumber: user.accountNumber,
+            iban: user.iban,
+          ),
+        ),
+      ),
+    );
+    final status = bloc.state.status;
+    if (context.mounted) {
+      resetPersonalInfoEditSheetOnDismiss(bloc, authCubit);
+    }
+    if (status == PersonalInfoEditStatus.mandateAlreadySigned) {
+      return BankDetailsSheetResult.mandateAlreadySigned;
+    }
+    if (status == PersonalInfoEditStatus.success) {
+      return BankDetailsSheetResult.saved;
+    }
+    return BankDetailsSheetResult.dismissed;
+  } finally {
+    await bloc.close();
+  }
+}
 
 Future<void> _showSheet(
   BuildContext context,

--- a/lib/features/account_details/widgets/personal_info_edit_feedback_listener.dart
+++ b/lib/features/account_details/widgets/personal_info_edit_feedback_listener.dart
@@ -47,8 +47,13 @@ class PersonalInfoEditFeedbackListener extends StatelessWidget {
           _showInfoModal(
             context,
             title: locals.saveFailed,
-            subtitle: locals.updatePersonalInfoError,
+            subtitle: state.error.isNotEmpty
+                ? state.error
+                : locals.updatePersonalInfoError,
           );
+        }
+        if (state.status == PersonalInfoEditStatus.mandateAlreadySigned) {
+          Navigator.of(context).pop();
         }
       },
       child: child,

--- a/lib/features/account_details/widgets/personal_info_edit_sheet_success.dart
+++ b/lib/features/account_details/widgets/personal_info_edit_sheet_success.dart
@@ -17,10 +17,15 @@ void resetPersonalInfoEditSheetOnDismiss(
   AuthCubit authCubit,
 ) {
   final status = bloc.state.status;
+  final updatedUser = bloc.state.loggedInUserExt;
   bloc.add(const PersonalInfoEditStatusReset());
   if (status == PersonalInfoEditStatus.success ||
       status == PersonalInfoEditStatus.emailChangeSuccess ||
       status == PersonalInfoEditStatus.mandateAlreadySigned) {
+    // Apply the just-saved user immediately. [refreshUser] is async and
+    // previously left AuthCubit stale, so UK mandate sign could re-POST the
+    // old sort code / account number.
+    authCubit.updateLocalUser(updatedUser);
     authCubit.refreshUser();
   }
 }

--- a/lib/features/account_details/widgets/personal_info_edit_sheet_success.dart
+++ b/lib/features/account_details/widgets/personal_info_edit_sheet_success.dart
@@ -19,7 +19,8 @@ void resetPersonalInfoEditSheetOnDismiss(
   final status = bloc.state.status;
   bloc.add(const PersonalInfoEditStatusReset());
   if (status == PersonalInfoEditStatus.success ||
-      status == PersonalInfoEditStatus.emailChangeSuccess) {
+      status == PersonalInfoEditStatus.emailChangeSuccess ||
+      status == PersonalInfoEditStatus.mandateAlreadySigned) {
     authCubit.refreshUser();
   }
 }

--- a/lib/features/account_details/widgets/personal_info_edit_sheet_success.dart
+++ b/lib/features/account_details/widgets/personal_info_edit_sheet_success.dart
@@ -25,7 +25,8 @@ void resetPersonalInfoEditSheetOnDismiss(
     // Apply the just-saved user immediately. [refreshUser] is async and
     // previously left AuthCubit stale, so UK mandate sign could re-POST the
     // old sort code / account number.
-    authCubit.updateLocalUser(updatedUser);
-    authCubit.refreshUser();
+    authCubit
+      ..updateLocalUser(updatedUser)
+      ..refreshUser();
   }
 }

--- a/lib/features/auth/cubit/auth_cubit.dart
+++ b/lib/features/auth/cubit/auth_cubit.dart
@@ -478,6 +478,20 @@ class AuthCubit extends Cubit<AuthState> {
     }
   }
 
+  /// Copies [user] into [AuthState] without a network fetch or loading flash.
+  ///
+  /// Used after a successful personal-info sheet so the next action (for
+  /// example UK BACS sign) reads the values just saved, before [refreshUser]
+  /// completes.
+  void updateLocalUser(UserExt user) {
+    emit(
+      state.copyWith(
+        status: state.status,
+        user: user,
+      ),
+    );
+  }
+
   Future<void> refreshUser({bool emitAuthentication = true}) async {
     if (emitAuthentication) emit(state.copyWith(status: AuthStatus.loading));
     try {

--- a/lib/features/auth/repositories/auth_repository.dart
+++ b/lib/features/auth/repositories/auth_repository.dart
@@ -6,6 +6,7 @@ import 'package:givt_app/core/logging/logging.dart';
 import 'package:givt_app/core/network/api_service.dart';
 import 'package:givt_app/features/amount_presets/models/models.dart';
 import 'package:givt_app/features/auth/models/session.dart';
+import 'package:givt_app/shared/models/bacs_mandate_response.dart';
 import 'package:givt_app/shared/models/stripe_response.dart';
 import 'package:givt_app/shared/models/temp_user.dart';
 import 'package:givt_app/shared/models/user_ext.dart';
@@ -60,6 +61,15 @@ mixin AuthRepository {
   });
 
   Future<bool> updateUserExt(Map<String, dynamic> newUserExt);
+
+  /// Patches pending UK BACS details for an existing user before mandate sign.
+  Future<BacsMandateResponse> updatePendingBacsBankDetails({
+    required String guid,
+    required String sortCode,
+    required String accountNumber,
+  }) {
+    throw UnimplementedError();
+  }
 
   Future<bool> updateLocalUserPresets({
     required UserPresets newUserPresets,
@@ -452,6 +462,20 @@ class AuthRepositoyImpl with AuthRepository {
   Future<bool> updateUserExt(
     Map<String, dynamic> newUserExt,
   ) async => _apiService.updateUserExt(newUserExt);
+
+  @override
+  Future<BacsMandateResponse> updatePendingBacsBankDetails({
+    required String guid,
+    required String sortCode,
+    required String accountNumber,
+  }) async {
+    final item = await _apiService.updatePendingBacsBankDetails(
+      guid: guid,
+      sortCode: sortCode,
+      accountNumber: accountNumber,
+    );
+    return BacsMandateResponse.fromJson(item);
+  }
 
   @override
   Future<StripeResponse> fetchStripeSetupIntent() async {

--- a/lib/features/registration/bloc/registration_bloc.dart
+++ b/lib/features/registration/bloc/registration_bloc.dart
@@ -12,6 +12,7 @@ import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/features/auth/repositories/auth_repository.dart';
 import 'package:givt_app/features/give/utils/mandate_popup_dismissal_tracker.dart';
 import 'package:givt_app/shared/models/temp_user.dart';
+import 'package:givt_app/shared/widgets/sort_code_text_formatter.dart';
 import 'package:givt_app/utils/utils.dart';
 
 part 'registration_event.dart';
@@ -19,7 +20,7 @@ part 'registration_state.dart';
 
 class RegistrationBloc extends Bloc<RegistrationEvent, RegistrationState> {
   RegistrationBloc({required this.authRepositoy, required this.authCubit})
-      : super(const RegistrationState()) {
+    : super(const RegistrationState()) {
     on<RegistrationPasswordSubmitted>(_onRegistrationPasswordSubmitted);
 
     on<RegistrationPersonalInfoSubmitted>(_onRegistrationPersonalInfoSubmitted);
@@ -62,8 +63,7 @@ class RegistrationBloc extends Bloc<RegistrationEvent, RegistrationState> {
   ) async {
     emit(state.copyWith(status: RegistrationStatus.loading));
 
-    final isUs =
-        event.country.toUpperCase() == Country.us.countryCode;
+    final isUs = event.country.toUpperCase() == Country.us.countryCode;
 
     try {
       // Trim spaces from IBAN and phone number to avoid duplicates - KIDS-2075
@@ -75,8 +75,9 @@ class RegistrationBloc extends Bloc<RegistrationEvent, RegistrationState> {
         country: event.country,
         appLanguage: event.appLanguage,
         timeZoneId: (await FlutterTimezone.getLocalTimezone()).identifier,
-        amountLimit:
-            event.country.toUpperCase() == Country.us.countryCode ? 4999 : 499,
+        amountLimit: event.country.toUpperCase() == Country.us.countryCode
+            ? 4999
+            : 499,
         address: event.address,
         city: event.city,
         firstName: state.firstName,
@@ -133,9 +134,23 @@ class RegistrationBloc extends Bloc<RegistrationEvent, RegistrationState> {
     RegistrationSignMandate event,
     Emitter<RegistrationState> emit,
   ) async {
-    emit(state.copyWith(status: RegistrationStatus.loading));
+    emit(state.copyWith(status: RegistrationStatus.loading, errorMessage: ''));
+
+    final userBeforeSign = authCubit.state.user;
+    final isUk = Country.unitedKingdomCodes().contains(userBeforeSign.country);
 
     try {
+      if (isUk) {
+        await authRepositoy.updatePendingBacsBankDetails(
+          guid: event.guid,
+          sortCode: SortCodeTextFormatter.stripDashes(userBeforeSign.sortCode),
+          accountNumber: userBeforeSign.accountNumber.replaceAll(
+            RegExp(r'[\s-]'),
+            '',
+          ),
+        );
+      }
+
       final response = await authRepositoy.signSepaMandate(
         appLanguage: event.appLanguage,
         guid: event.guid,
@@ -145,12 +160,13 @@ class RegistrationBloc extends Bloc<RegistrationEvent, RegistrationState> {
       await authCubit.refreshUser();
       await authCubit.refreshSession();
       final user = authCubit.state.user;
-      
+
       // Reset mandate popup dismissal tracker when mandate is signed
-      final mandatePopupDismissalTracker =
-          MandatePopupDismissalTracker(getIt());
+      final mandatePopupDismissalTracker = MandatePopupDismissalTracker(
+        getIt(),
+      );
       await mandatePopupDismissalTracker.reset();
-      
+
       if (user.sortCode.isNotEmpty && user.accountNumber.isNotEmpty) {
         emit(
           state.copyWith(
@@ -172,24 +188,40 @@ class RegistrationBloc extends Bloc<RegistrationEvent, RegistrationState> {
         body.toString(),
         methodName: stackTrace.toString(),
       );
-      if (statusCode == 409) {
+      if (e.isMandateAlreadySigned) {
+        await authCubit.refreshUser();
         emit(
           state.copyWith(
-            status: RegistrationStatus.conflict,
+            status: RegistrationStatus.bacsDirectDebitMandateSigned,
           ),
         );
         return;
       }
-      if (statusCode == 400) {
+      if (statusCode == 409) {
         emit(
           state.copyWith(
-            status: RegistrationStatus.badRequest,
+            status: RegistrationStatus.conflict,
+            errorMessage: e.userFacingMessage ?? '',
+          ),
+        );
+        return;
+      }
+      if (statusCode == 400 || statusCode == 422) {
+        emit(
+          state.copyWith(
+            status: isUk
+                ? RegistrationStatus.bacsDetailsWrong
+                : RegistrationStatus.badRequest,
+            errorMessage: e.userFacingMessage ?? '',
           ),
         );
         return;
       }
       emit(
-        state.copyWith(status: RegistrationStatus.failure),
+        state.copyWith(
+          status: RegistrationStatus.failure,
+          errorMessage: e.userFacingMessage ?? '',
+        ),
       );
     } catch (e, stackTrace) {
       log(e.toString());
@@ -245,7 +277,9 @@ class RegistrationBloc extends Bloc<RegistrationEvent, RegistrationState> {
       ///and update it in the app
       await authCubit.refreshUser(emitAuthentication: event.emitAuthenticated);
       user = authCubit.state.user;
-      log('trial number $trials, delay time is $delayTime,\n   user is temporary: ${user.tempUser}');
+      log(
+        'trial number $trials, delay time is $delayTime,\n   user is temporary: ${user.tempUser}',
+      );
 
       if (trials > 16) {
         delayTime = 60;
@@ -297,7 +331,9 @@ class RegistrationBloc extends Bloc<RegistrationEvent, RegistrationState> {
   }
 
   FutureOr<void> _onReset(
-      RegistrationReset event, Emitter<RegistrationState> emit) {
+    RegistrationReset event,
+    Emitter<RegistrationState> emit,
+  ) {
     emit(const RegistrationState());
   }
 
@@ -309,13 +345,15 @@ class RegistrationBloc extends Bloc<RegistrationEvent, RegistrationState> {
     if (Country.unitedKingdomCodes().contains(user.country)) {
       emit(
         state.copyWith(
-          status: RegistrationStatus.bacsDirectDebitMandateExplanation,
+          status: RegistrationStatus.bacsDirectDebitMandate,
+          errorMessage: '',
         ),
       );
     } else {
       emit(
         state.copyWith(
-          status: RegistrationStatus.sepaMandateExplanation,
+          status: RegistrationStatus.sepaMandate,
+          errorMessage: '',
         ),
       );
     }

--- a/lib/features/registration/bloc/registration_state.dart
+++ b/lib/features/registration/bloc/registration_state.dart
@@ -28,6 +28,7 @@ class RegistrationState extends Equatable {
     this.firstName = '',
     this.lastName = '',
     this.password = '',
+    this.errorMessage = '',
   });
 
   final RegistrationStatus status;
@@ -35,6 +36,7 @@ class RegistrationState extends Equatable {
   final String firstName;
   final String lastName;
   final String password;
+  final String errorMessage;
 
   RegistrationState copyWith({
     RegistrationStatus? status,
@@ -42,6 +44,7 @@ class RegistrationState extends Equatable {
     String? firstName,
     String? lastName,
     String? password,
+    String? errorMessage,
   }) {
     return RegistrationState(
       status: status ?? this.status,
@@ -49,15 +52,17 @@ class RegistrationState extends Equatable {
       firstName: firstName ?? this.firstName,
       lastName: lastName ?? this.lastName,
       password: password ?? this.password,
+      errorMessage: errorMessage ?? this.errorMessage,
     );
   }
 
   @override
   List<Object> get props => [
-        status,
-        email,
-        firstName,
-        lastName,
-        password,
-      ];
+    status,
+    email,
+    firstName,
+    lastName,
+    password,
+    errorMessage,
+  ];
 }

--- a/lib/features/registration/pages/sign_mandate_page.dart
+++ b/lib/features/registration/pages/sign_mandate_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -109,14 +111,24 @@ class SignMandatePage extends StatelessWidget {
                         ),
                         leadingIcon: FontAwesomeIcons.hashtag,
                         leadingIconColor: FamilyAppTheme.primary40,
-                        showEdit: false,
+                        showEdit: !user.mandateSigned,
+                        onEdit: () => _onEditUkBankDetails(
+                          context,
+                          user,
+                          rowType: 'sort_code',
+                        ),
                       ),
                       SignMandateDetailRow(
                         label: locals.signMandateRowBankAccountNumber,
                         value: user.accountNumber,
                         leadingIcon: FontAwesomeIcons.buildingColumns,
                         leadingIconColor: FamilyAppTheme.primary40,
-                        showEdit: false,
+                        showEdit: !user.mandateSigned,
+                        onEdit: () => _onEditUkBankDetails(
+                          context,
+                          user,
+                          rowType: 'account_number',
+                        ),
                       ),
                     ] else
                       SignMandateDetailRow(
@@ -220,10 +232,7 @@ class SignMandatePage extends StatelessWidget {
         specificErrorContext: locals.mandateFailTryAgainLater,
       );
     } else if (state.status == RegistrationStatus.bacsDetailsWrong) {
-      pushError(
-        errorReason: 'bacs_details_wrong',
-        specificErrorContext: locals.updateBacsAccountDetailsError,
-      );
+      _showBacsDetailsWrongModal(context, state, locals);
     } else if (state.status == RegistrationStatus.ddiFailed) {
       pushError(
         errorReason: 'ddi_failed',
@@ -231,5 +240,58 @@ class SignMandatePage extends StatelessWidget {
             '${locals.ddiFailedTitle}. ${locals.ddiFailedMessage}',
       );
     }
+  }
+
+  Future<void> _onEditUkBankDetails(
+    BuildContext context,
+    UserExt user, {
+    required String rowType,
+  }) async {
+    unawaited(
+      AnalyticsHelper.logEvent(
+        eventName: AnalyticsEventName.signMandateChangeDetailsClicked,
+        eventProperties: {'row_type': rowType},
+      ),
+    );
+    final result = await showChangeBankDetailsSheetForUser(context, user);
+    if (!context.mounted) return;
+    if (result == BankDetailsSheetResult.mandateAlreadySigned) {
+      await navigateAfterMandateSigning(context, user.country);
+    }
+  }
+
+  void _showBacsDetailsWrongModal(
+    BuildContext context,
+    RegistrationState state,
+    AppLocalizations locals,
+  ) {
+    final registrationBloc = context.read<RegistrationBloc>();
+    final subtitle = state.errorMessage.contains('MANDATE_ALREADY_SIGNED')
+        ? locals.mandateAlreadySignedError
+        : (state.errorMessage.isNotEmpty
+              ? state.errorMessage
+              : locals.mandateFailTryAgainLater);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!context.mounted) return;
+      FunModal(
+        title: locals.saveFailed,
+        subtitle: subtitle,
+        closeAction: () {
+          registrationBloc.add(const RegistrationMandateErrorDismissed());
+          Navigator.of(context).pop();
+        },
+        buttons: [
+          FunButton(
+            text: locals.confirm,
+            analyticsEvent: AnalyticsEventName.okClicked.toEvent(),
+            onTap: () {
+              registrationBloc.add(const RegistrationMandateErrorDismissed());
+              Navigator.of(context).pop();
+            },
+          ),
+        ],
+      ).show(context);
+    });
   }
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -366,6 +366,11 @@
     "description": "Error message shown when bank account number is not 8 digits",
     "type": "text"
   },
+  "mandateAlreadySignedError": "Bankdaten können nicht geändert werden, weil dein BACS-Mandat bereits unterzeichnet ist.",
+  "@mandateAlreadySignedError": {
+    "description": "Shown when UK BACS bank details cannot be edited because the mandate is already signed",
+    "type": "text"
+  },
   "passwordRuleMinChars": "Mindestens 7 Zeichen verwenden",
   "@passwordRuleMinChars": {
     "description": "Password requirement: minimum 7 characters",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -365,6 +365,11 @@
     "description": "Error message shown when bank account number is not 8 digits",
     "type": "text"
   },
+  "mandateAlreadySignedError": "Bank details cannot be changed because your BACS mandate is already signed.",
+  "@mandateAlreadySignedError": {
+    "description": "Shown when UK BACS bank details cannot be edited because the mandate is already signed",
+    "type": "text"
+  },
   "passwordRuleMinChars": "Use at least 7 characters",
   "@passwordRuleMinChars": {
     "description": "Password requirement: minimum 7 characters",

--- a/lib/l10n/arb/app_en_US.arb
+++ b/lib/l10n/arb/app_en_US.arb
@@ -361,6 +361,11 @@
     "description": "Error message shown when bank account number is not 8 digits",
     "type": "text"
   },
+  "mandateAlreadySignedError": "Bank details cannot be changed because your BACS mandate is already signed.",
+  "@mandateAlreadySignedError": {
+    "description": "Shown when UK BACS bank details cannot be edited because the mandate is already signed",
+    "type": "text"
+  },
   "passwordRuleMinChars": "Use at least 7 characters",
   "@passwordRuleMinChars": {
     "description": "Password requirement: minimum 7 characters",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -366,6 +366,11 @@
     "description": "Error message shown when bank account number is not 8 digits",
     "type": "text"
   },
+  "mandateAlreadySignedError": "No se pueden cambiar los datos bancarios porque tu mandato BACS ya está firmado.",
+  "@mandateAlreadySignedError": {
+    "description": "Shown when UK BACS bank details cannot be edited because the mandate is already signed",
+    "type": "text"
+  },
   "passwordRuleMinChars": "Use at least 7 characters",
   "@passwordRuleMinChars": {
     "description": "Password requirement: minimum 7 characters",

--- a/lib/l10n/arb/app_es_419.arb
+++ b/lib/l10n/arb/app_es_419.arb
@@ -361,6 +361,11 @@
     "description": "Error message shown when bank account number is not 8 digits",
     "type": "text"
   },
+  "mandateAlreadySignedError": "No se pueden cambiar los datos bancarios porque tu mandato BACS ya está firmado.",
+  "@mandateAlreadySignedError": {
+    "description": "Shown when UK BACS bank details cannot be edited because the mandate is already signed",
+    "type": "text"
+  },
   "passwordRuleMinChars": "Usa al menos 7 caracteres",
   "@passwordRuleMinChars": {
     "description": "Password requirement: minimum 7 characters",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -1274,6 +1274,12 @@ abstract class AppLocalizations {
   /// **'Account number must be 8 digits'**
   String get accountNumberMustBe8Digits;
 
+  /// Shown when UK BACS bank details cannot be edited because the mandate is already signed
+  ///
+  /// In en, this message translates to:
+  /// **'Bank details cannot be changed because your BACS mandate is already signed.'**
+  String get mandateAlreadySignedError;
+
   /// Password requirement: minimum 7 characters
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -685,6 +685,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get accountNumberMustBe8Digits => 'Kontonummer muss 8-stellig sein';
 
   @override
+  String get mandateAlreadySignedError =>
+      'Bankdaten können nicht geändert werden, weil dein BACS-Mandat bereits unterzeichnet ist.';
+
+  @override
   String get passwordRuleMinChars => 'Mindestens 7 Zeichen verwenden';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -679,6 +679,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get accountNumberMustBe8Digits => 'Account number must be 8 digits';
 
   @override
+  String get mandateAlreadySignedError =>
+      'Bank details cannot be changed because your BACS mandate is already signed.';
+
+  @override
   String get passwordRuleMinChars => 'Use at least 7 characters';
 
   @override
@@ -4231,6 +4235,10 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
 
   @override
   String get accountNumberMustBe8Digits => 'Account number must be 8 digits';
+
+  @override
+  String get mandateAlreadySignedError =>
+      'Bank details cannot be changed because your BACS mandate is already signed.';
 
   @override
   String get passwordRuleMinChars => 'Use at least 7 characters';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -679,6 +679,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get accountNumberMustBe8Digits => 'Account number must be 8 digits';
 
   @override
+  String get mandateAlreadySignedError =>
+      'No se pueden cambiar los datos bancarios porque tu mandato BACS ya está firmado.';
+
+  @override
   String get passwordRuleMinChars => 'Use at least 7 characters';
 
   @override
@@ -4250,6 +4254,10 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   @override
   String get accountNumberMustBe8Digits =>
       'El número de cuenta debe tener 8 dígitos';
+
+  @override
+  String get mandateAlreadySignedError =>
+      'No se pueden cambiar los datos bancarios porque tu mandato BACS ya está firmado.';
 
   @override
   String get passwordRuleMinChars => 'Usa al menos 7 caracteres';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -683,6 +683,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get accountNumberMustBe8Digits => 'Rekeningnummer moet 8 cijfers zijn';
 
   @override
+  String get mandateAlreadySignedError =>
+      'Bankgegevens kunnen niet worden gewijzigd omdat je BACS-machtiging al is ondertekend.';
+
+  @override
   String get passwordRuleMinChars => 'Gebruik minimaal 7 tekens';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -366,6 +366,11 @@
     "description": "Error message shown when bank account number is not 8 digits",
     "type": "text"
   },
+  "mandateAlreadySignedError": "Bankgegevens kunnen niet worden gewijzigd omdat je BACS-machtiging al is ondertekend.",
+  "@mandateAlreadySignedError": {
+    "description": "Shown when UK BACS bank details cannot be edited because the mandate is already signed",
+    "type": "text"
+  },
   "passwordRuleMinChars": "Gebruik minimaal 7 tekens",
   "@passwordRuleMinChars": {
     "description": "Password requirement: minimum 7 characters",

--- a/lib/shared/models/bacs_mandate_response.dart
+++ b/lib/shared/models/bacs_mandate_response.dart
@@ -1,0 +1,25 @@
+import 'package:equatable/equatable.dart';
+
+/// Item payload from `POST /givtservice/v1/Mandates/bacs`.
+class BacsMandateResponse extends Equatable {
+  const BacsMandateResponse({
+    required this.sortCode,
+    required this.accountNumber,
+    this.mandateStatus,
+  });
+
+  factory BacsMandateResponse.fromJson(Map<String, dynamic> json) {
+    return BacsMandateResponse(
+      sortCode: (json['sortCode'] ?? '') as String,
+      accountNumber: (json['accountNumber'] ?? '') as String,
+      mandateStatus: json['mandateStatus'] as String?,
+    );
+  }
+
+  final String sortCode;
+  final String accountNumber;
+  final String? mandateStatus;
+
+  @override
+  List<Object?> get props => [sortCode, accountNumber, mandateStatus];
+}

--- a/lib/shared/models/models.dart
+++ b/lib/shared/models/models.dart
@@ -1,4 +1,5 @@
 export 'app_update.dart';
+export 'bacs_mandate_response.dart';
 export 'collect_group.dart';
 export 'location.dart';
 export 'multi_use_allocation.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: givt_app
 description: Givt App
-version: 6.5.1
+version: 6.6.0
 publish_to: none
 
 environment:

--- a/test/core/failures/givt_server_failure_test.dart
+++ b/test/core/failures/givt_server_failure_test.dart
@@ -62,4 +62,28 @@ void main() {
       );
     });
   });
+
+  group('GivtServerFailure mandate already signed', () {
+    test('is true when 409 message contains the code', () {
+      const failure = GivtServerFailure(
+        statusCode: 409,
+        body: {'errorMessage': 'MANDATE_ALREADY_SIGNED: closed.completed'},
+      );
+
+      expect(failure.isMandateAlreadySigned, isTrue);
+      expect(
+        failure.userFacingMessage,
+        'MANDATE_ALREADY_SIGNED: closed.completed',
+      );
+    });
+
+    test('is false for other 409s', () {
+      const failure = GivtServerFailure(
+        statusCode: 409,
+        body: {'errorMessage': 'duplicate'},
+      );
+
+      expect(failure.isMandateAlreadySigned, isFalse);
+    });
+  });
 }

--- a/test/features/account_details/personal_info_edit_bloc_bank_details_test.dart
+++ b/test/features/account_details/personal_info_edit_bloc_bank_details_test.dart
@@ -1,0 +1,278 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/core/failures/failure.dart';
+import 'package:givt_app/features/account_details/bloc/personal_info_edit_bloc.dart';
+import 'package:givt_app/features/auth/models/session.dart';
+import 'package:givt_app/features/auth/repositories/auth_repository.dart';
+import 'package:givt_app/shared/models/bacs_mandate_response.dart';
+import 'package:givt_app/shared/models/stripe_response.dart';
+import 'package:givt_app/shared/models/temp_user.dart';
+import 'package:givt_app/shared/models/user_ext.dart';
+import 'package:givt_app/features/amount_presets/models/models.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _FakeAuthRepository repository;
+  late PersonalInfoEditBloc bloc;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  tearDown(() async {
+    await bloc.close();
+    repository.dispose();
+  });
+
+  PersonalInfoEditBloc createBloc(UserExt user) {
+    repository = _FakeAuthRepository();
+    return PersonalInfoEditBloc(
+      authRepository: repository,
+      loggedInUserExt: user,
+    );
+  }
+
+  test(
+    'unsigned UK bank save uses pending BACS endpoint not updateUserExt',
+    () async {
+      bloc = createBloc(
+        const UserExt(
+          email: 'uk@givt.app',
+          guid: 'existing-guid',
+          amountLimit: 499,
+          country: 'GB',
+          sortCode: '123456',
+          accountNumber: '12345678',
+        ),
+      );
+
+      bloc.add(
+        const PersonalInfoEditBankDetails(
+          iban: '',
+          accountNumber: '87654321',
+          sortCode: '654321',
+        ),
+      );
+
+      await expectLater(
+        bloc.stream,
+        emitsThrough(
+          predicate<PersonalInfoEditState>(
+            (state) =>
+                state.status == PersonalInfoEditStatus.success &&
+                state.loggedInUserExt.sortCode == '654321' &&
+                state.loggedInUserExt.accountNumber == '87654321',
+          ),
+        ),
+      );
+
+      expect(repository.bacsGuids, ['existing-guid']);
+      expect(repository.updateUserExtCalls, 0);
+    },
+  );
+
+  test('signed UK bank save uses updateUserExt', () async {
+    bloc = createBloc(
+      const UserExt(
+        email: 'uk@givt.app',
+        guid: 'existing-guid',
+        amountLimit: 499,
+        country: 'GB',
+        mandateSigned: true,
+        sortCode: '123456',
+        accountNumber: '12345678',
+      ),
+    );
+
+    bloc.add(
+      const PersonalInfoEditBankDetails(
+        iban: '',
+        accountNumber: '87654321',
+        sortCode: '654321',
+      ),
+    );
+
+    await expectLater(
+      bloc.stream,
+      emitsThrough(
+        predicate<PersonalInfoEditState>(
+          (state) => state.status == PersonalInfoEditStatus.success,
+        ),
+      ),
+    );
+
+    expect(repository.bacsGuids, isEmpty);
+    expect(repository.updateUserExtCalls, 1);
+  });
+
+  test(
+    'unsigned UK 409 MANDATE_ALREADY_SIGNED emits mandateAlreadySigned',
+    () async {
+      bloc = createBloc(
+        const UserExt(
+          email: 'uk@givt.app',
+          guid: 'existing-guid',
+          amountLimit: 499,
+          country: 'GB',
+          sortCode: '123456',
+          accountNumber: '12345678',
+        ),
+      );
+      repository.bacsError = const GivtServerFailure(
+        statusCode: 409,
+        body: {'errorMessage': 'MANDATE_ALREADY_SIGNED: open.running'},
+      );
+
+      bloc.add(
+        const PersonalInfoEditBankDetails(
+          iban: '',
+          accountNumber: '87654321',
+          sortCode: '654321',
+        ),
+      );
+
+      await expectLater(
+        bloc.stream,
+        emitsThrough(
+          predicate<PersonalInfoEditState>(
+            (state) =>
+                state.status == PersonalInfoEditStatus.mandateAlreadySigned,
+          ),
+        ),
+      );
+    },
+  );
+}
+
+class _FakeAuthRepository with AuthRepository {
+  final _sessionController = StreamController<bool>.broadcast();
+  final bacsGuids = <String>[];
+  Object? bacsError;
+  int updateUserExtCalls = 0;
+
+  void dispose() {
+    _sessionController.close();
+  }
+
+  @override
+  Future<BacsMandateResponse> updatePendingBacsBankDetails({
+    required String guid,
+    required String sortCode,
+    required String accountNumber,
+  }) async {
+    bacsGuids.add(guid);
+    final error = bacsError;
+    if (error is Exception) {
+      throw error;
+    }
+    if (error != null) {
+      throw Exception(error);
+    }
+    return BacsMandateResponse(
+      sortCode: sortCode,
+      accountNumber: accountNumber,
+    );
+  }
+
+  @override
+  Future<Session> refreshToken({bool refreshUserExt = false}) async =>
+      const Session.empty();
+
+  @override
+  Future<Session> login(String email, String password) async =>
+      const Session.empty();
+
+  @override
+  Future<UserExt> fetchUserExtension(String guid) async =>
+      const UserExt(email: '', guid: '', amountLimit: 0);
+
+  @override
+  Future<(UserExt, Session, UserPresets)?> isAuthenticated() async => (
+    const UserExt(email: '', guid: '', amountLimit: 0),
+    const Session.empty(),
+    const UserPresets.empty(),
+  );
+
+  @override
+  Future<bool> logout() async => true;
+
+  @override
+  Future<bool> checkTld(String email) async => true;
+
+  @override
+  Future<String> checkEmail(String email) async => '';
+
+  @override
+  Future<bool> resetPassword(String email) async => true;
+
+  @override
+  Future<String> signSepaMandate({
+    required String guid,
+    required String appLanguage,
+  }) async => '';
+
+  @override
+  Future<StripeResponse> fetchStripeSetupIntent() async =>
+      const StripeResponse.empty();
+
+  @override
+  Future<UserExt> registerUser({
+    required TempUser tempUser,
+    required bool isNewUser,
+  }) async => const UserExt(email: '', guid: '', amountLimit: 0);
+
+  @override
+  Future<bool> changeGiftAid({
+    required String guid,
+    required bool giftAid,
+  }) async => true;
+
+  @override
+  Future<bool> unregisterUser({required String email}) async => true;
+
+  @override
+  Future<bool> updateUser({
+    required String guid,
+    required Map<String, dynamic> newUserExt,
+  }) async => true;
+
+  @override
+  Future<bool> updateUserExt(Map<String, dynamic> newUserExt) async {
+    updateUserExtCalls++;
+    return true;
+  }
+
+  @override
+  Future<bool> updateLocalUserPresets({
+    required UserPresets newUserPresets,
+  }) async => true;
+
+  @override
+  Future<void> checkUserExt({required String email}) async {}
+
+  @override
+  Future<bool> updateNotificationId({
+    required String guid,
+    required String notificationId,
+    required bool notificationPermissionStatus,
+  }) async => true;
+
+  @override
+  void updateSessionStream(bool hasSession) {
+    if (!_sessionController.isClosed) {
+      _sessionController.add(hasSession);
+    }
+  }
+
+  @override
+  Stream<bool> hasSessionStream() => _sessionController.stream;
+
+  @override
+  void setHasSessionInitialValue(bool hasSession) {}
+
+  @override
+  Future<Session> getStoredSession() async => const Session.empty();
+}

--- a/test/features/account_details/personal_info_edit_bottom_sheets_test.dart
+++ b/test/features/account_details/personal_info_edit_bottom_sheets_test.dart
@@ -98,7 +98,8 @@ void main() {
   );
 
   test(
-    'resetPersonalInfoEditSheetOnDismiss applies saved bank details before refreshUser',
+    'resetPersonalInfoEditSheetOnDismiss applies saved bank details '
+    'before refreshUser',
     () async {
       const original = UserExt(
         email: 'uk@givt.app',
@@ -117,18 +118,17 @@ void main() {
       repository.fetchUserExtensionCompleter = Completer<UserExt>();
 
       await personalInfoEditBloc.close();
-      personalInfoEditBloc = PersonalInfoEditBloc(
-        authRepository: repository,
-        loggedInUserExt: original,
-      );
-
-      personalInfoEditBloc.add(
-        const PersonalInfoEditBankDetails(
-          iban: '',
-          accountNumber: '87654321',
-          sortCode: '654321',
-        ),
-      );
+      personalInfoEditBloc =
+          PersonalInfoEditBloc(
+            authRepository: repository,
+            loggedInUserExt: original,
+          )..add(
+            const PersonalInfoEditBankDetails(
+              iban: '',
+              accountNumber: '87654321',
+              sortCode: '654321',
+            ),
+          );
       await personalInfoEditBloc.stream.firstWhere(
         (state) => state.status == PersonalInfoEditStatus.success,
       );

--- a/test/features/account_details/personal_info_edit_bottom_sheets_test.dart
+++ b/test/features/account_details/personal_info_edit_bottom_sheets_test.dart
@@ -14,6 +14,7 @@ import 'package:givt_app/features/auth/models/session.dart';
 import 'package:givt_app/features/auth/repositories/auth_repository.dart';
 import 'package:givt_app/l10n/arb/app_localizations.dart';
 import 'package:givt_app/shared/design_system/components/actions/fun_button.dart';
+import 'package:givt_app/shared/models/bacs_mandate_response.dart';
 import 'package:givt_app/shared/models/stripe_response.dart';
 import 'package:givt_app/shared/models/temp_user.dart';
 import 'package:givt_app/shared/models/user_ext.dart';
@@ -41,6 +42,13 @@ void main() {
   });
 
   tearDown(() async {
+    final completer = repository.fetchUserExtensionCompleter;
+    if (completer != null && !completer.isCompleted) {
+      completer.complete(
+        const UserExt(email: '', guid: '', amountLimit: 0),
+      );
+      await Future<void>.delayed(Duration.zero);
+    }
     await personalInfoEditBloc.close();
     await authCubit.close();
     repository.dispose();
@@ -86,6 +94,51 @@ void main() {
       await personalInfoEditBloc.stream.firstWhere(
         (state) => state.status == PersonalInfoEditStatus.initial,
       );
+    },
+  );
+
+  test(
+    'resetPersonalInfoEditSheetOnDismiss applies saved bank details before refreshUser',
+    () async {
+      const original = UserExt(
+        email: 'uk@givt.app',
+        guid: 'guid',
+        amountLimit: 499,
+        country: 'GB',
+        sortCode: '123456',
+        accountNumber: '12345678',
+      );
+      authCubit.emit(
+        authCubit.state.copyWith(
+          status: AuthStatus.authenticated,
+          user: original,
+        ),
+      );
+      repository.fetchUserExtensionCompleter = Completer<UserExt>();
+
+      await personalInfoEditBloc.close();
+      personalInfoEditBloc = PersonalInfoEditBloc(
+        authRepository: repository,
+        loggedInUserExt: original,
+      );
+
+      personalInfoEditBloc.add(
+        const PersonalInfoEditBankDetails(
+          iban: '',
+          accountNumber: '87654321',
+          sortCode: '654321',
+        ),
+      );
+      await personalInfoEditBloc.stream.firstWhere(
+        (state) => state.status == PersonalInfoEditStatus.success,
+      );
+
+      resetPersonalInfoEditSheetOnDismiss(personalInfoEditBloc, authCubit);
+
+      // refreshUser may already have flipped status to loading; bank
+      // details must still be the values just saved.
+      expect(authCubit.state.user.sortCode, '654321');
+      expect(authCubit.state.user.accountNumber, '87654321');
     },
   );
 
@@ -251,10 +304,21 @@ void main() {
 
 class _FakeAuthRepository with AuthRepository {
   final _sessionController = StreamController<bool>.broadcast();
+  Completer<UserExt>? fetchUserExtensionCompleter;
 
   void dispose() {
     _sessionController.close();
   }
+
+  @override
+  Future<BacsMandateResponse> updatePendingBacsBankDetails({
+    required String guid,
+    required String sortCode,
+    required String accountNumber,
+  }) async => BacsMandateResponse(
+    sortCode: sortCode,
+    accountNumber: accountNumber,
+  );
 
   @override
   Future<Session> refreshToken({bool refreshUserExt = false}) async =>
@@ -265,8 +329,13 @@ class _FakeAuthRepository with AuthRepository {
       const Session.empty();
 
   @override
-  Future<UserExt> fetchUserExtension(String guid) async =>
-      const UserExt(email: '', guid: '', amountLimit: 0);
+  Future<UserExt> fetchUserExtension(String guid) async {
+    final completer = fetchUserExtensionCompleter;
+    if (completer != null) {
+      return completer.future;
+    }
+    return const UserExt(email: '', guid: '', amountLimit: 0);
+  }
 
   @override
   Future<(UserExt, Session, UserPresets)?> isAuthenticated() async => (

--- a/test/features/account_details/personal_info_edit_bottom_sheets_test.dart
+++ b/test/features/account_details/personal_info_edit_bottom_sheets_test.dart
@@ -180,6 +180,31 @@ void main() {
     expect(find.text(locals.editIbanAccount), findsNothing);
   });
 
+  testWidgets('bank sheet shows 6 and 8 digit validation copy', (tester) async {
+    await pumpSheet(
+      tester,
+      const ChangeBankDetailsBottomSheet(
+        iban: '',
+        accountNumber: '12345678',
+        sortCode: '123456',
+      ),
+    );
+
+    final context = tester.element(find.byType(ChangeBankDetailsBottomSheet));
+    final locals = AppLocalizations.of(context)!;
+
+    final fields = find.byType(TextField);
+    expect(fields, findsNWidgets(2));
+
+    await tester.enterText(fields.at(0), '12');
+    await tester.pump();
+    expect(find.text(locals.sortCodeMustBe6Digits), findsOneWidget);
+
+    await tester.enterText(fields.at(1), '123');
+    await tester.pump();
+    expect(find.text(locals.accountNumberMustBe8Digits), findsOneWidget);
+  });
+
   testWidgets('address sheet shows split fields for Netherlands', (
     tester,
   ) async {

--- a/test/features/registration/registration_bloc_test.dart
+++ b/test/features/registration/registration_bloc_test.dart
@@ -1,0 +1,320 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:givt_app/core/failures/failure.dart';
+import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
+import 'package:givt_app/features/auth/models/session.dart';
+import 'package:givt_app/features/auth/repositories/auth_repository.dart';
+import 'package:givt_app/features/registration/bloc/registration_bloc.dart';
+import 'package:givt_app/shared/models/bacs_mandate_response.dart';
+import 'package:givt_app/shared/models/stripe_response.dart';
+import 'package:givt_app/shared/models/temp_user.dart';
+import 'package:givt_app/shared/models/user_ext.dart';
+import 'package:givt_app/features/amount_presets/models/models.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _FakeAuthRepository repository;
+  late AuthCubit authCubit;
+  late RegistrationBloc bloc;
+
+  const ukUser = UserExt(
+    email: 'uk@givt.app',
+    guid: 'existing-guid',
+    amountLimit: 499,
+    country: 'GB',
+    sortCode: '12-34-56',
+    accountNumber: '12345678',
+  );
+
+  const nlUser = UserExt(
+    email: 'nl@givt.app',
+    guid: 'existing-guid',
+    amountLimit: 499,
+    country: 'NL',
+    iban: 'NL8610000000124300013',
+  );
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await GetIt.instance.reset();
+    GetIt.instance.registerSingleton<SharedPreferences>(
+      await SharedPreferences.getInstance(),
+    );
+    repository = _FakeAuthRepository();
+    authCubit = AuthCubit(repository);
+    bloc = RegistrationBloc(
+      authRepositoy: repository,
+      authCubit: authCubit,
+    );
+  });
+
+  tearDown(() async {
+    await bloc.close();
+    await authCubit.close();
+    repository.dispose();
+    await GetIt.instance.reset();
+  });
+
+  void emitUser(UserExt user) {
+    authCubit.emit(
+      authCubit.state.copyWith(
+        status: AuthStatus.authenticated,
+        user: user,
+      ),
+    );
+  }
+
+  test('UK sign patches BACS then signs with the existing GUID', () async {
+    emitUser(ukUser);
+    repository.fetchUser = ukUser;
+
+    bloc.add(
+      const RegistrationSignMandate(
+        guid: 'existing-guid',
+        appLanguage: 'en',
+      ),
+    );
+
+    await expectLater(
+      bloc.stream,
+      emitsThrough(
+        predicate<RegistrationState>(
+          (state) =>
+              state.status == RegistrationStatus.bacsDirectDebitMandateSigned,
+        ),
+      ),
+    );
+
+    expect(repository.bacsGuids, ['existing-guid']);
+    expect(repository.bacsSortCodes, ['123456']);
+    expect(repository.bacsAccountNumbers, ['12345678']);
+    expect(repository.signGuids, ['existing-guid']);
+    expect(repository.updateUserExtCalls, 0);
+  });
+
+  test(
+    'UK BACS 400 keeps the existing GUID and emits bacsDetailsWrong',
+    () async {
+      emitUser(ukUser);
+      repository.bacsError = const GivtServerFailure(
+        statusCode: 400,
+        body: {'errorMessage': 'Sort code must be 6 digits'},
+      );
+
+      bloc.add(
+        const RegistrationSignMandate(
+          guid: 'existing-guid',
+          appLanguage: 'en',
+        ),
+      );
+
+      await expectLater(
+        bloc.stream,
+        emitsThrough(
+          predicate<RegistrationState>(
+            (state) =>
+                state.status == RegistrationStatus.bacsDetailsWrong &&
+                state.errorMessage == 'Sort code must be 6 digits',
+          ),
+        ),
+      );
+
+      expect(repository.bacsGuids, ['existing-guid']);
+      expect(repository.signGuids, isEmpty);
+    },
+  );
+
+  test('UK 409 MANDATE_ALREADY_SIGNED emits signed status', () async {
+    emitUser(ukUser);
+    repository.fetchUser = ukUser.copyWith(mandateSigned: true);
+    repository.bacsError = const GivtServerFailure(
+      statusCode: 409,
+      body: {'errorMessage': 'MANDATE_ALREADY_SIGNED: closed.completed'},
+    );
+
+    bloc.add(
+      const RegistrationSignMandate(
+        guid: 'existing-guid',
+        appLanguage: 'en',
+      ),
+    );
+
+    await expectLater(
+      bloc.stream,
+      emitsThrough(
+        predicate<RegistrationState>(
+          (state) =>
+              state.status == RegistrationStatus.bacsDirectDebitMandateSigned,
+        ),
+      ),
+    );
+
+    expect(repository.signGuids, isEmpty);
+  });
+
+  test('non-UK sign does not call the pending BACS endpoint', () async {
+    emitUser(nlUser);
+    repository.fetchUser = nlUser;
+
+    bloc.add(
+      const RegistrationSignMandate(
+        guid: 'existing-guid',
+        appLanguage: 'en',
+      ),
+    );
+
+    await expectLater(
+      bloc.stream,
+      emitsThrough(
+        predicate<RegistrationState>(
+          (state) => state.status == RegistrationStatus.success,
+        ),
+      ),
+    );
+
+    expect(repository.bacsGuids, isEmpty);
+    expect(repository.signGuids, ['existing-guid']);
+  });
+}
+
+class _FakeAuthRepository with AuthRepository {
+  final _sessionController = StreamController<bool>.broadcast();
+  final bacsGuids = <String>[];
+  final bacsSortCodes = <String>[];
+  final bacsAccountNumbers = <String>[];
+  final signGuids = <String>[];
+  Object? bacsError;
+  UserExt fetchUser = const UserExt(email: '', guid: '', amountLimit: 0);
+  int updateUserExtCalls = 0;
+
+  void dispose() {
+    _sessionController.close();
+  }
+
+  @override
+  Future<BacsMandateResponse> updatePendingBacsBankDetails({
+    required String guid,
+    required String sortCode,
+    required String accountNumber,
+  }) async {
+    bacsGuids.add(guid);
+    bacsSortCodes.add(sortCode);
+    bacsAccountNumbers.add(accountNumber);
+    final error = bacsError;
+    if (error is Exception) {
+      throw error;
+    }
+    if (error != null) {
+      throw Exception(error);
+    }
+    return BacsMandateResponse(
+      sortCode: sortCode,
+      accountNumber: accountNumber,
+    );
+  }
+
+  @override
+  Future<Session> refreshToken({bool refreshUserExt = false}) async =>
+      const Session.empty();
+
+  @override
+  Future<Session> login(String email, String password) async =>
+      const Session.empty();
+
+  @override
+  Future<UserExt> fetchUserExtension(String guid) async => fetchUser;
+
+  @override
+  Future<(UserExt, Session, UserPresets)?> isAuthenticated() async => (
+    fetchUser,
+    const Session.empty(),
+    const UserPresets.empty(),
+  );
+
+  @override
+  Future<bool> logout() async => true;
+
+  @override
+  Future<bool> checkTld(String email) async => true;
+
+  @override
+  Future<String> checkEmail(String email) async => '';
+
+  @override
+  Future<bool> resetPassword(String email) async => true;
+
+  @override
+  Future<String> signSepaMandate({
+    required String guid,
+    required String appLanguage,
+  }) async {
+    signGuids.add(guid);
+    return '';
+  }
+
+  @override
+  Future<StripeResponse> fetchStripeSetupIntent() async =>
+      const StripeResponse.empty();
+
+  @override
+  Future<UserExt> registerUser({
+    required TempUser tempUser,
+    required bool isNewUser,
+  }) async => fetchUser;
+
+  @override
+  Future<bool> changeGiftAid({
+    required String guid,
+    required bool giftAid,
+  }) async => true;
+
+  @override
+  Future<bool> unregisterUser({required String email}) async => true;
+
+  @override
+  Future<bool> updateUser({
+    required String guid,
+    required Map<String, dynamic> newUserExt,
+  }) async => true;
+
+  @override
+  Future<bool> updateUserExt(Map<String, dynamic> newUserExt) async {
+    updateUserExtCalls++;
+    return true;
+  }
+
+  @override
+  Future<bool> updateLocalUserPresets({
+    required UserPresets newUserPresets,
+  }) async => true;
+
+  @override
+  Future<void> checkUserExt({required String email}) async {}
+
+  @override
+  Future<bool> updateNotificationId({
+    required String guid,
+    required String notificationId,
+    required bool notificationPermissionStatus,
+  }) async => true;
+
+  @override
+  void updateSessionStream(bool hasSession) {
+    if (!_sessionController.isClosed) {
+      _sessionController.add(hasSession);
+    }
+  }
+
+  @override
+  Stream<bool> hasSessionStream() => _sessionController.stream;
+
+  @override
+  void setHasSessionInitialValue(bool hasSession) {}
+
+  @override
+  Future<Session> getStoredSession() async => const Session.empty();
+}

--- a/test/features/registration/registration_bloc_test.dart
+++ b/test/features/registration/registration_bloc_test.dart
@@ -68,6 +68,40 @@ void main() {
     );
   }
 
+  test(
+    'UK sign posts AuthCubit bank details even when fetchUser is stale',
+    () async {
+      emitUser(
+        ukUser.copyWith(
+          sortCode: '654321',
+          accountNumber: '87654321',
+        ),
+      );
+      repository.fetchUser = ukUser;
+
+      bloc.add(
+        const RegistrationSignMandate(
+          guid: 'existing-guid',
+          appLanguage: 'en',
+        ),
+      );
+
+      await expectLater(
+        bloc.stream,
+        emitsThrough(
+          predicate<RegistrationState>(
+            (state) =>
+                state.status == RegistrationStatus.bacsDirectDebitMandateSigned,
+          ),
+        ),
+      );
+
+      expect(repository.bacsSortCodes, ['654321']);
+      expect(repository.bacsAccountNumbers, ['87654321']);
+      expect(repository.signGuids, ['existing-guid']);
+    },
+  );
+
   test('UK sign patches BACS then signs with the existing GUID', () async {
     emitUser(ukUser);
     repository.fetchUser = ukUser;

--- a/test/features/registration/sign_mandate_page_test.dart
+++ b/test/features/registration/sign_mandate_page_test.dart
@@ -1,0 +1,213 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
+import 'package:givt_app/features/auth/models/session.dart';
+import 'package:givt_app/features/auth/repositories/auth_repository.dart';
+import 'package:givt_app/features/registration/bloc/registration_bloc.dart';
+import 'package:givt_app/features/registration/pages/sign_mandate_page.dart';
+import 'package:givt_app/features/registration/widgets/sign_mandate_detail_row.dart';
+import 'package:givt_app/l10n/arb/app_localizations.dart';
+import 'package:givt_app/shared/models/stripe_response.dart';
+import 'package:givt_app/shared/models/temp_user.dart';
+import 'package:givt_app/shared/models/user_ext.dart';
+import 'package:givt_app/features/amount_presets/models/models.dart';
+
+void main() {
+  late _FakeAuthRepository repository;
+  late AuthCubit authCubit;
+  late RegistrationBloc registrationBloc;
+
+  setUp(() {
+    repository = _FakeAuthRepository();
+    authCubit = AuthCubit(repository);
+    registrationBloc = RegistrationBloc(
+      authRepositoy: repository,
+      authCubit: authCubit,
+    );
+  });
+
+  tearDown(() async {
+    await registrationBloc.close();
+    await authCubit.close();
+    repository.dispose();
+  });
+
+  Future<AppLocalizations> pumpPage(WidgetTester tester, UserExt user) async {
+    authCubit.emit(
+      authCubit.state.copyWith(
+        status: AuthStatus.authenticated,
+        user: user,
+      ),
+    );
+
+    await tester.pumpWidget(
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<AuthCubit>.value(value: authCubit),
+          BlocProvider<RegistrationBloc>.value(value: registrationBloc),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: SignMandatePage(),
+        ),
+      ),
+    );
+    await tester.pump();
+    final context = tester.element(find.byType(SignMandatePage));
+    return AppLocalizations.of(context);
+  }
+
+  List<SignMandateDetailRow> rows(WidgetTester tester) => tester
+      .widgetList<SignMandateDetailRow>(find.byType(SignMandateDetailRow))
+      .toList();
+
+  testWidgets(
+    'UK unsigned mandate shows edit on sort code and account number',
+    (tester) async {
+      await pumpPage(
+        tester,
+        const UserExt(
+          email: 'uk@givt.app',
+          guid: 'guid',
+          amountLimit: 499,
+          country: 'GB',
+          firstName: 'Jane',
+          lastName: 'Doe',
+          sortCode: '123456',
+          accountNumber: '12345678',
+        ),
+      );
+
+      expect(find.textContaining('12-34-56'), findsOneWidget);
+      expect(find.text('12345678'), findsOneWidget);
+      expect(rows(tester).where((row) => row.showEdit).length, 5);
+    },
+  );
+
+  testWidgets('UK signed mandate hides bank row edit', (tester) async {
+    await pumpPage(
+      tester,
+      const UserExt(
+        email: 'uk@givt.app',
+        guid: 'guid',
+        amountLimit: 499,
+        country: 'GB',
+        mandateSigned: true,
+        firstName: 'Jane',
+        lastName: 'Doe',
+        sortCode: '123456',
+        accountNumber: '12345678',
+      ),
+    );
+
+    expect(rows(tester).where((row) => row.showEdit).length, 3);
+  });
+}
+
+class _FakeAuthRepository with AuthRepository {
+  final _sessionController = StreamController<bool>.broadcast();
+
+  void dispose() {
+    _sessionController.close();
+  }
+
+  @override
+  Future<Session> refreshToken({bool refreshUserExt = false}) async =>
+      const Session.empty();
+
+  @override
+  Future<Session> login(String email, String password) async =>
+      const Session.empty();
+
+  @override
+  Future<UserExt> fetchUserExtension(String guid) async =>
+      const UserExt(email: '', guid: '', amountLimit: 0);
+
+  @override
+  Future<(UserExt, Session, UserPresets)?> isAuthenticated() async => (
+    const UserExt(email: '', guid: '', amountLimit: 0),
+    const Session.empty(),
+    const UserPresets.empty(),
+  );
+
+  @override
+  Future<bool> logout() async => true;
+
+  @override
+  Future<bool> checkTld(String email) async => true;
+
+  @override
+  Future<String> checkEmail(String email) async => '';
+
+  @override
+  Future<bool> resetPassword(String email) async => true;
+
+  @override
+  Future<String> signSepaMandate({
+    required String guid,
+    required String appLanguage,
+  }) async => '';
+
+  @override
+  Future<StripeResponse> fetchStripeSetupIntent() async =>
+      const StripeResponse.empty();
+
+  @override
+  Future<UserExt> registerUser({
+    required TempUser tempUser,
+    required bool isNewUser,
+  }) async => const UserExt(email: '', guid: '', amountLimit: 0);
+
+  @override
+  Future<bool> changeGiftAid({
+    required String guid,
+    required bool giftAid,
+  }) async => true;
+
+  @override
+  Future<bool> unregisterUser({required String email}) async => true;
+
+  @override
+  Future<bool> updateUser({
+    required String guid,
+    required Map<String, dynamic> newUserExt,
+  }) async => true;
+
+  @override
+  Future<bool> updateUserExt(Map<String, dynamic> newUserExt) async => true;
+
+  @override
+  Future<bool> updateLocalUserPresets({
+    required UserPresets newUserPresets,
+  }) async => true;
+
+  @override
+  Future<void> checkUserExt({required String email}) async {}
+
+  @override
+  Future<bool> updateNotificationId({
+    required String guid,
+    required String notificationId,
+    required bool notificationPermissionStatus,
+  }) async => true;
+
+  @override
+  void updateSessionStream(bool hasSession) {
+    if (!_sessionController.isClosed) {
+      _sessionController.add(hasSession);
+    }
+  }
+
+  @override
+  Stream<bool> hasSessionStream() => _sessionController.stream;
+
+  @override
+  void setHasSessionInitialValue(bool hasSession) {}
+
+  @override
+  Future<Session> getStoredSession() async => const Session.empty();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
UK users can now correct sort code and account number on the sign-mandate screen after a failed BACS registration, then resubmit with the same user GUID before the mandate is signed.

Bank rows stay read-only after the mandate is signed. Unsigned UK edits go to `POST /givtservice/v1/Mandates/bacs` (ENG-1350); signing still uses `POST /api/v2/users/{guid}/mandate`. Bank validation errors stay on this screen instead of sending people to Personal information (which is locked until the mandate is signed).

After a successful bank-details sheet, the saved user is copied into `AuthCubit` immediately so Sign cannot re-POST stale sort code / account number while `refreshUser` is still in flight.

## Test plan
- [x] `flutter test` — 327 passed, 1 skipped (no Android/iOS platform builds)
- [x] `flutter analyze` on changed files — no new errors (pre-existing infos/warnings only)
- [ ] Manual UK registration: enter invalid BACS details, fail sign, edit sort code / account number on confirm, resubmit, then sign
- [ ] Confirm 409 `MANDATE_ALREADY_SIGNED` leaves the flow (Gift Aid / next step) and hides bank edit
- [ ] Confirm SEPA IBAN row is still not editable
- [ ] Confirm signed-account settings still use `PUT /api/v2/usersExtension` for bank changes

Page check: skip (Flutter/native).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-884029fc-601a-45a0-9405-925bb0c3e258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-884029fc-601a-45a0-9405-925bb0c3e258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

