### PR TITLE
Show native donation result after the confirm browser closes

### DIFF
--- a/lib/app/injection/injection.dart
+++ b/lib/app/injection/injection.dart
@@ -22,6 +22,7 @@ import 'package:givt_app/features/family/features/family_goal/repositories/creat
 import 'package:givt_app/features/family/features/family_history/repository/family_history_repository.dart';
 import 'package:givt_app/features/family/features/parental_approval/repositories/parental_approval_repository.dart';
 import 'package:givt_app/features/give/cubit/for_you_beacon_discovery_cubit.dart';
+import 'package:givt_app/features/give/cubit/give_result_cubit.dart';
 import 'package:givt_app/features/give/repositories/beacon_repository.dart';
 import 'package:givt_app/features/give/repositories/campaign_repository.dart';
 import 'package:givt_app/features/impact_groups_legacy_logic/repo/impact_groups_repository.dart';
@@ -251,6 +252,11 @@ void initRepositories() {
     ..registerFactory<ForYouBeaconDiscoveryCubit>(
       () => ForYouBeaconDiscoveryCubit(
         collectGroupRepository: getIt<CollectGroupRepository>(),
+      ),
+    )
+    ..registerFactory<GiveResultCubit>(
+      () => GiveResultCubit(
+        getIt<GivtRepository>(),
       ),
     )
     ..registerLazySingleton<RecurringDonationRepository>(

--- a/lib/core/enums/analytics_event_name.dart
+++ b/lib/core/enums/analytics_event_name.dart
@@ -153,9 +153,13 @@ enum AnalyticsEventName {
   externalDonationsTabsChanged('external_donations_tabs_changed'),
   externalDonationsAddClicked('external_donations_add_clicked'),
   externalDonationsCardClicked('external_donations_card_clicked'),
-  externalDonationsDetailSummaryViewed('external_donations_detail_summary_viewed'),
+  externalDonationsDetailSummaryViewed(
+    'external_donations_detail_summary_viewed',
+  ),
   externalDonationsStopClicked('external_donations_stop_clicked'),
-  externalDonationsStopConfirmClicked('external_donations_stop_confirm_clicked'),
+  externalDonationsStopConfirmClicked(
+    'external_donations_stop_confirm_clicked',
+  ),
   externalDonationsStopCancelClicked('external_donations_stop_cancel_clicked'),
   externalDonationsCreateOrganisationSearchClicked(
     'external_donations_create_organisation_search_clicked',
@@ -169,7 +173,9 @@ enum AnalyticsEventName {
   externalDonationsCreateOrganisationContinueClicked(
     'external_donations_create_organisation_continue_clicked',
   ),
-  externalDonationsCreateAmountEntered('external_donations_create_amount_entered'),
+  externalDonationsCreateAmountEntered(
+    'external_donations_create_amount_entered',
+  ),
   externalDonationsCreateAmountContinueClicked(
     'external_donations_create_amount_continue_clicked',
   ),
@@ -185,7 +191,9 @@ enum AnalyticsEventName {
   externalDonationsCreateStartDateContinueClicked(
     'external_donations_create_start_date_continue_clicked',
   ),
-  externalDonationsCreateConfirmClicked('external_donations_create_confirm_clicked'),
+  externalDonationsCreateConfirmClicked(
+    'external_donations_create_confirm_clicked',
+  ),
   externalDonationsCreateSuccessDoneClicked(
     'external_donations_create_success_done_clicked',
   ),
@@ -195,9 +203,13 @@ enum AnalyticsEventName {
   externalDonationsCreateCloseCancelClicked(
     'external_donations_create_close_cancel_clicked',
   ),
-  externalDonationsCreateSearchTapped('external_donations_create_search_tapped'),
+  externalDonationsCreateSearchTapped(
+    'external_donations_create_search_tapped',
+  ),
   externalDonationsManageClicked('external_donations_manage_clicked'),
-  externalDonationsManageAmountClicked('external_donations_manage_amount_clicked'),
+  externalDonationsManageAmountClicked(
+    'external_donations_manage_amount_clicked',
+  ),
   externalDonationsManageFrequencyClicked(
     'external_donations_manage_frequency_clicked',
   ),
@@ -685,7 +697,16 @@ enum AnalyticsEventName {
   ),
   flowGenericErrorGoHomeClicked('flow_generic_error_go_home_clicked'),
   homeFaqIconClicked('home_faq_icon_clicked'),
-  offlineSuccessGotItTapped('offline_success_got_it_tapped');
+  offlineSuccessGotItTapped('offline_success_got_it_tapped'),
+  giveResultSuccessDoneClicked('give_result_success_done_clicked'),
+  giveResultFailedGoHomeClicked('give_result_failed_go_home_clicked'),
+  giveResultFailedContactSupportClicked(
+    'give_result_failed_contact_support_clicked',
+  ),
+  giveResultUnknownGoHomeClicked('give_result_unknown_go_home_clicked'),
+  giveResultUnknownContactSupportClicked(
+    'give_result_unknown_contact_support_clicked',
+  );
 
   const AnalyticsEventName(this.value);
 

--- a/lib/core/network/api_service.dart
+++ b/lib/core/network/api_service.dart
@@ -1545,4 +1545,40 @@ class APIService {
 
     return response.statusCode == 200;
   }
+
+  Future<int> fetchTransactionStatus(int transactionId) async {
+    final url = Uri.https(
+      _apiURL,
+      '/givtservice/v1/Transaction/$transactionId',
+    );
+    final response = await client.get(url);
+    if (response.statusCode >= 400) {
+      throw GivtServerFailure.fromHttpResponse(
+        statusCode: response.statusCode,
+        body: response.body,
+      );
+    }
+    final decodedBody = jsonDecode(response.body) as Map<String, dynamic>;
+    if (decodedBody['isError'] == true) {
+      throw GivtServerFailure(
+        statusCode: response.statusCode,
+        body: decodedBody,
+      );
+    }
+    final item = decodedBody['item'];
+    if (item is! Map<String, dynamic>) {
+      throw GivtServerFailure(
+        statusCode: response.statusCode,
+        body: decodedBody,
+      );
+    }
+    final status = item['status'];
+    if (status is! num) {
+      throw GivtServerFailure(
+        statusCode: response.statusCode,
+        body: decodedBody,
+      );
+    }
+    return status.toInt();
+  }
 }

--- a/lib/features/give/cubit/give_result_cubit.dart
+++ b/lib/features/give/cubit/give_result_cubit.dart
@@ -1,0 +1,78 @@
+import 'package:givt_app/core/logging/logging.dart';
+import 'package:givt_app/features/give/cubit/give_result_uimodel.dart';
+import 'package:givt_app/shared/bloc/base_state.dart';
+import 'package:givt_app/shared/bloc/common_cubit.dart';
+import 'package:givt_app/shared/repositories/givt_repository.dart';
+
+typedef GiveResultClock = DateTime Function();
+typedef GiveResultSleeper = Future<void> Function(Duration duration);
+
+/// Polls a submitted donation's status after the confirm browser closes.
+class GiveResultCubit extends CommonCubit<GiveResultUIModel, dynamic> {
+  GiveResultCubit(
+    this._givtRepository, {
+    this.pollInterval = const Duration(seconds: 1),
+    this.timeout = const Duration(seconds: 10),
+    GiveResultClock? clock,
+    GiveResultSleeper? sleeper,
+  }) : _clock = clock ?? DateTime.now,
+       _sleeper = sleeper ?? Future<void>.delayed,
+       super(const BaseState.initial());
+
+  final GivtRepository _givtRepository;
+  final Duration pollInterval;
+  final Duration timeout;
+  final GiveResultClock _clock;
+  final GiveResultSleeper _sleeper;
+
+  Future<void> checkStatus(List<int> transactionIds) async {
+    emitLoading();
+
+    if (transactionIds.isEmpty) {
+      LoggingInfo.instance.warning(
+        'No transaction ids available after confirm browser closed',
+        methodName: 'GiveResultCubit.checkStatus',
+      );
+      _emitOutcome(GiveResultOutcome.unknown);
+      return;
+    }
+
+    final transactionId = transactionIds.first;
+    final deadline = _clock().add(timeout);
+
+    while (true) {
+      if (isClosed) {
+        return;
+      }
+      try {
+        final status = await _givtRepository.fetchTransactionStatus(
+          transactionId,
+        );
+        LoggingInfo.instance.info(
+          'Fetched transaction $transactionId status $status',
+          methodName: 'GiveResultCubit.checkStatus',
+        );
+        _emitOutcome(GiveResultUIModel.fromLegacyStatus(status));
+        return;
+      } on Object catch (e) {
+        LoggingInfo.instance.error(
+          'Failed to fetch transaction $transactionId status: $e',
+          methodName: 'GiveResultCubit.checkStatus',
+        );
+        if (!_clock().isBefore(deadline)) {
+          break;
+        }
+        await _sleeper(pollInterval);
+      }
+    }
+
+    _emitOutcome(GiveResultOutcome.unknown);
+  }
+
+  void _emitOutcome(GiveResultOutcome outcome) {
+    if (isClosed) {
+      return;
+    }
+    emitData(GiveResultUIModel(outcome: outcome));
+  }
+}

--- a/lib/features/give/cubit/give_result_uimodel.dart
+++ b/lib/features/give/cubit/give_result_uimodel.dart
@@ -1,0 +1,30 @@
+enum GiveResultOutcome {
+  success,
+  failed,
+  unknown,
+}
+
+class GiveResultUIModel {
+  const GiveResultUIModel({required this.outcome});
+
+  final GiveResultOutcome outcome;
+
+  /// Maps the BFF/legacy integer status to a post-browser outcome.
+  ///
+  /// `1` Entered, `2` ToProcess, `3` Processed → success.
+  /// `4` Rejected, `5` Cancelled → failed.
+  /// Any other value → unknown.
+  static GiveResultOutcome fromLegacyStatus(int status) {
+    switch (status) {
+      case 1:
+      case 2:
+      case 3:
+        return GiveResultOutcome.success;
+      case 4:
+      case 5:
+        return GiveResultOutcome.failed;
+      default:
+        return GiveResultOutcome.unknown;
+    }
+  }
+}

--- a/lib/features/give/pages/giving_page.dart
+++ b/lib/features/give/pages/giving_page.dart
@@ -11,8 +11,12 @@ import 'package:givt_app/core/logging/logging.dart';
 import 'package:givt_app/core/network/request_helper.dart';
 import 'package:givt_app/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app/features/give/bloc/bloc.dart';
+import 'package:givt_app/features/give/cubit/give_result_cubit.dart';
+import 'package:givt_app/features/give/cubit/give_result_uimodel.dart';
 import 'package:givt_app/features/give/models/models.dart';
+import 'package:givt_app/features/give/widgets/give_result_views.dart';
 import 'package:givt_app/l10n/l10n.dart';
+import 'package:givt_app/shared/widgets/base/base_state_consumer.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -28,12 +32,15 @@ class GivingPage extends StatefulWidget {
 
 class _GivingPageState extends State<GivingPage> {
   late CustomInAppBrowser _customInAppBrowser;
+  late GiveResultCubit _resultCubit;
   bool browserIsOpened = false;
   bool showBackButton = false;
+  bool _isCheckingResult = false;
 
   @override
   void initState() {
     super.initState();
+    _resultCubit = getIt<GiveResultCubit>();
     _customInAppBrowser = CustomInAppBrowser(
       onLoad: (url) async {
         if (url == null) {
@@ -43,12 +50,13 @@ class _GivingPageState extends State<GivingPage> {
           return;
         }
         LoggingInfo.instance.info(
-          'Closing browser and navigating to home page from $url',
+          'Closing confirm browser from $url',
         );
         await _closeBrowser();
       },
+      onExitCallback: _onBrowserExited,
     );
-    
+
     // Show the back button after 1 second delay
     Timer(const Duration(seconds: 1), () {
       if (mounted) {
@@ -59,28 +67,54 @@ class _GivingPageState extends State<GivingPage> {
     });
   }
 
+  @override
+  void dispose() {
+    unawaited(_resultCubit.close());
+    super.dispose();
+  }
+
+  Future<void> _onBrowserExited() async {
+    if (_isCheckingResult) {
+      return;
+    }
+    _isCheckingResult = true;
+    if (!mounted) {
+      return;
+    }
+    LoggingInfo.instance.info(
+      'Confirm browser closed, fetching transaction status',
+    );
+    final transactionIds = context.read<GiveBloc>().state.transactionIds;
+    await _resultCubit.checkStatus(transactionIds);
+  }
+
   Future<void> _closeBrowser() async {
     if (_customInAppBrowser.isOpened()) {
       LoggingInfo.instance.info(
-        'Browser is opened, closing browser and navigating to home page',
+        'Browser is opened, closing browser',
       );
       await _customInAppBrowser.close();
     }
+  }
+
+  Future<void> _goHome({required bool given}) async {
     if (!mounted) {
       return;
     }
 
-    final afterGivingRedirection =
-        context.read<GiveBloc>().state.afterGivingRedirection;
+    final afterGivingRedirection = context
+        .read<GiveBloc>()
+        .state
+        .afterGivingRedirection;
 
     context.goNamed(
       Pages.home.name,
       queryParameters: {
-        'given': 'true',
+        'given': given.toString(),
       },
     );
 
-    if (afterGivingRedirection.isNotEmpty) {
+    if (given && afterGivingRedirection.isNotEmpty) {
       final url = Uri.parse(afterGivingRedirection);
       LoggingInfo.instance.info(
         'Redirecting after external link donation. Attempting to launch $url',
@@ -149,75 +183,95 @@ class _GivingPageState extends State<GivingPage> {
     return country.isCreditCard ? 'confirm-G4F.html' : 'confirm.html';
   }
 
+  void _openBrowser(BuildContext context) {
+    if (browserIsOpened) {
+      return;
+    }
+    final givt = _buildGivt(context);
+    final confirmPath = _confirmPagePath(context);
+
+    Vibration.vibrate(amplitude: 128);
+    LoggingInfo.instance.info(
+      'Opening browser at $confirmPath with $givt',
+    );
+
+    browserIsOpened = true;
+    _customInAppBrowser.openUrlRequest(
+      urlRequest: URLRequest(
+        url: WebUri.uri(
+          Uri.https(
+            getIt<RequestHelper>().apiURL,
+            confirmPath,
+            {'msg': base64.encode(utf8.encode(jsonEncode(givt)))},
+          ),
+        ),
+      ),
+      settings: InAppBrowserClassSettings(
+        browserSettings: InAppBrowserSettings(
+          hideCloseButton: true,
+          hideUrlBar: true,
+          hideTitleBar: true,
+          hideToolbarBottom: true,
+          hideToolbarTop: true,
+          toolbarTopBackgroundColor: Colors.white,
+          toolbarTopTintColor: Colors.white,
+          toolbarBottomBackgroundColor: Colors.white,
+          allowGoBackWithBackButton: false,
+          shouldCloseOnBackButtonPressed: false,
+          closeOnCannotGoBack: false,
+        ),
+        webViewSettings: InAppWebViewSettings(
+          underPageBackgroundColor: Colors.white,
+          allowsBackForwardNavigationGestures: false,
+        ),
+      ),
+    );
+  }
+
+  Widget _browserPlaceholder(BuildContext context) {
+    _openBrowser(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: showBackButton
+            ? ElevatedButton(
+                child: const Text('Go Back Home'),
+                onPressed: () {
+                  context.goNamed(
+                    Pages.home.name,
+                    queryParameters: {
+                      'given': 'true',
+                    },
+                  );
+                },
+              )
+            : const SizedBox.shrink(),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Builder(
-        builder: (
-          context,
-        ) {
-          if (browserIsOpened) {
-            return const SizedBox.shrink();
+      body: BaseStateConsumer(
+        cubit: _resultCubit,
+        onInitial: _browserPlaceholder,
+        onLoading: (_) => const GiveResultLoadingView(),
+        onData: (context, uiModel) {
+          switch (uiModel.outcome) {
+            case GiveResultOutcome.success:
+              return GiveResultSuccessView(
+                onDone: () => _goHome(given: true),
+              );
+            case GiveResultOutcome.failed:
+              return GiveResultFailedView(
+                onGoHome: () => _goHome(given: false),
+              );
+            case GiveResultOutcome.unknown:
+              return GiveResultUnknownView(
+                onGoHome: () => _goHome(given: false),
+              );
           }
-          final givt = _buildGivt(context);
-          final confirmPath = _confirmPagePath(context);
-
-          Vibration.vibrate(amplitude: 128);
-          LoggingInfo.instance.info(
-            'Opening browser at $confirmPath with $givt',
-          );
-
-          browserIsOpened = true;
-          _customInAppBrowser.openUrlRequest(
-            urlRequest: URLRequest(
-              url: WebUri.uri(
-                Uri.https(
-                  getIt<RequestHelper>().apiURL,
-                  confirmPath,
-                  {'msg': base64.encode(utf8.encode(jsonEncode(givt)))},
-                ),
-              ),
-            ),
-            settings: InAppBrowserClassSettings(
-              browserSettings: InAppBrowserSettings(
-                hideCloseButton: true,
-                hideUrlBar: true,
-                hideTitleBar: true,
-                hideToolbarBottom: true,
-                hideToolbarTop: true,
-                toolbarTopBackgroundColor: Colors.white,
-                toolbarTopTintColor: Colors.white,
-                toolbarBottomBackgroundColor: Colors.white,
-                allowGoBackWithBackButton: false,
-                shouldCloseOnBackButtonPressed: false,
-                closeOnCannotGoBack: false,
-              ),
-              webViewSettings: InAppWebViewSettings(
-                underPageBackgroundColor: Colors.white,
-                allowsBackForwardNavigationGestures: false,
-              )
-            ),
-          );
-
-          /// In case the user ends up on the giving screen
-          return Center(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: showBackButton
-                  ? ElevatedButton(
-                      child: const Text('Go Back Home'),
-                      onPressed: () {
-                        context.goNamed(
-                          Pages.home.name,
-                          queryParameters: {
-                            'given': 'true',
-                          },
-                        );
-                      },
-                    )
-                  : const SizedBox.shrink(),
-            ),
-          );
         },
       ),
     );
@@ -226,13 +280,16 @@ class _GivingPageState extends State<GivingPage> {
 
 /// Custom InAppBrowser class with custom callback
 typedef CustomInAppBroserCallback = void Function(Uri? url);
+typedef CustomInAppBrowserExitCallback = Future<void> Function();
 
 class CustomInAppBrowser extends InAppBrowser {
   CustomInAppBrowser({
     required this.onLoad,
+    required this.onExitCallback,
   }) : super();
 
   final CustomInAppBroserCallback onLoad;
+  final CustomInAppBrowserExitCallback onExitCallback;
 
   @override
   Future<void> onLoadStart(Uri? url) async => onLoad(url);
@@ -240,5 +297,10 @@ class CustomInAppBrowser extends InAppBrowser {
   @override
   Future<void> onCloseWindow() async {
     LoggingInfo.instance.info('User has pressed the back button');
+  }
+
+  @override
+  void onExit() {
+    unawaited(onExitCallback());
   }
 }

--- a/lib/features/give/widgets/give_result_views.dart
+++ b/lib/features/give/widgets/give_result_views.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:givt_app/core/enums/analytics_event_name.dart';
+import 'package:givt_app/features/family/shared/widgets/loading/custom_progress_indicator.dart';
+import 'package:givt_app/features/family/shared/widgets/texts/texts.dart';
+import 'package:givt_app/l10n/l10n.dart';
+import 'package:givt_app/shared/design_system/design_system.dart';
+import 'package:givt_app/shared/widgets/about_givt_bottom_sheet.dart';
+import 'package:givt_app/shared/widgets/fun_scaffold.dart';
+
+class GiveResultLoadingView extends StatelessWidget {
+  const GiveResultLoadingView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final locals = context.l10n;
+    return FunScaffold(
+      canPop: false,
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Spacer(),
+          const Center(child: CustomCircularProgressIndicator()),
+          const SizedBox(height: 24),
+          TitleMediumText(
+            locals.giveResultLoadingTitle,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          BodyMediumText(
+            locals.giveResultLoadingMessage,
+            textAlign: TextAlign.center,
+          ),
+          const Spacer(),
+        ],
+      ),
+    );
+  }
+}
+
+class GiveResultSuccessView extends StatelessWidget {
+  const GiveResultSuccessView({
+    required this.onDone,
+    super.key,
+  });
+
+  final VoidCallback onDone;
+
+  @override
+  Widget build(BuildContext context) {
+    final locals = context.l10n;
+    return FunScaffold(
+      canPop: false,
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Spacer(),
+          Center(child: FunIcon.checkmark()),
+          const SizedBox(height: 32),
+          TitleMediumText(
+            locals.giveResultSuccessTitle,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          BodyMediumText(
+            locals.giveResultSuccessMessage,
+            textAlign: TextAlign.center,
+          ),
+          const Spacer(),
+          FunButton(
+            text: locals.giveResultDone,
+            onTap: onDone,
+            analyticsEvent: AnalyticsEventName.giveResultSuccessDoneClicked
+                .toEvent(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class GiveResultFailedView extends StatelessWidget {
+  const GiveResultFailedView({
+    required this.onGoHome,
+    super.key,
+  });
+
+  final VoidCallback onGoHome;
+
+  @override
+  Widget build(BuildContext context) {
+    final locals = context.l10n;
+    final theme = FunTheme.of(context);
+    return FunScaffold(
+      canPop: false,
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Spacer(),
+          Center(
+            child: FunIconGivy.sad(
+              circleColor: theme.error90,
+              circleSize: 140,
+            ),
+          ),
+          const SizedBox(height: 32),
+          TitleMediumText(
+            locals.giveResultFailedTitle,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          BodyMediumText(
+            locals.giveResultFailedMessage,
+            textAlign: TextAlign.center,
+          ),
+          const Spacer(),
+          FunButton(
+            text: locals.flowGenericErrorGoToHome,
+            onTap: onGoHome,
+            analyticsEvent: AnalyticsEventName.giveResultFailedGoHomeClicked
+                .toEvent(),
+          ),
+          const SizedBox(height: 12),
+          FunButton(
+            variant: FunButtonVariant.secondary,
+            fullBorder: true,
+            text: locals.flowGenericErrorContactSupport,
+            analyticsEvent: AnalyticsEventName
+                .giveResultFailedContactSupportClicked
+                .toEvent(),
+            onTap: () => AboutGivtBottomSheet.show(
+              context,
+              metadata: const {
+                'Flow': 'Giving',
+                'Error reason': 'donation_failed',
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class GiveResultUnknownView extends StatelessWidget {
+  const GiveResultUnknownView({
+    required this.onGoHome,
+    super.key,
+  });
+
+  final VoidCallback onGoHome;
+
+  @override
+  Widget build(BuildContext context) {
+    final locals = context.l10n;
+    final theme = FunTheme.of(context);
+    return FunScaffold(
+      canPop: false,
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Spacer(),
+          Center(
+            child: FunIconGivy.sad(
+              circleColor: theme.secondary90,
+              circleSize: 140,
+            ),
+          ),
+          const SizedBox(height: 32),
+          TitleMediumText(
+            locals.giveResultUnknownTitle,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          BodyMediumText(
+            locals.giveResultUnknownMessage,
+            textAlign: TextAlign.center,
+          ),
+          const Spacer(),
+          FunButton(
+            text: locals.flowGenericErrorGoToHome,
+            onTap: onGoHome,
+            analyticsEvent: AnalyticsEventName.giveResultUnknownGoHomeClicked
+                .toEvent(),
+          ),
+          const SizedBox(height: 12),
+          FunButton(
+            variant: FunButtonVariant.secondary,
+            fullBorder: true,
+            text: locals.flowGenericErrorContactSupport,
+            analyticsEvent: AnalyticsEventName
+                .giveResultUnknownContactSupportClicked
+                .toEvent(),
+            onTap: () => AboutGivtBottomSheet.show(
+              context,
+              metadata: const {
+                'Flow': 'Giving',
+                'Error reason': 'donation_status_unknown',
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -450,6 +450,51 @@
     "description": "Leave shared flow error screen to app home",
     "type": "text"
   },
+  "giveResultLoadingTitle": "Bitte warten...",
+  "@giveResultLoadingTitle": {
+    "description": "Title shown while checking donation status after the confirm browser closes",
+    "type": "text"
+  },
+  "giveResultLoadingMessage": "Wir prüfen deine Spende.",
+  "@giveResultLoadingMessage": {
+    "description": "Body shown while checking donation status after the confirm browser closes",
+    "type": "text"
+  },
+  "giveResultSuccessTitle": "Danke fürs Geben!",
+  "@giveResultSuccessTitle": {
+    "description": "Title on native success screen after donation confirmation",
+    "type": "text"
+  },
+  "giveResultSuccessMessage": "Deine Spende wird verarbeitet. Den Status siehst du in der Übersicht.",
+  "@giveResultSuccessMessage": {
+    "description": "Body on native success screen after donation confirmation",
+    "type": "text"
+  },
+  "giveResultFailedTitle": "Spende nicht abgeschlossen",
+  "@giveResultFailedTitle": {
+    "description": "Title when the confirmed donation was cancelled or refused",
+    "type": "text"
+  },
+  "giveResultFailedMessage": "Diese Spende wurde abgebrochen oder konnte nicht verarbeitet werden. Schau in deine Übersicht oder kontaktiere uns, wenn du Fragen hast.",
+  "@giveResultFailedMessage": {
+    "description": "Body when the confirmed donation was cancelled or refused",
+    "type": "text"
+  },
+  "giveResultUnknownTitle": "Wir sind uns noch nicht sicher",
+  "@giveResultUnknownTitle": {
+    "description": "Title when donation status could not be confirmed in time",
+    "type": "text"
+  },
+  "giveResultUnknownMessage": "Wir konnten den Status dieser Spende noch nicht bestätigen. Schau gleich in deine Übersicht oder kontaktiere uns, wenn sie nicht erscheint.",
+  "@giveResultUnknownMessage": {
+    "description": "Body when donation status could not be confirmed in time",
+    "type": "text"
+  },
+  "giveResultDone": "Fertig",
+  "@giveResultDone": {
+    "description": "Primary action on native donation success screen",
+    "type": "text"
+  },
   "wrongCredentials": "Ungültige E-Mail-Adresse oder Passwort. Ist es möglich, dass du dich mit einem anderen E-Mail-Konto registriert hast?",
   "@wrongCredentials": {
     "description": "Kan dit leuker? \n  Foutmelding die je te zien krijgt als je een verkeerd email of wachtwoord invoert",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -449,6 +449,51 @@
     "description": "Leave shared flow error screen to app home",
     "type": "text"
   },
+  "giveResultLoadingTitle": "Please wait...",
+  "@giveResultLoadingTitle": {
+    "description": "Title shown while checking donation status after the confirm browser closes",
+    "type": "text"
+  },
+  "giveResultLoadingMessage": "We're checking your donation.",
+  "@giveResultLoadingMessage": {
+    "description": "Body shown while checking donation status after the confirm browser closes",
+    "type": "text"
+  },
+  "giveResultSuccessTitle": "Thanks for giving!",
+  "@giveResultSuccessTitle": {
+    "description": "Title on native success screen after donation confirmation",
+    "type": "text"
+  },
+  "giveResultSuccessMessage": "Your donation is being processed. You can check the status in the overview.",
+  "@giveResultSuccessMessage": {
+    "description": "Body on native success screen after donation confirmation",
+    "type": "text"
+  },
+  "giveResultFailedTitle": "Donation not completed",
+  "@giveResultFailedTitle": {
+    "description": "Title when the confirmed donation was cancelled or refused",
+    "type": "text"
+  },
+  "giveResultFailedMessage": "This donation was cancelled or could not be processed. Check your overview or contact us if you have questions.",
+  "@giveResultFailedMessage": {
+    "description": "Body when the confirmed donation was cancelled or refused",
+    "type": "text"
+  },
+  "giveResultUnknownTitle": "We're not sure what happened",
+  "@giveResultUnknownTitle": {
+    "description": "Title when donation status could not be confirmed in time",
+    "type": "text"
+  },
+  "giveResultUnknownMessage": "We couldn't confirm the status of this donation yet. Check your overview in a moment, or contact us if it doesn't appear.",
+  "@giveResultUnknownMessage": {
+    "description": "Body when donation status could not be confirmed in time",
+    "type": "text"
+  },
+  "giveResultDone": "Done",
+  "@giveResultDone": {
+    "description": "Primary action on native donation success screen",
+    "type": "text"
+  },
   "wrongCredentials": "Invalid e-mail address or password. Is it possible that you registered with a different e-mail account?",
   "@wrongCredentials": {
     "description": "Kan dit leuker? \n  Foutmelding die je te zien krijgt als je een verkeerd email of wachtwoord invoert",

--- a/lib/l10n/arb/app_en_US.arb
+++ b/lib/l10n/arb/app_en_US.arb
@@ -445,6 +445,15 @@
     "description": "Leave shared flow error screen to app home",
     "type": "text"
   },
+  "giveResultLoadingTitle": "Please wait...",
+  "giveResultLoadingMessage": "We're checking your donation.",
+  "giveResultSuccessTitle": "Thanks for giving!",
+  "giveResultSuccessMessage": "Your donation is being processed. You can check the status in the overview.",
+  "giveResultFailedTitle": "Donation not completed",
+  "giveResultFailedMessage": "This donation was cancelled or could not be processed. Check your overview or contact us if you have questions.",
+  "giveResultUnknownTitle": "We're not sure what happened",
+  "giveResultUnknownMessage": "We couldn't confirm the status of this donation yet. Check your overview in a moment, or contact us if it doesn't appear.",
+  "giveResultDone": "Done",
   "wrongCredentials": "Invalid email address or password. Is it possible that you registered with a different email account?",
   "@wrongCredentials": {
     "description": "Kan dit leuker? \n  Foutmelding die je te zien krijgt als je een verkeerd email of wachtwoord invoert",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -450,6 +450,51 @@
     "description": "Leave shared flow error screen to app home",
     "type": "text"
   },
+  "giveResultLoadingTitle": "Por favor, espera...",
+  "@giveResultLoadingTitle": {
+    "description": "Title shown while checking donation status after the confirm browser closes",
+    "type": "text"
+  },
+  "giveResultLoadingMessage": "Estamos comprobando tu donación.",
+  "@giveResultLoadingMessage": {
+    "description": "Body shown while checking donation status after the confirm browser closes",
+    "type": "text"
+  },
+  "giveResultSuccessTitle": "¡Gracias por dar!",
+  "@giveResultSuccessTitle": {
+    "description": "Title on native success screen after donation confirmation",
+    "type": "text"
+  },
+  "giveResultSuccessMessage": "Tu donación se está procesando. Puedes ver el estado en el resumen.",
+  "@giveResultSuccessMessage": {
+    "description": "Body on native success screen after donation confirmation",
+    "type": "text"
+  },
+  "giveResultFailedTitle": "Donación no completada",
+  "@giveResultFailedTitle": {
+    "description": "Title when the confirmed donation was cancelled or refused",
+    "type": "text"
+  },
+  "giveResultFailedMessage": "Esta donación se canceló o no se pudo procesar. Revisa el resumen o contáctanos si tienes preguntas.",
+  "@giveResultFailedMessage": {
+    "description": "Body when the confirmed donation was cancelled or refused",
+    "type": "text"
+  },
+  "giveResultUnknownTitle": "No estamos seguros de lo que pasó",
+  "@giveResultUnknownTitle": {
+    "description": "Title when donation status could not be confirmed in time",
+    "type": "text"
+  },
+  "giveResultUnknownMessage": "Aún no pudimos confirmar el estado de esta donación. Revisa el resumen en un momento o contáctanos si no aparece.",
+  "@giveResultUnknownMessage": {
+    "description": "Body when donation status could not be confirmed in time",
+    "type": "text"
+  },
+  "giveResultDone": "Listo",
+  "@giveResultDone": {
+    "description": "Primary action on native donation success screen",
+    "type": "text"
+  },
   "wrongCredentials": "Invalid e-mail address or password. Is it possible that you registered with a different e-mail account?",
   "@wrongCredentials": {
     "description": "Kan dit leuker? \n  Foutmelding die je te zien krijgt als je een verkeerd email of wachtwoord invoert",

--- a/lib/l10n/arb/app_es_419.arb
+++ b/lib/l10n/arb/app_es_419.arb
@@ -445,6 +445,15 @@
     "description": "Leave shared flow error screen to app home",
     "type": "text"
   },
+  "giveResultLoadingTitle": "Por favor, espera...",
+  "giveResultLoadingMessage": "Estamos comprobando tu donación.",
+  "giveResultSuccessTitle": "¡Gracias por dar!",
+  "giveResultSuccessMessage": "Tu donación se está procesando. Puedes ver el estado en el resumen.",
+  "giveResultFailedTitle": "Donación no completada",
+  "giveResultFailedMessage": "Esta donación se canceló o no se pudo procesar. Revisa el resumen o contáctanos si tienes preguntas.",
+  "giveResultUnknownTitle": "No estamos seguros de lo que pasó",
+  "giveResultUnknownMessage": "Aún no pudimos confirmar el estado de esta donación. Revisa el resumen en un momento o contáctanos si no aparece.",
+  "giveResultDone": "Listo",
   "wrongCredentials": "Correo electrónico o contraseña no válidos. ¿Es posible que te hayas registrado con un correo electrónico diferente?",
   "@wrongCredentials": {
     "description": "Kan dit leuker? \n  Foutmelding die je te zien krijgt als je een verkeerd email of wachtwoord invoert",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -1397,6 +1397,60 @@ abstract class AppLocalizations {
   /// **'Go to home'**
   String get flowGenericErrorGoToHome;
 
+  /// Title shown while checking donation status after the confirm browser closes
+  ///
+  /// In en, this message translates to:
+  /// **'Please wait...'**
+  String get giveResultLoadingTitle;
+
+  /// Body shown while checking donation status after the confirm browser closes
+  ///
+  /// In en, this message translates to:
+  /// **'We\'re checking your donation.'**
+  String get giveResultLoadingMessage;
+
+  /// Title on native success screen after donation confirmation
+  ///
+  /// In en, this message translates to:
+  /// **'Thanks for giving!'**
+  String get giveResultSuccessTitle;
+
+  /// Body on native success screen after donation confirmation
+  ///
+  /// In en, this message translates to:
+  /// **'Your donation is being processed. You can check the status in the overview.'**
+  String get giveResultSuccessMessage;
+
+  /// Title when the confirmed donation was cancelled or refused
+  ///
+  /// In en, this message translates to:
+  /// **'Donation not completed'**
+  String get giveResultFailedTitle;
+
+  /// Body when the confirmed donation was cancelled or refused
+  ///
+  /// In en, this message translates to:
+  /// **'This donation was cancelled or could not be processed. Check your overview or contact us if you have questions.'**
+  String get giveResultFailedMessage;
+
+  /// Title when donation status could not be confirmed in time
+  ///
+  /// In en, this message translates to:
+  /// **'We\'re not sure what happened'**
+  String get giveResultUnknownTitle;
+
+  /// Body when donation status could not be confirmed in time
+  ///
+  /// In en, this message translates to:
+  /// **'We couldn\'t confirm the status of this donation yet. Check your overview in a moment, or contact us if it doesn\'t appear.'**
+  String get giveResultUnknownMessage;
+
+  /// Primary action on native donation success screen
+  ///
+  /// In en, this message translates to:
+  /// **'Done'**
+  String get giveResultDone;
+
   /// Kan dit leuker?
   ///   Foutmelding die je te zien krijgt als je een verkeerd email of wachtwoord invoert
   ///

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -748,6 +748,36 @@ class AppLocalizationsDe extends AppLocalizations {
   String get flowGenericErrorGoToHome => 'Zur Startseite';
 
   @override
+  String get giveResultLoadingTitle => 'Bitte warten...';
+
+  @override
+  String get giveResultLoadingMessage => 'Wir prüfen deine Spende.';
+
+  @override
+  String get giveResultSuccessTitle => 'Danke fürs Geben!';
+
+  @override
+  String get giveResultSuccessMessage =>
+      'Deine Spende wird verarbeitet. Den Status siehst du in der Übersicht.';
+
+  @override
+  String get giveResultFailedTitle => 'Spende nicht abgeschlossen';
+
+  @override
+  String get giveResultFailedMessage =>
+      'Diese Spende wurde abgebrochen oder konnte nicht verarbeitet werden. Schau in deine Übersicht oder kontaktiere uns, wenn du Fragen hast.';
+
+  @override
+  String get giveResultUnknownTitle => 'Wir sind uns noch nicht sicher';
+
+  @override
+  String get giveResultUnknownMessage =>
+      'Wir konnten den Status dieser Spende noch nicht bestätigen. Schau gleich in deine Übersicht oder kontaktiere uns, wenn sie nicht erscheint.';
+
+  @override
+  String get giveResultDone => 'Fertig';
+
+  @override
   String get wrongCredentials =>
       'Ungültige E-Mail-Adresse oder Passwort. Ist es möglich, dass du dich mit einem anderen E-Mail-Konto registriert hast?';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -742,6 +742,36 @@ class AppLocalizationsEn extends AppLocalizations {
   String get flowGenericErrorGoToHome => 'Go to home';
 
   @override
+  String get giveResultLoadingTitle => 'Please wait...';
+
+  @override
+  String get giveResultLoadingMessage => 'We\'re checking your donation.';
+
+  @override
+  String get giveResultSuccessTitle => 'Thanks for giving!';
+
+  @override
+  String get giveResultSuccessMessage =>
+      'Your donation is being processed. You can check the status in the overview.';
+
+  @override
+  String get giveResultFailedTitle => 'Donation not completed';
+
+  @override
+  String get giveResultFailedMessage =>
+      'This donation was cancelled or could not be processed. Check your overview or contact us if you have questions.';
+
+  @override
+  String get giveResultUnknownTitle => 'We\'re not sure what happened';
+
+  @override
+  String get giveResultUnknownMessage =>
+      'We couldn\'t confirm the status of this donation yet. Check your overview in a moment, or contact us if it doesn\'t appear.';
+
+  @override
+  String get giveResultDone => 'Done';
+
+  @override
   String get wrongCredentials =>
       'Invalid e-mail address or password. Is it possible that you registered with a different e-mail account?';
 
@@ -4294,6 +4324,36 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
 
   @override
   String get flowGenericErrorGoToHome => 'Go to home';
+
+  @override
+  String get giveResultLoadingTitle => 'Please wait...';
+
+  @override
+  String get giveResultLoadingMessage => 'We\'re checking your donation.';
+
+  @override
+  String get giveResultSuccessTitle => 'Thanks for giving!';
+
+  @override
+  String get giveResultSuccessMessage =>
+      'Your donation is being processed. You can check the status in the overview.';
+
+  @override
+  String get giveResultFailedTitle => 'Donation not completed';
+
+  @override
+  String get giveResultFailedMessage =>
+      'This donation was cancelled or could not be processed. Check your overview or contact us if you have questions.';
+
+  @override
+  String get giveResultUnknownTitle => 'We\'re not sure what happened';
+
+  @override
+  String get giveResultUnknownMessage =>
+      'We couldn\'t confirm the status of this donation yet. Check your overview in a moment, or contact us if it doesn\'t appear.';
+
+  @override
+  String get giveResultDone => 'Done';
 
   @override
   String get wrongCredentials =>

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -742,6 +742,36 @@ class AppLocalizationsEs extends AppLocalizations {
   String get flowGenericErrorGoToHome => 'Ir al inicio';
 
   @override
+  String get giveResultLoadingTitle => 'Por favor, espera...';
+
+  @override
+  String get giveResultLoadingMessage => 'Estamos comprobando tu donación.';
+
+  @override
+  String get giveResultSuccessTitle => '¡Gracias por dar!';
+
+  @override
+  String get giveResultSuccessMessage =>
+      'Tu donación se está procesando. Puedes ver el estado en el resumen.';
+
+  @override
+  String get giveResultFailedTitle => 'Donación no completada';
+
+  @override
+  String get giveResultFailedMessage =>
+      'Esta donación se canceló o no se pudo procesar. Revisa el resumen o contáctanos si tienes preguntas.';
+
+  @override
+  String get giveResultUnknownTitle => 'No estamos seguros de lo que pasó';
+
+  @override
+  String get giveResultUnknownMessage =>
+      'Aún no pudimos confirmar el estado de esta donación. Revisa el resumen en un momento o contáctanos si no aparece.';
+
+  @override
+  String get giveResultDone => 'Listo';
+
+  @override
   String get wrongCredentials =>
       'Invalid e-mail address or password. Is it possible that you registered with a different e-mail account?';
 
@@ -4312,6 +4342,36 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get flowGenericErrorGoToHome => 'Ir al inicio';
+
+  @override
+  String get giveResultLoadingTitle => 'Por favor, espera...';
+
+  @override
+  String get giveResultLoadingMessage => 'Estamos comprobando tu donación.';
+
+  @override
+  String get giveResultSuccessTitle => '¡Gracias por dar!';
+
+  @override
+  String get giveResultSuccessMessage =>
+      'Tu donación se está procesando. Puedes ver el estado en el resumen.';
+
+  @override
+  String get giveResultFailedTitle => 'Donación no completada';
+
+  @override
+  String get giveResultFailedMessage =>
+      'Esta donación se canceló o no se pudo procesar. Revisa el resumen o contáctanos si tienes preguntas.';
+
+  @override
+  String get giveResultUnknownTitle => 'No estamos seguros de lo que pasó';
+
+  @override
+  String get giveResultUnknownMessage =>
+      'Aún no pudimos confirmar el estado de esta donación. Revisa el resumen en un momento o contáctanos si no aparece.';
+
+  @override
+  String get giveResultDone => 'Listo';
 
   @override
   String get wrongCredentials =>

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -746,6 +746,36 @@ class AppLocalizationsNl extends AppLocalizations {
   String get flowGenericErrorGoToHome => 'Naar home';
 
   @override
+  String get giveResultLoadingTitle => 'Even geduld...';
+
+  @override
+  String get giveResultLoadingMessage => 'We controleren je gift.';
+
+  @override
+  String get giveResultSuccessTitle => 'Bedankt voor je gift!';
+
+  @override
+  String get giveResultSuccessMessage =>
+      'Je gift wordt verwerkt. Je kunt de status bekijken in het overzicht.';
+
+  @override
+  String get giveResultFailedTitle => 'Gift niet afgerond';
+
+  @override
+  String get giveResultFailedMessage =>
+      'Deze gift is geannuleerd of kon niet worden verwerkt. Bekijk je overzicht of neem contact op als je vragen hebt.';
+
+  @override
+  String get giveResultUnknownTitle => 'We weten het nog niet zeker';
+
+  @override
+  String get giveResultUnknownMessage =>
+      'We konden de status van deze gift nog niet bevestigen. Bekijk zo je overzicht, of neem contact op als de gift niet verschijnt.';
+
+  @override
+  String get giveResultDone => 'Klaar';
+
+  @override
   String get wrongCredentials =>
       'Dit e-mailadres of wachtwoord komt ons niet bekend voor. Is het mogelijk dat je een ander e-mailadres en/of wachtwoord hebt opgegeven?';
 

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -450,6 +450,51 @@
     "description": "Leave shared flow error screen to app home",
     "type": "text"
   },
+  "giveResultLoadingTitle": "Even geduld...",
+  "@giveResultLoadingTitle": {
+    "description": "Title shown while checking donation status after the confirm browser closes",
+    "type": "text"
+  },
+  "giveResultLoadingMessage": "We controleren je gift.",
+  "@giveResultLoadingMessage": {
+    "description": "Body shown while checking donation status after the confirm browser closes",
+    "type": "text"
+  },
+  "giveResultSuccessTitle": "Bedankt voor je gift!",
+  "@giveResultSuccessTitle": {
+    "description": "Title on native success screen after donation confirmation",
+    "type": "text"
+  },
+  "giveResultSuccessMessage": "Je gift wordt verwerkt. Je kunt de status bekijken in het overzicht.",
+  "@giveResultSuccessMessage": {
+    "description": "Body on native success screen after donation confirmation",
+    "type": "text"
+  },
+  "giveResultFailedTitle": "Gift niet afgerond",
+  "@giveResultFailedTitle": {
+    "description": "Title when the confirmed donation was cancelled or refused",
+    "type": "text"
+  },
+  "giveResultFailedMessage": "Deze gift is geannuleerd of kon niet worden verwerkt. Bekijk je overzicht of neem contact op als je vragen hebt.",
+  "@giveResultFailedMessage": {
+    "description": "Body when the confirmed donation was cancelled or refused",
+    "type": "text"
+  },
+  "giveResultUnknownTitle": "We weten het nog niet zeker",
+  "@giveResultUnknownTitle": {
+    "description": "Title when donation status could not be confirmed in time",
+    "type": "text"
+  },
+  "giveResultUnknownMessage": "We konden de status van deze gift nog niet bevestigen. Bekijk zo je overzicht, of neem contact op als de gift niet verschijnt.",
+  "@giveResultUnknownMessage": {
+    "description": "Body when donation status could not be confirmed in time",
+    "type": "text"
+  },
+  "giveResultDone": "Klaar",
+  "@giveResultDone": {
+    "description": "Primary action on native donation success screen",
+    "type": "text"
+  },
   "wrongCredentials": "Dit e-mailadres of wachtwoord komt ons niet bekend voor. Is het mogelijk dat je een ander e-mailadres en/of wachtwoord hebt opgegeven?",
   "@wrongCredentials": {
     "description": "Kan dit leuker? \n  Foutmelding die je te zien krijgt als je een verkeerd email of wachtwoord invoert",

--- a/lib/shared/repositories/givt_repository.dart
+++ b/lib/shared/repositories/givt_repository.dart
@@ -82,6 +82,8 @@ mixin GivtRepository {
     required String orderType,
     required String groupType,
   });
+
+  Future<int> fetchTransactionStatus(int transactionId);
 }
 
 class GivtRepositoryImpl with GivtRepository {
@@ -96,8 +98,7 @@ class GivtRepositoryImpl with GivtRepository {
   Future<void>? _syncOfflineGivtsInFlight;
 
   @override
-  Stream<void> get offlineQueueChanged =>
-      _offlineQueueChangedController.stream;
+  Stream<void> get offlineQueueChanged => _offlineQueueChangedController.stream;
 
   @override
   List<GivtTransaction> getCachedOfflineGivtTransactions() {
@@ -252,6 +253,11 @@ class GivtRepositoryImpl with GivtRepository {
     return Givt.fromJsonList(
       decodedJson,
     );
+  }
+
+  @override
+  Future<int> fetchTransactionStatus(int transactionId) {
+    return apiClient.fetchTransactionStatus(transactionId);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: givt_app
 description: Givt App
-version: 6.5.1
+version: 6.6.0
 publish_to: none
 
 environment:

--- a/test/features/give/cubit/give_result_cubit_test.dart
+++ b/test/features/give/cubit/give_result_cubit_test.dart
@@ -1,0 +1,227 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/features/external_donations/shared/models/external_donation.dart';
+import 'package:givt_app/features/external_donations/shared/models/external_donation_transaction.dart';
+import 'package:givt_app/features/give/cubit/give_result_cubit.dart';
+import 'package:givt_app/features/give/cubit/give_result_uimodel.dart';
+import 'package:givt_app/features/give/models/givt_transaction.dart';
+import 'package:givt_app/features/pledges/shared/models/pledge.dart';
+import 'package:givt_app/shared/bloc/base_state.dart';
+import 'package:givt_app/shared/models/givt.dart';
+import 'package:givt_app/shared/models/models.dart';
+import 'package:givt_app/shared/repositories/givt_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeGivtRepository with GivtRepository {
+  _FakeGivtRepository({this.statusResult, this.failCount = 0});
+
+  int? statusResult;
+  int failCount;
+  int fetchCount = 0;
+
+  @override
+  Future<int> fetchTransactionStatus(int transactionId) async {
+    fetchCount++;
+    if (failCount > 0) {
+      failCount--;
+      throw Exception('status unavailable');
+    }
+    final status = statusResult;
+    if (status == null) {
+      throw Exception('status unavailable');
+    }
+    return status;
+  }
+
+  @override
+  Stream<void> get offlineQueueChanged => const Stream.empty();
+
+  @override
+  List<GivtTransaction> getCachedOfflineGivtTransactions() => const [];
+
+  @override
+  Future<List<int>> submitGivts({
+    required String guid,
+    required Map<String, dynamic> body,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<void> syncOfflineGivts() => throw UnimplementedError();
+
+  @override
+  Future<List<Givt>> fetchGivts() => throw UnimplementedError();
+
+  @override
+  Future<List<Pledge>> fetchPledges() => throw UnimplementedError();
+
+  @override
+  Future<PledgeGroup> fetchPledgeGroupDetail(String pledgeGroupId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<List<ExternalDonation>> fetchExternalDonations() =>
+      throw UnimplementedError();
+
+  @override
+  Future<List<ExternalDonation>> fetchExternalDonationSummary({
+    required String fromDate,
+    required String tillDate,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<List<ExternalDonationTransaction>> fetchExternalDonationTransactions(
+    String externalDonationId,
+  ) => throw UnimplementedError();
+
+  @override
+  Future<bool> stopExternalDonation(String id) => throw UnimplementedError();
+
+  @override
+  Future<bool> deleteGivt(List<dynamic> ids) => throw UnimplementedError();
+
+  @override
+  Future<bool> downloadYearlyOverview({
+    required String fromDate,
+    required String toDate,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<ExternalDonation?> addExternalDonation({
+    required Map<String, dynamic> body,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<ExternalDonation?> fetchExternalDonationDetail(String id) =>
+      throw UnimplementedError();
+
+  @override
+  Future<bool> updateExternalDonation({
+    required String id,
+    required Map<String, dynamic> body,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<bool> deleteExternalDonation(String id) => throw UnimplementedError();
+
+  @override
+  Future<bool> bulkUpdateExternalDonationTransactions({
+    required List<String> transactionIds,
+    required double newAmount,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<bool> bulkDeleteExternalDonationTransactions({
+    required List<String> transactionIds,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<List<SummaryItem>> fetchSummary({
+    required String guid,
+    required String fromDate,
+    required String tillDate,
+    required String orderType,
+    required String groupType,
+  }) => throw UnimplementedError();
+}
+
+void main() {
+  group('GiveResultUIModel.fromLegacyStatus', () {
+    test('maps entered, to-process and processed as success', () {
+      expect(GiveResultUIModel.fromLegacyStatus(1), GiveResultOutcome.success);
+      expect(GiveResultUIModel.fromLegacyStatus(2), GiveResultOutcome.success);
+      expect(GiveResultUIModel.fromLegacyStatus(3), GiveResultOutcome.success);
+    });
+
+    test('maps rejected and cancelled as failed', () {
+      expect(GiveResultUIModel.fromLegacyStatus(4), GiveResultOutcome.failed);
+      expect(GiveResultUIModel.fromLegacyStatus(5), GiveResultOutcome.failed);
+    });
+
+    test('maps unknown values as unknown', () {
+      expect(GiveResultUIModel.fromLegacyStatus(0), GiveResultOutcome.unknown);
+      expect(GiveResultUIModel.fromLegacyStatus(-1), GiveResultOutcome.unknown);
+    });
+  });
+
+  group('GiveResultCubit', () {
+    Future<void> noSleep(Duration duration) async {}
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('emits unknown when there are no transaction ids', () async {
+      final cubit = GiveResultCubit(
+        _FakeGivtRepository(statusResult: 1),
+        sleeper: noSleep,
+      );
+
+      await cubit.checkStatus(const []);
+
+      final state = cubit.state;
+      expect(state, isA<DataState<GiveResultUIModel, dynamic>>());
+      expect(
+        (state as DataState<GiveResultUIModel, dynamic>).data.outcome,
+        GiveResultOutcome.unknown,
+      );
+      await cubit.close();
+    });
+
+    test('emits success for processed status', () async {
+      final cubit = GiveResultCubit(
+        _FakeGivtRepository(statusResult: 3),
+        sleeper: noSleep,
+      );
+
+      await cubit.checkStatus(const [42]);
+
+      final state = cubit.state as DataState<GiveResultUIModel, dynamic>;
+      expect(state.data.outcome, GiveResultOutcome.success);
+      await cubit.close();
+    });
+
+    test('emits failed for cancelled status', () async {
+      final cubit = GiveResultCubit(
+        _FakeGivtRepository(statusResult: 5),
+        sleeper: noSleep,
+      );
+
+      await cubit.checkStatus(const [42]);
+
+      final state = cubit.state as DataState<GiveResultUIModel, dynamic>;
+      expect(state.data.outcome, GiveResultOutcome.failed);
+      await cubit.close();
+    });
+
+    test('retries after a failed fetch then emits success', () async {
+      final repository = _FakeGivtRepository(statusResult: 1, failCount: 1);
+      final cubit = GiveResultCubit(
+        repository,
+        timeout: const Duration(seconds: 10),
+        sleeper: noSleep,
+      );
+
+      await cubit.checkStatus(const [42]);
+
+      expect(repository.fetchCount, 2);
+      final state = cubit.state as DataState<GiveResultUIModel, dynamic>;
+      expect(state.data.outcome, GiveResultOutcome.success);
+      await cubit.close();
+    });
+
+    test('emits unknown when fetches keep failing past the timeout', () async {
+      final repository = _FakeGivtRepository();
+      final cubit = GiveResultCubit(
+        repository,
+        timeout: Duration.zero,
+        sleeper: noSleep,
+      );
+
+      await cubit.checkStatus(const [42]);
+
+      expect(repository.fetchCount, 1);
+      final state = cubit.state as DataState<GiveResultUIModel, dynamic>;
+      expect(state.data.outcome, GiveResultOutcome.unknown);
+      await cubit.close();
+    });
+  });
+}

--- a/test/features/give/cubit/offline_queue_cubit_test.dart
+++ b/test/features/give/cubit/offline_queue_cubit_test.dart
@@ -68,8 +68,7 @@ class _FakeGivtRepository with GivtRepository {
   Future<List<int>> submitGivts({
     required String guid,
     required Map<String, dynamic> body,
-  }) =>
-      throw UnimplementedError();
+  }) => throw UnimplementedError();
 
   @override
   Future<List<Givt>> fetchGivts() => throw UnimplementedError();
@@ -89,14 +88,12 @@ class _FakeGivtRepository with GivtRepository {
   Future<List<ExternalDonation>> fetchExternalDonationSummary({
     required String fromDate,
     required String tillDate,
-  }) =>
-      throw UnimplementedError();
+  }) => throw UnimplementedError();
 
   @override
   Future<List<ExternalDonationTransaction>> fetchExternalDonationTransactions(
     String externalDonationId,
-  ) =>
-      throw UnimplementedError();
+  ) => throw UnimplementedError();
 
   @override
   Future<bool> stopExternalDonation(String id) => throw UnimplementedError();
@@ -108,14 +105,12 @@ class _FakeGivtRepository with GivtRepository {
   Future<bool> downloadYearlyOverview({
     required String fromDate,
     required String toDate,
-  }) =>
-      throw UnimplementedError();
+  }) => throw UnimplementedError();
 
   @override
   Future<ExternalDonation?> addExternalDonation({
     required Map<String, dynamic> body,
-  }) =>
-      throw UnimplementedError();
+  }) => throw UnimplementedError();
 
   @override
   Future<ExternalDonation?> fetchExternalDonationDetail(String id) =>
@@ -125,8 +120,7 @@ class _FakeGivtRepository with GivtRepository {
   Future<bool> updateExternalDonation({
     required String id,
     required Map<String, dynamic> body,
-  }) =>
-      throw UnimplementedError();
+  }) => throw UnimplementedError();
 
   @override
   Future<bool> deleteExternalDonation(String id) => throw UnimplementedError();
@@ -135,14 +129,12 @@ class _FakeGivtRepository with GivtRepository {
   Future<bool> bulkUpdateExternalDonationTransactions({
     required List<String> transactionIds,
     required double newAmount,
-  }) =>
-      throw UnimplementedError();
+  }) => throw UnimplementedError();
 
   @override
   Future<bool> bulkDeleteExternalDonationTransactions({
     required List<String> transactionIds,
-  }) =>
-      throw UnimplementedError();
+  }) => throw UnimplementedError();
 
   @override
   Future<List<SummaryItem>> fetchSummary({
@@ -151,7 +143,10 @@ class _FakeGivtRepository with GivtRepository {
     required String tillDate,
     required String orderType,
     required String groupType,
-  }) =>
+  }) => throw UnimplementedError();
+
+  @override
+  Future<int> fetchTransactionStatus(int transactionId) =>
       throw UnimplementedError();
 }
 
@@ -200,7 +195,9 @@ void main() {
 
     test('syncs when reconnecting after being offline', () async {
       networkInfo = _FakeNetworkInfo(isConnected: false);
-      repository = _FakeGivtRepository(transactions: const [_sampleTransaction]);
+      repository = _FakeGivtRepository(
+        transactions: const [_sampleTransaction],
+      );
       cubit = OfflineQueueCubit(repository, networkInfo);
 
       networkInfo.emitConnection(false);
@@ -218,7 +215,9 @@ void main() {
 
     test('keeps pending count when sync fails while online', () async {
       networkInfo = _FakeNetworkInfo(isConnected: true);
-      repository = _FakeGivtRepository(transactions: const [_sampleTransaction]);
+      repository = _FakeGivtRepository(
+        transactions: const [_sampleTransaction],
+      );
       repository.failSync = true;
       cubit = OfflineQueueCubit(repository, networkInfo);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
After the donation confirm browser closes, the app now checks that transaction’s status and shows a native result instead of always going home.

Depends on BFF: https://github.com/givtnl/givt-backend-bff-givt-service/pull/392

## What
- `InAppBrowser.onExit` is the single trigger after `natived` closes the window
- `GiveResultCubit` polls `GET /givtservice/v1/Transaction/{id}` for up to 10 seconds
- Native FUN screens: loading, success, failed, unknown
- Success goes home (`given=true`) and still honors `afterGivingRedirection`
- Failed / unknown go home without resubmitting; contact support is available

## Status mapping
- `1` Entered, `2` ToProcess, `3` Processed → success
- `4` Rejected, `5` Cancelled → failed
- No successful response in time → unknown

## Test plan
- [ ] Unit tests for mapping + cubit polling/timeout
- [ ] Confirm a SEPA gift, close the browser, see success, then home
- [ ] Cancel in the confirm page, see failed, then home (no second submit)
- [ ] Force a slow/failing status call and see the unknown screen
- [ ] Credit-card (`confirm-G4F.html`) gift still ends on a result screen

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc8f48bd-0ee4-4699-8c76-571b62709370?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc8f48bd-0ee4-4699-8c76-571b62709370&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

