### PR TITLE
Add quarterly frequency to external donation create flow (ENG-1460)

### DIFF
--- a/lib/features/external_donations/create/widgets/external_donation_frequency_dropdown.dart
+++ b/lib/features/external_donations/create/widgets/external_donation_frequency_dropdown.dart
@@ -5,15 +5,8 @@ import 'package:givt_app/l10n/arb/app_localizations.dart';
 import 'package:givt_app/l10n/l10n.dart';
 import 'package:givt_app/shared/design_system/design_system.dart';
 
-const _recurringFrequencies = [
-  ExternalDonationFrequency.weekly,
-  ExternalDonationFrequency.monthly,
-  ExternalDonationFrequency.halfYearly,
-  ExternalDonationFrequency.yearly,
-];
-
-/// Includes [ExternalDonationFrequency.quarterly] for editing legacy donations.
-const manageRecurringFrequencies = [
+/// Recurring frequencies for create and manage flows, including quarterly.
+const List<ExternalDonationFrequency> manageRecurringFrequencies = [
   ExternalDonationFrequency.weekly,
   ExternalDonationFrequency.monthly,
   ExternalDonationFrequency.quarterly,
@@ -42,7 +35,7 @@ class ExternalDonationFrequencyDropdown extends StatelessWidget {
     return FunInputDropdown<ExternalDonationFrequency>(
       label: label ?? locals.externalDonationsCreateFrequencyLabel,
       value: value,
-      items: frequencies ?? _recurringFrequencies,
+      items: frequencies ?? manageRecurringFrequencies,
       hint: Text(locals.recurringDonationsCreateFrequencyHint),
       onChanged: onChanged,
       itemBuilder: (context, option) => Padding(

--- a/test/features/external_donations/create/external_donation_create_payload_test.dart
+++ b/test/features/external_donations/create/external_donation_create_payload_test.dart
@@ -31,26 +31,46 @@ void main() {
       expect(body.containsKey('collectGroupId'), isFalse);
     });
 
-    test('builds recurring payload with startDate from first donation date', () {
+    test(
+      'builds recurring payload with startDate from first donation date',
+      () {
+        final body = ExternalDonationCreatePayloadBuilder.build(
+          ExternalDonationCreateDraft(
+            organisationName: 'WWF',
+            amountInput: '10',
+            isOneOff: false,
+            frequency: ExternalDonationFrequency.monthly,
+            seriesStartDate: DateTime(2024, 1, 12),
+            selectedOrganisation: null,
+            isCustomOrganisation: false,
+          ),
+        );
+
+        expect(body['frequency'], 'Monthly');
+        expect(body['startDate'], '2024-01-12T00:00:00.000');
+        expect((body['startDate'] as String).endsWith('Z'), isFalse);
+        expect(body.containsKey('creationDate'), isFalse);
+        expect(body['taxDeductable'], isFalse);
+        expect(body.containsKey('active'), isFalse);
+        expect(body.containsKey('collectGroupId'), isFalse);
+      },
+    );
+
+    test('builds recurring payload with Quarterly frequency', () {
       final body = ExternalDonationCreatePayloadBuilder.build(
         ExternalDonationCreateDraft(
           organisationName: 'WWF',
           amountInput: '10',
           isOneOff: false,
-          frequency: ExternalDonationFrequency.monthly,
+          frequency: ExternalDonationFrequency.quarterly,
           seriesStartDate: DateTime(2024, 1, 12),
           selectedOrganisation: null,
           isCustomOrganisation: false,
         ),
       );
 
-      expect(body['frequency'], 'Monthly');
+      expect(body['frequency'], 'Quarterly');
       expect(body['startDate'], '2024-01-12T00:00:00.000');
-      expect((body['startDate'] as String).endsWith('Z'), isFalse);
-      expect(body.containsKey('creationDate'), isFalse);
-      expect(body['taxDeductable'], isFalse);
-      expect(body.containsKey('active'), isFalse);
-      expect(body.containsKey('collectGroupId'), isFalse);
     });
   });
 
@@ -104,6 +124,24 @@ void main() {
       );
 
       expect(preview.length, greaterThan(2));
+    });
+
+    test('supports quarterly frequency with next occurrence', () {
+      final preview = generateOccurrencePreview(
+        seriesStartDate: DateTime(2024, 1, 12),
+        frequency: ExternalDonationFrequency.quarterly,
+        now: DateTime(2024, 7, 12),
+      );
+
+      expect(
+        preview,
+        [
+          DateTime(2024, 1, 12),
+          DateTime(2024, 4, 12),
+          DateTime(2024, 7, 12),
+          DateTime(2024, 10, 12),
+        ],
+      );
     });
   });
 }

--- a/test/features/external_donations/create/widgets/external_donation_frequency_dropdown_test.dart
+++ b/test/features/external_donations/create/widgets/external_donation_frequency_dropdown_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:givt_app/features/external_donations/create/widgets/external_donation_frequency_dropdown.dart';
+import 'package:givt_app/features/external_donations/shared/models/external_donation_frequency.dart';
+import 'package:givt_app/l10n/arb/app_localizations.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    locale: const Locale('en'),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  testWidgets(
+    'default list includes Quarterly and selecting it calls onChanged',
+    (tester) async {
+      ExternalDonationFrequency? selected;
+
+      await tester.pumpWidget(
+        _wrap(
+          ExternalDonationFrequencyDropdown(
+            value: ExternalDonationFrequency.monthly,
+            onChanged: (frequency) => selected = frequency,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('FunInputDropdown')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Quarterly'), findsOneWidget);
+
+      await tester.tap(find.text('Quarterly').last);
+      await tester.pumpAndSettle();
+
+      expect(selected, ExternalDonationFrequency.quarterly);
+    },
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Quarterly** to the external-donation create-flow frequency dropdown ([ENG-1460](https://linear.app/givt/issue/ENG-1460/add-quarterly-option-for-entering-external-donations)). Create now uses the same `manageRecurringFrequencies` list as the edit sheet. Enum, i18n, `POST /givtservice/v1/externaldonations` (`frequency: "Quarterly"`), schedule math, and overview display were already in place.

## Test plan

- [x] Widget test: default dropdown includes **Quarterly** and selecting it emits `ExternalDonationFrequency.quarterly`
- [x] Payload builder emits `'Quarterly'`
- [x] `generateOccurrencePreview` for quarterly includes Jan / Apr / Jul / Oct from `2024-01-12`
- [x] `flutter test test/features/external_donations/` (44 passed)

Page check skipped (Flutter/native). No APK/IPA.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8eb5d332-fe36-4f6e-99d1-69cbd1ee2b94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8eb5d332-fe36-4f6e-99d1-69cbd1ee2b94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

