### PR TITLE
Include active category filter in missing-org Zendesk context (ENG-1459)

### DIFF
--- a/lib/core/enums/collect_group_type.dart
+++ b/lib/core/enums/collect_group_type.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:givt_app/l10n/arb/app_localizations.dart';
 import 'package:givt_app/shared/design_system/design_system.dart';
 import 'package:givt_app/shared/models/color_combo.dart';
 import 'package:givt_app/utils/app_theme.dart';
@@ -62,6 +63,28 @@ enum CollectGroupType {
       }
     }
     return CollectGroupType.none;
+  }
+
+  /// Chip / Zendesk label for organisation search filters.
+  ///
+  /// Church, Charity, Campaign, Other (enum value artists). [none] is the
+  /// support-ticket technical value `'None'`, not a user-facing ARB key.
+  String localizedOrganisationFilterTitle(AppLocalizations locals) {
+    switch (this) {
+      case CollectGroupType.church:
+        return locals.church;
+      case CollectGroupType.charities:
+        return locals.charity;
+      case CollectGroupType.campaign:
+        return locals.campaign;
+      case CollectGroupType.artists:
+      case CollectGroupType.unknown:
+      case CollectGroupType.demo:
+      case CollectGroupType.debug:
+        return locals.other;
+      case CollectGroupType.none:
+        return 'None';
+    }
   }
 
   /// Order for organisation search filter chips: Church, Charity, Campaign,
@@ -154,7 +177,8 @@ enum CollectGroupType {
   }
 
   /// Same mapping as [getIconByType] (US-specific variants were unified).
-  static FaIconData getIconByTypeUS(CollectGroupType type) => getIconByType(type);
+  static FaIconData getIconByTypeUS(CollectGroupType type) =>
+      getIconByType(type);
 
   static Color getHighlightColor(CollectGroupType type) {
     switch (type) {

--- a/lib/features/family/features/parent_giving_flow/presentation/widgets/organisation_list_family_content.dart
+++ b/lib/features/family/features/parent_giving_flow/presentation/widgets/organisation_list_family_content.dart
@@ -122,7 +122,8 @@ class _OrganisationListFamilyContentState
                     color: AppTheme.neutralVariant95,
                   ),
                   shrinkWrap: true,
-                  itemCount: visibleOrganisations.length +
+                  itemCount:
+                      visibleOrganisations.length +
                       (widget.showReportMissingOption ? 1 : 0),
                   itemBuilder: (context, index) {
                     if (widget.showReportMissingOption &&
@@ -145,11 +146,8 @@ class _OrganisationListFamilyContentState
                           ),
                         ),
                         onTap: () {
-                          final searchQuery =
-                              widget.bloc.state.previousSearchQuery;
-                          final metadata = searchQuery.isNotEmpty
-                              ? {'searchText': searchQuery}
-                              : null;
+                          final metadata = widget.bloc.state
+                              .buildSupportMetadata(locals);
                           showModalBottomSheet<void>(
                             context: context,
                             isScrollControlled: true,

--- a/lib/features/family/shared/widgets/buttons/tiles/filter_tile.dart
+++ b/lib/features/family/shared/widgets/buttons/tiles/filter_tile.dart
@@ -22,41 +22,22 @@ class FilterTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Padding(
-        padding: edgeInsets ?? EdgeInsets.zero,
-        child: QuickTile(
-          onClick: (context) => onClick?.call(context),
-          isSelected: isSelected,
-          colorCombo: CollectGroupType.getColorComboByType(type),
-          iconPath: iconPath ?? '',
-          iconData:
-              iconPath == null ? CollectGroupType.getIconByTypeUS(type) : null,
-          titleBig: _localizedFilterTitle(context, type),
-          analyticsEvent:
-              AnalyticsEventName.parentGiveFilterTileClicked.toEvent(
-            parameters: {
-              'type': type.name,
-              'isSelected': isSelected,
-            },
-          ),
-        ),
-      );
-}
-
-String _localizedFilterTitle(BuildContext context, CollectGroupType type) {
-  final locals = context.l10n;
-  switch (type) {
-    case CollectGroupType.charities:
-      return locals.charity;
-    case CollectGroupType.church:
-      return locals.church;
-    case CollectGroupType.campaign:
-      return locals.campaign;
-    case CollectGroupType.artists:
-    case CollectGroupType.unknown:
-    case CollectGroupType.demo:
-    case CollectGroupType.debug:
-      return locals.other;
-    case CollectGroupType.none:
-      return type.name[0].toUpperCase() + type.name.substring(1);
-  }
+    padding: edgeInsets ?? EdgeInsets.zero,
+    child: QuickTile(
+      onClick: (context) => onClick?.call(context),
+      isSelected: isSelected,
+      colorCombo: CollectGroupType.getColorComboByType(type),
+      iconPath: iconPath ?? '',
+      iconData: iconPath == null
+          ? CollectGroupType.getIconByTypeUS(type)
+          : null,
+      titleBig: type.localizedOrganisationFilterTitle(context.l10n),
+      analyticsEvent: AnalyticsEventName.parentGiveFilterTileClicked.toEvent(
+        parameters: {
+          'type': type.name,
+          'isSelected': isSelected,
+        },
+      ),
+    ),
+  );
 }

--- a/lib/features/give/pages/organization_list_page.dart
+++ b/lib/features/give/pages/organization_list_page.dart
@@ -162,11 +162,9 @@ class _OrganizationListPageState extends State<OrganizationListPage> {
                           return ListTile(
                             key: UniqueKey(),
                             onTap: () {
-                              // Build metadata with search text if available
-                              final metadata =
-                                  state.previousSearchQuery.isNotEmpty
-                                  ? {'searchText': state.previousSearchQuery}
-                                  : null;
+                              final metadata = state.buildSupportMetadata(
+                                locals,
+                              );
 
                               showModalBottomSheet<void>(
                                 context: context,
@@ -342,8 +340,8 @@ class _OrganizationListPageState extends State<OrganizationListPage> {
               ? FunButton(
                   onTap: onPressed,
                   text: title,
-                  analyticsEvent:
-                      AnalyticsEventName.giveButtonPressed.toEvent(),
+                  analyticsEvent: AnalyticsEventName.giveButtonPressed
+                      .toEvent(),
                   isDisabled: onPressed == null,
                 )
               : const Center(
@@ -483,7 +481,8 @@ class _OrganizationListPageState extends State<OrganizationListPage> {
         mainAxisSize: MainAxisSize.min,
         children: [
           ListTile(
-            leading: FaIcon(FontAwesomeIcons.handHoldingHeart,
+            leading: FaIcon(
+              FontAwesomeIcons.handHoldingHeart,
               color: AppTheme.givtBlue,
             ),
             title: Text(locals.discoverOrAmountActionSheetOnce),

--- a/lib/shared/bloc/organisation/organisation_bloc.dart
+++ b/lib/shared/bloc/organisation/organisation_bloc.dart
@@ -13,6 +13,7 @@ import 'package:givt_app/core/logging/logging.dart';
 import 'package:givt_app/features/auth/models/models.dart';
 import 'package:givt_app/features/give/models/organisation.dart';
 import 'package:givt_app/features/give/repositories/campaign_repository.dart';
+import 'package:givt_app/l10n/arb/app_localizations.dart';
 import 'package:givt_app/shared/models/collect_group.dart';
 import 'package:givt_app/shared/repositories/collect_group_repository.dart';
 import 'package:givt_app/utils/util.dart';

--- a/lib/shared/bloc/organisation/organisation_state.dart
+++ b/lib/shared/bloc/organisation/organisation_state.dart
@@ -52,15 +52,28 @@ class OrganisationState extends Equatable {
     );
   }
 
+  Map<String, String> buildSupportMetadata(AppLocalizations locals) {
+    final metadata = <String, String>{};
+    if (previousSearchQuery.isNotEmpty) {
+      metadata['searchText'] = previousSearchQuery;
+    }
+
+    final type = CollectGroupType.fromInt(selectedType);
+    final isFilterActive = type != CollectGroupType.none;
+    metadata['categoryFilterActive'] = isFilterActive ? 'true' : 'false';
+    metadata['categoryFilter'] = type.localizedOrganisationFilterTitle(locals);
+    return metadata;
+  }
+
   @override
   List<Object> get props => [
-        organisations,
-        selectedType,
-        filteredOrganisations,
-        status,
-        selectedCollectGroup,
-        previousSearchQuery,
-        favoritedOrganisations,
-        sortByFavorites,
-      ];
+    organisations,
+    selectedType,
+    filteredOrganisations,
+    status,
+    selectedCollectGroup,
+    previousSearchQuery,
+    favoritedOrganisations,
+    sortByFavorites,
+  ];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: givt_app
 description: Givt App
-version: 6.5.1
+version: 6.5.2
 publish_to: none
 
 environment:

--- a/test/features/family/features/parent_giving_flow/presentation/widgets/organisation_list_family_content_test.dart
+++ b/test/features/family/features/parent_giving_flow/presentation/widgets/organisation_list_family_content_test.dart
@@ -72,15 +72,13 @@ class _FakeInfraRepository with InfraRepository {
     required String guid,
     required String message,
     String? subject,
-  }) async =>
-      true;
+  }) async => true;
 
   @override
   Future<AppUpdate?> checkAppUpdate({
     required String buildNumber,
     required String platform,
-  }) async =>
-      null;
+  }) async => null;
 }
 
 class _TestAuthCubit extends AuthCubit {
@@ -112,17 +110,18 @@ void main() {
 
   Future<void> initBloc({List<CollectGroup> groups = const []}) async {
     final prefs = await SharedPreferences.getInstance();
-    organisationBloc = OrganisationBloc(
-      _FakeCollectGroupRepository(groups),
-      _FakeCampaignRepository(),
-      prefs,
-    )..add(
-        OrganisationFetch(
-          Country.nl,
-          showLastDonated: false,
-          type: CollectGroupType.none.index,
-        ),
-      );
+    organisationBloc =
+        OrganisationBloc(
+          _FakeCollectGroupRepository(groups),
+          _FakeCampaignRepository(),
+          prefs,
+        )..add(
+          OrganisationFetch(
+            Country.nl,
+            showLastDonated: false,
+            type: CollectGroupType.none.index,
+          ),
+        );
     await organisationBloc.stream.firstWhere(
       (s) => s.status == OrganisationStatus.filtered,
     );
@@ -283,7 +282,46 @@ void main() {
       final bottomSheet = tester.widget<AboutGivtBottomSheet>(
         find.byType(AboutGivtBottomSheet),
       );
-      expect(bottomSheet.metadata, {'searchText': searchQuery});
+      expect(bottomSheet.metadata, {
+        'searchText': searchQuery,
+        'categoryFilterActive': 'false',
+        'categoryFilter': 'None',
+      });
+    },
+  );
+
+  testWidgets(
+    'passes active category filter in metadata when church chip is selected',
+    (tester) async {
+      await pumpContent(
+        tester,
+        showReportMissingOption: true,
+        groups: const [],
+      );
+
+      organisationBloc.add(
+        OrganisationTypeChanged(CollectGroupType.church.index),
+      );
+      await tester.pump();
+      expect(
+        organisationBloc.state.selectedType,
+        CollectGroupType.church.index,
+      );
+
+      await tester.tap(
+        find.byKey(const ValueKey('reportMissingOrganisationTile')),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      ignoreKnownBottomSheetOverflow(tester);
+
+      final bottomSheet = tester.widget<AboutGivtBottomSheet>(
+        find.byType(AboutGivtBottomSheet),
+      );
+      expect(bottomSheet.metadata, {
+        'categoryFilterActive': 'true',
+        'categoryFilter': 'Church',
+      });
     },
   );
 }

--- a/test/shared/bloc/organisation/organisation_state_support_metadata_test.dart
+++ b/test/shared/bloc/organisation/organisation_state_support_metadata_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/core/enums/collect_group_type.dart';
+import 'package:givt_app/l10n/arb/app_localizations.dart';
+import 'package:givt_app/shared/bloc/organisation/organisation_bloc.dart';
+
+void main() {
+  late AppLocalizations locals;
+
+  setUp(() {
+    locals = lookupAppLocalizations(const Locale('en'));
+  });
+
+  group('OrganisationState.buildSupportMetadata', () {
+    test('includes search text and church filter when chip is active', () {
+      final state = OrganisationState(
+        previousSearchQuery: 'kwf',
+        selectedType: CollectGroupType.church.index,
+      );
+
+      expect(
+        state.buildSupportMetadata(locals),
+        {
+          'searchText': 'kwf',
+          'categoryFilterActive': 'true',
+          'categoryFilter': 'Church',
+        },
+      );
+    });
+
+    test('omits searchText and reports no filter for none.index', () {
+      final state = OrganisationState(
+        selectedType: CollectGroupType.none.index,
+      );
+
+      expect(
+        state.buildSupportMetadata(locals),
+        {
+          'categoryFilterActive': 'false',
+          'categoryFilter': 'None',
+        },
+      );
+    });
+
+    test(
+      'omits searchText and reports no filter for default selectedType -1',
+      () {
+        const state = OrganisationState();
+
+        expect(
+          state.buildSupportMetadata(locals),
+          {
+            'categoryFilterActive': 'false',
+            'categoryFilter': 'None',
+          },
+        );
+      },
+    );
+
+    test('maps charities to Charity', () {
+      final state = OrganisationState(
+        previousSearchQuery: 'kwf',
+        selectedType: CollectGroupType.charities.index,
+      );
+
+      expect(
+        state.buildSupportMetadata(locals),
+        {
+          'searchText': 'kwf',
+          'categoryFilterActive': 'true',
+          'categoryFilter': 'Charity',
+        },
+      );
+    });
+
+    test('maps campaign to Campaign', () {
+      final state = OrganisationState(
+        selectedType: CollectGroupType.campaign.index,
+      );
+
+      expect(
+        state.buildSupportMetadata(locals)['categoryFilter'],
+        'Campaign',
+      );
+      expect(
+        state.buildSupportMetadata(locals)['categoryFilterActive'],
+        'true',
+      );
+    });
+
+    test('maps artists to Other', () {
+      final state = OrganisationState(
+        selectedType: CollectGroupType.artists.index,
+      );
+
+      expect(
+        state.buildSupportMetadata(locals)['categoryFilter'],
+        'Other',
+      );
+      expect(
+        state.buildSupportMetadata(locals)['categoryFilterActive'],
+        'true',
+      );
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Missing-organisation Zendesk tickets now include whether a category filter chip was active when the user searched, so support can tell if results (for example KWF) were hidden by a Church/Charity/Campaign/Other chip.

- `OrganisationState.buildSupportMetadata` always sends `categoryFilterActive` and `categoryFilter` (plus `searchText` when the query is non-empty).
- Wired on the EU organisation list and family For You report-missing tile.
- Chip labels reuse existing `church` / `charity` / `campaign` / `other` strings; inactive filter is the technical value `None`.
- No `/api/sendsupport` contract change — metadata is still inlined under `--- Additional Context ---`.

Linear: [ENG-1459](https://linear.app/givt/issue/ENG-1459/add-active-category-filter-state-to-zendesk-support-ticket-context)

## Tests

- `flutter test test/shared/bloc/organisation/organisation_state_support_metadata_test.dart test/features/family/features/parent_giving_flow/presentation/widgets/organisation_list_family_content_test.dart` — 11 passed

Page check: skip (Flutter/native, metadata-only; no visual layout change).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57711bd7-8463-4d22-897a-efb77b8ece91?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57711bd7-8463-4d22-897a-efb77b8ece91&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

